### PR TITLE
validators.BugFreeSQL actually validates input sql

### DIFF
--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -470,7 +470,7 @@ class BugFreeSQL(Validator):
     def validate(self, key: str, value: Any, schema: Union[Dict, List]) -> Dict:
         import sqlvalidator
 
-        sql_query = sqlvalidator.parse("SELECT * from table")
+        sql_query = sqlvalidator.parse(value)
 
         if not sql_query.is_valid():
             raise EventDetail(


### PR DESCRIPTION
Before the change, everything would be passing, for example

```
from guardrails.validators import BugFreeSQL
v = BugFreeSQL()
invalid_query = "SELECT FROM;"
v.validate("", invalid_query, {})
```

Note, `sqlvalidator` has a bunch of open issues that will lead to an uncaught exception, see for example https://github.com/David-Wobrock/sqlvalidator/issues/51, https://github.com/David-Wobrock/sqlvalidator/issues/44. It can't be assumed that the exception is because of the query being invalid, at the same time, a query cannot be considered valid by just catching these exceptions and moving on. I've had the issue come up with fairly trivial examples, e.g. `"SELECT ** FROM table;"`  