### PR TITLE
Minor fixes to the getting started notebook

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -236,6 +236,10 @@
    ],
    "source": [
     "import openai\n",
+    "import os\n",
+    "\n",
+    "# Set your OpenAI API key\n",
+    "os.environ[\"OPENAI_API_KEY\"] = 'YOUR_OPENAI_API_KEY'\n",
     "\n",
     "# Wrap the OpenAI API call with the `guard` object\n",
     "raw_llm_output, validated_output = guard(openai.Completion.create, engine=\"text-davinci-003\", max_tokens=1024, temperature=0.3)\n",
@@ -311,6 +315,8 @@
     }
    ],
    "source": [
+    "import tempfile\n",
+    "\n",
     "rail_spec = \"\"\"\n",
     "<rail version=\"0.1\">\n",
     "\n",


### PR DESCRIPTION
Minor additions to `getting_started.ipynb` to resolve some issues I ran into while stepping through it:

* Add line to set OpenAI API Key env var
* Import `tempfile`