### PR TITLE
Add Jupyter notebook with translation quality

### DIFF
--- a/docs/examples/translation_with_quality_check.ipynb
+++ b/docs/examples/translation_with_quality_check.ipynb
@@ -31,24 +31,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: inspiredco in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (0.0.2)\n",
-      "Requirement already satisfied: requests>=2.27.0 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from inspiredco) (2.28.1)\n",
-      "Requirement already satisfied: charset-normalizer<3,>=2 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from requests>=2.27.0->inspiredco) (2.0.4)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from requests>=2.27.0->inspiredco) (3.4)\n",
-      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from requests>=2.27.0->inspiredco) (1.26.14)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from requests>=2.27.0->inspiredco) (2022.12.7)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pip install inspiredco\n"
    ]
@@ -68,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -79,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 2,
    "metadata": {
     "tags": []
    },
@@ -109,8 +96,7 @@
     "            dataset = [{\"source\": key, \"target\": value}],\n",
     "        )\n",
     "        quality = prediction[\"examples\"][0][\"value\"]\n",
-    "        print(f\"{key} -> {value} has quality {quality}\")\n",
-    "        if quality &lt; 0.0:\n",
+    "        if quality &lt; -0.1:\n",
     "            raise EventDetail(\n",
     "                key,\n",
     "                value,\n",
@@ -172,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 3,
    "metadata": {
     "tags": []
    },
@@ -194,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "metadata": {
     "tags": []
    },
@@ -294,22 +280,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, let's try translating a statement that doesn't have any profanity in it."
+    "First, let's try translating a statement that is relatively easy to translate."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Validated Output: <span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'translated_statement'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">''</span><span style=\"font-weight: bold\">}</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Validated Output: <span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'translated_statement'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'This may be easy to translate.'</span><span style=\"font-weight: bold\">}</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "Validated Output: \u001b[1m{\u001b[0m\u001b[32m'translated_statement'\u001b[0m: \u001b[32m''\u001b[0m\u001b[1m}\u001b[0m\n"
+       "Validated Output: \u001b[1m{\u001b[0m\u001b[32m'translated_statement'\u001b[0m: \u001b[32m'This may be easy to translate.'\u001b[0m\u001b[1m}\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -321,7 +307,7 @@
     "\n",
     "raw_llm_response, validated_response = guard(\n",
     "    openai.Completion.create,\n",
-    "    prompt_params={'statement_to_be_translated': 'quesadilla de pollo'},\n",
+    "    prompt_params={'statement_to_be_translated': 'これは簡単に翻訳できるかもしれない。'},\n",
     "    engine='text-davinci-003',\n",
     "    max_tokens=2048,\n",
     "    temperature=0\n",
@@ -337,12 +323,12 @@
    "source": [
     "The `guard` wrapper returns the raw_llm_respose (which is a simple string), and the validated and corrected output (which is a dictionary). We can see that the output is a dictionary with the correct schema and types.\n",
     "\n",
-    "Next, let's try translating a statement that has profanity in it. We see that the translated statement has been corrected to return an empty string instead of the translated statement."
+    "Next, let's try translating a statement that is harder to translate (because it contains some difficult-to-translate slang words). We see that the translated statement has been corrected to return an empty string instead of the translated statement."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
@@ -364,7 +350,7 @@
    "source": [
     "raw_llm_response, validated_response = guard(\n",
     "    openai.Completion.create,\n",
-    "    prompt_params={'statement_to_be_translated': 'убей себя'},\n",
+    "    prompt_params={'statement_to_be_translated': 'ドン引きするほど翻訳が悪い。'},\n",
     "    engine='text-davinci-003',\n",
     "    max_tokens=2048,\n",
     "    temperature=0\n",

--- a/docs/examples/translation_with_quality_check.ipynb
+++ b/docs/examples/translation_with_quality_check.ipynb
@@ -1,0 +1,398 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Translate text with quality checks\n",
+    "\n",
+    "!!! note\n",
+    "    To download this example as a Jupyter notebook, click [here](https://github.com/ShreyaR/guardrails/blob/main/docs/examples/translation_with_quality_check.ipynb).\n",
+    "\n",
+    "In this example, we will use Guardrails during the translation of a statement from another language to English. We will check whether the translated statement is likely high quality or not.\n",
+    "\n",
+    "## Objective\n",
+    "\n",
+    "We want to translate a statement from another languages to English and ensure that the translated statement accurately reflects the original content.\n",
+    "\n",
+    "## Step 0: Setup\n",
+    "\n",
+    "To do the quality check, we can use the [Critique](https://docs.inspiredco.ai/critique/) library, which allows for simple calculation of various metrics over generated text, including [translation quality estimation](https://docs.inspiredco.ai/critique/criteria_translation_quality.html).\n",
+    "\n",
+    "First you can get an API key from the [Inspired Cognition Dashboard](https://dashboard.inspiredco.ai) add the following line to the \".env\" file in your top directory (like you do for your OpenAI API key).\n",
+    "\n",
+    "```bash\n",
+    "INSPIREDCO_API_KEY=<your_api_key>\n",
+    "```\n",
+    "\n",
+    "Then you can install the library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: inspiredco in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (0.0.2)\n",
+      "Requirement already satisfied: requests>=2.27.0 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from inspiredco) (2.28.1)\n",
+      "Requirement already satisfied: charset-normalizer<3,>=2 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from requests>=2.27.0->inspiredco) (2.0.4)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from requests>=2.27.0->inspiredco) (3.4)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from requests>=2.27.0->inspiredco) (1.26.14)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /Users/gneubig/opt/anaconda3/envs/langchain/lib/python3.10/site-packages (from requests>=2.27.0->inspiredco) (2022.12.7)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install inspiredco\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Create the RAIL Spec\n",
+    "\n",
+    "Ordinarily, we would create an RAIL spec in a separate file. For the purposes of this example, we will create the spec in this notebook as a string following the RAIL syntax. For more information on RAIL, see the [RAIL documentation](../rail/output.md).\n",
+    "\n",
+    "In this RAIL spec, we:\n",
+    "\n",
+    "1. Create an `output` schema that returns a single key-value pair. The key should be 'translated_statement', and the value should be the English translation of the given statement. The translated statement should not have any profanity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from inspiredco import critique"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "rail_str = \"\"\"\n",
+    "<rail version=\"0.1\">\n",
+    "\n",
+    "<script language='python'>\n",
+    "import inspiredco.critique\n",
+    "import os\n",
+    "from guardrails.validators import Validator, EventDetail, register_validator\n",
+    "\n",
+    "critique = inspiredco.critique.Critique(api_key=os.environ['INSPIREDCO_API_KEY'])\n",
+    "\n",
+    "from typing import Dict, List\n",
+    "\n",
+    "\n",
+    "@register_validator(name=\"is-high-quality-translation\", data_type=\"string\")\n",
+    "class IsHighQualityTranslation(Validator):\n",
+    "    global critique\n",
+    "    global EventDetail\n",
+    "    def validate(self, key, value, schema) -> Dict:\n",
+    "        prediction = critique.evaluate(\n",
+    "            metric = \"comet\",\n",
+    "            config = {\"model\": \"unbabel_comet/wmt21-comet-qe-da\"},\n",
+    "            dataset = [{\"source\": key, \"target\": value}],\n",
+    "        )\n",
+    "        quality = prediction[\"examples\"][0][\"value\"]\n",
+    "        print(f\"{key} -> {value} has quality {quality}\")\n",
+    "        if quality &lt; 0.0:\n",
+    "            raise EventDetail(\n",
+    "                key,\n",
+    "                value,\n",
+    "                schema,\n",
+    "                f\"Value {value} has relatively low quality {quality}\",\n",
+    "                \"\",\n",
+    "            )\n",
+    "        return schema\n",
+    "</script>\n",
+    "\n",
+    "<output>\n",
+    "    <string\n",
+    "        name=\"translated_statement\"\n",
+    "        description=\"Translate the given statement into the English language\"\n",
+    "        format=\"is-high-quality-translation\"\n",
+    "        on-fail-is-high-quality-translation=\"fix\" \n",
+    "    />\n",
+    "</output>\n",
+    "\n",
+    "\n",
+    "<prompt>\n",
+    "\n",
+    "Translate the given statement into the English language:\n",
+    "\n",
+    "{{statement_to_be_translated}}\n",
+    "\n",
+    "@complete_json_suffix\n",
+    "</prompt>\n",
+    "\n",
+    "\n",
+    "</rail>\n",
+    "\n",
+    "\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "!!! note\n",
+    "\n",
+    "    In order to ensure the translated statement is high quality, we use `is-high-quality-translation` as the validator. This validator uses `inspiredco` package."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Create a `Guard` object with the RAIL Spec\n",
+    "\n",
+    "We create a `gd.Guard` object that will check, validate and correct the output of the LLM. This object:\n",
+    "\n",
+    "1. Enforces the quality criteria specified in the RAIL spec.\n",
+    "2. Takes corrective action when the quality criteria are not met.\n",
+    "3. Compiles the schema and type info from the RAIL spec and adds it to the prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import guardrails as gd\n",
+    "\n",
+    "from rich import print\n",
+    "\n",
+    "guard = gd.Guard.from_rail_string(rail_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see the prompt that will be sent to the LLM:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "\n",
+       "Translate the given statement into the English language:\n",
+       "\n",
+       "<span style=\"font-weight: bold\">{</span>statement_to_be_translated<span style=\"font-weight: bold\">}</span>\n",
+       "\n",
+       "\n",
+       "Given below is XML that describes the information to extract from this document and the tags to extract it into.\n",
+       "\n",
+       "<span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">output</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">    &lt;string </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"translated_statement\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #808000; text-decoration-color: #808000\">description</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"Translate the given statement into the English language\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span>\n",
+       "<span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"is-high-quality-translation\"</span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">&lt;</span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">output</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;</span>\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">ONLY return a valid JSON object </span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">(</span><span style=\"color: #000000; text-decoration-color: #000000\">no other text is necessary</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">)</span><span style=\"color: #000000; text-decoration-color: #000000\">, where the key of the field in JSON is the `name` </span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and </span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">specific types. Be correct and concise. If you are unsure anywhere, enter `</span><span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span><span style=\"color: #000000; text-decoration-color: #000000\">`.</span>\n",
+       "\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">Here are examples of simple </span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">(</span><span style=\"color: #000000; text-decoration-color: #000000\">XML, JSON</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">)</span><span style=\"color: #000000; text-decoration-color: #000000\"> pairs that show the expected behavior:</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">- `&lt;string </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'foo'</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'two-words lower-case'</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;` =&gt; `</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">{{</span><span style=\"color: #008000; text-decoration-color: #008000\">'foo'</span><span style=\"color: #000000; text-decoration-color: #000000\">: </span><span style=\"color: #008000; text-decoration-color: #008000\">'example one'</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">}}</span><span style=\"color: #000000; text-decoration-color: #000000\">`</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">- `&lt;list </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'bar'</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;string </span><span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'upper-case'</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;</span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">list</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;` =&gt; `</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">{{</span><span style=\"color: #008000; text-decoration-color: #008000\">\"bar\"</span><span style=\"color: #000000; text-decoration-color: #000000\">: </span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">[</span><span style=\"color: #008000; text-decoration-color: #008000\">'STRING ONE'</span><span style=\"color: #000000; text-decoration-color: #000000\">, </span><span style=\"color: #008000; text-decoration-color: #008000\">'STRING TWO'</span><span style=\"color: #000000; text-decoration-color: #000000\">, etc.</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">]}}</span><span style=\"color: #000000; text-decoration-color: #000000\">`</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">- `&lt;object </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'baz'</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;string </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"foo\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"capitalize two-words\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;integer </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"index\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"1-indexed\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;</span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">object</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;` =</span><span style=\"font-weight: bold\">&gt;</span> `<span style=\"font-weight: bold\">{{</span><span style=\"color: #008000; text-decoration-color: #008000\">'baz'</span>: <span style=\"font-weight: bold\">{{</span><span style=\"color: #008000; text-decoration-color: #008000\">'foo'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'Some String'</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'index'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span><span style=\"font-weight: bold\">}}}}</span>`\n",
+       "\n",
+       "JSON Object:\n",
+       "\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n",
+       "\n",
+       "Translate the given statement into the English language:\n",
+       "\n",
+       "\u001b[1m{\u001b[0mstatement_to_be_translated\u001b[1m}\u001b[0m\n",
+       "\n",
+       "\n",
+       "Given below is XML that describes the information to extract from this document and the tags to extract it into.\n",
+       "\n",
+       "\u001b[1m<\u001b[0m\u001b[1;95moutput\u001b[0m\u001b[39m>\u001b[0m\n",
+       "\u001b[39m    <string \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"translated_statement\"\u001b[0m\u001b[39m \u001b[0m\u001b[33mdescription\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"Translate\u001b[0m\u001b[32m the given statement into the English language\"\u001b[0m\u001b[39m \u001b[0m\n",
+       "\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"is\u001b[0m\u001b[32m-high-quality-translation\"\u001b[0m\u001b[35m/\u001b[0m\u001b[39m>\u001b[0m\n",
+       "\u001b[39m<\u001b[0m\u001b[35m/\u001b[0m\u001b[95moutput\u001b[0m\u001b[39m>\u001b[0m\n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "\u001b[39mONLY return a valid JSON object \u001b[0m\u001b[1;39m(\u001b[0m\u001b[39mno other text is necessary\u001b[0m\u001b[1;39m)\u001b[0m\u001b[39m, where the key of the field in JSON is the `name` \u001b[0m\n",
+       "\u001b[39mattribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON\u001b[0m\n",
+       "\u001b[39mMUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and \u001b[0m\n",
+       "\u001b[39mspecific types. Be correct and concise. If you are unsure anywhere, enter `\u001b[0m\u001b[3;35mNone\u001b[0m\u001b[39m`.\u001b[0m\n",
+       "\n",
+       "\u001b[39mHere are examples of simple \u001b[0m\u001b[1;39m(\u001b[0m\u001b[39mXML, JSON\u001b[0m\u001b[1;39m)\u001b[0m\u001b[39m pairs that show the expected behavior:\u001b[0m\n",
+       "\u001b[39m- `<string \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'foo'\u001b[0m\u001b[39m \u001b[0m\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'two-words lower-case'\u001b[0m\u001b[39m \u001b[0m\u001b[35m/\u001b[0m\u001b[39m>` => `\u001b[0m\u001b[1;39m{\u001b[0m\u001b[1;39m{\u001b[0m\u001b[32m'foo'\u001b[0m\u001b[39m: \u001b[0m\u001b[32m'example one'\u001b[0m\u001b[1;39m}\u001b[0m\u001b[1;39m}\u001b[0m\u001b[39m`\u001b[0m\n",
+       "\u001b[39m- `<list \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'bar'\u001b[0m\u001b[39m><string \u001b[0m\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'upper-case'\u001b[0m\u001b[39m \u001b[0m\u001b[35m/\u001b[0m\u001b[39m><\u001b[0m\u001b[35m/\u001b[0m\u001b[95mlist\u001b[0m\u001b[39m>` => `\u001b[0m\u001b[1;39m{\u001b[0m\u001b[1;39m{\u001b[0m\u001b[32m\"bar\"\u001b[0m\u001b[39m: \u001b[0m\u001b[1;39m[\u001b[0m\u001b[32m'STRING ONE'\u001b[0m\u001b[39m, \u001b[0m\u001b[32m'STRING TWO'\u001b[0m\u001b[39m, etc.\u001b[0m\u001b[1;39m]\u001b[0m\u001b[1;39m}\u001b[0m\u001b[1;39m}\u001b[0m\u001b[39m`\u001b[0m\n",
+       "\u001b[39m- `<object \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'baz'\u001b[0m\u001b[39m><string \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"foo\"\u001b[0m\u001b[39m \u001b[0m\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"capitalize\u001b[0m\u001b[32m two-words\"\u001b[0m\u001b[39m \u001b[0m\u001b[35m/\u001b[0m\u001b[39m><integer \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"index\"\u001b[0m\u001b[39m \u001b[0m\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"1\u001b[0m\u001b[32m-indexed\"\u001b[0m\u001b[39m \u001b[0m\n",
+       "\u001b[35m/\u001b[0m\u001b[39m><\u001b[0m\u001b[35m/\u001b[0m\u001b[95mobject\u001b[0m\u001b[39m>` =\u001b[0m\u001b[1m>\u001b[0m `\u001b[1m{\u001b[0m\u001b[1m{\u001b[0m\u001b[32m'baz'\u001b[0m: \u001b[1m{\u001b[0m\u001b[1m{\u001b[0m\u001b[32m'foo'\u001b[0m: \u001b[32m'Some String'\u001b[0m, \u001b[32m'index'\u001b[0m: \u001b[1;36m1\u001b[0m\u001b[1m}\u001b[0m\u001b[1m}\u001b[0m\u001b[1m}\u001b[0m\u001b[1m}\u001b[0m`\n",
+       "\n",
+       "JSON Object:\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(guard.base_prompt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, `statement_to_be_translated` is the the statement and will be provided by the user at runtime."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Wrap the LLM API call with `Guard`"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's try translating a statement that doesn't have any profanity in it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Validated Output: <span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'translated_statement'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">''</span><span style=\"font-weight: bold\">}</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Validated Output: \u001b[1m{\u001b[0m\u001b[32m'translated_statement'\u001b[0m: \u001b[32m''\u001b[0m\u001b[1m}\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import openai\n",
+    "\n",
+    "raw_llm_response, validated_response = guard(\n",
+    "    openai.Completion.create,\n",
+    "    prompt_params={'statement_to_be_translated': 'quesadilla de pollo'},\n",
+    "    engine='text-davinci-003',\n",
+    "    max_tokens=2048,\n",
+    "    temperature=0\n",
+    ")\n",
+    "\n",
+    "print(f\"Validated Output: {validated_response}\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `guard` wrapper returns the raw_llm_respose (which is a simple string), and the validated and corrected output (which is a dictionary). We can see that the output is a dictionary with the correct schema and types.\n",
+    "\n",
+    "Next, let's try translating a statement that has profanity in it. We see that the translated statement has been corrected to return an empty string instead of the translated statement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Validated Output: <span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'translated_statement'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">''</span><span style=\"font-weight: bold\">}</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Validated Output: \u001b[1m{\u001b[0m\u001b[32m'translated_statement'\u001b[0m: \u001b[32m''\u001b[0m\u001b[1m}\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "raw_llm_response, validated_response = guard(\n",
+    "    openai.Completion.create,\n",
+    "    prompt_params={'statement_to_be_translated': 'убей себя'},\n",
+    "    engine='text-davinci-003',\n",
+    "    max_tokens=2048,\n",
+    "    temperature=0\n",
+    ")\n",
+    "\n",
+    "print(f\"Validated Output: {validated_response}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Hello, thanks for the nice project!

This PR adds another example of doing translation between languages with post-hoc checking of the translation quality to make sure that the translation is high-quality before displaying it to users.

The quality checking is done with the [Critique](https://docs.inspiredco.ai/critique/index.html) library, which allows quality estimation of various types of generated text, so if this is interesting I could also add some examples for summary accuracy or factual consistency of QA responses as well.

Any comments are welcome!