### PR TITLE
validators.BugFreePython: Replace exec validation with ast.parse

### DIFF
--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -1,6 +1,6 @@
 import warnings
-from typing import Any, Dict, List
 from types import SimpleNamespace
+from typing import Any, Dict, List
 
 from lxml import etree as ET
 

--- a/guardrails/output_schema.py
+++ b/guardrails/output_schema.py
@@ -1,6 +1,5 @@
-from typing import Dict, Optional
 from types import SimpleNamespace
-
+from typing import Dict, Optional
 
 from lxml import etree as ET
 

--- a/guardrails/utils/logs_utils.py
+++ b/guardrails/utils/logs_utils.py
@@ -2,7 +2,8 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-from guardrails.utils.reask_utils import ReAsk, gather_reasks, prune_json_for_reasking
+from guardrails.utils.reask_utils import (ReAsk, gather_reasks,
+                                          prune_json_for_reasking)
 
 
 @dataclass

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -3,6 +3,7 @@
 The name with which a validator is registered is the name that is used in the `RAIL` spec to specify formatters.
 """
 
+import ast
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
@@ -420,7 +421,7 @@ class ValidUrl(Validator):
 class BugFreePython(Validator):
     """Validate that there are no Python syntactic bugs in the generated code.
 
-    This validator checks for syntax errors by running `exec(code)`, and will raise an exception if there are any.
+    This validator checks for syntax errors by running `ast.parse(code)`, and will raise an exception if there are any.
     Only the packages in the `python` environment are available to the code snippet.
 
     - Name for `format` attribute: `bug-free-python`
@@ -431,10 +432,10 @@ class BugFreePython(Validator):
     def validate(self, key: str, value: Any, schema: Union[Dict, List]) -> Dict:
         logger.debug(f"Validating {value} is not a bug...")
 
-        # The value represents a Python code snippet. We need to execute it and check if there are any bugs
+        # The value represents a Python code snippet. We need to check for syntax errors.
         try:
-            exec(value)
-        except Exception as e:
+            ast.parse(value)
+        except SyntaxError as e:
             raise EventDetail(
                 key,
                 value,


### PR DESCRIPTION
`exec`ing python code generated by the language model is inadvisable. You describe the feature as a syntax error check, which we can do by parsing it into an abstract syntax tree.

Great work by the way!