### PR TITLE
makefile: add support for passing docs serve addr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+MKDOCS_SERVE_ADDR ?= localhost:8000 # Default address for mkdocs serve, format: <host>:<port>, override with `make docs-serve MKDOCS_SERVE_ADDR=<host>:<port>`
+
 autoformat:
 	black guardrails/ tests/
 	isort --atomic guardrails/ tests/
@@ -20,7 +22,7 @@ test-cov:
 	pytest tests/ --cov=./ --cov-report=xml
 
 docs-serve:
-	mkdocs serve
+	mkdocs serve -a $(MKDOCS_SERVE_ADDR)
 
 docs-deploy:
 	mkdocs gh-deploy


### PR DESCRIPTION
A very, very tiny change.

I added the ability to serve docs from different ports. I run some other services at this port on localhost. It is a good practice to expose this. 

*Separate suggestion*

To ease the development, we should add `How to run tests/docs/ locally guide` in the readme. One can check the `makefile`, but it would be good to put it in the readme to make it more obvious. 


