### PR TITLE
Reask: Fix `repr` recursion error, remove use of `pretty_repr`

### DIFF
--- a/guardrails/utils/reask_utils.py
+++ b/guardrails/utils/reask_utils.py
@@ -1,11 +1,10 @@
-import dataclasses
+import json
 from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
 
 from lxml import etree as ET
-from rich.pretty import pretty_repr
 
 from guardrails.utils.constants import constants
 
@@ -16,9 +15,6 @@ class ReAsk:
     error_message: str
     fix_value: Any
     path: List[Any] = None
-
-    def __repr__(self) -> str:
-        return pretty_repr(dataclasses.asdict(self))
 
 
 def gather_reasks(validated_output: Dict) -> List[ReAsk]:
@@ -234,7 +230,7 @@ def get_reask_prompt(
     )
 
     reask_prompt = reask_prompt_template.format(
-        previous_response=pretty_repr(reask_json),
+        previous_response=json.dumps(reask_json, indent=2),
         output_schema=pruned_tree_string,
     )
 

--- a/guardrails/utils/reask_utils.py
+++ b/guardrails/utils/reask_utils.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
@@ -17,7 +18,7 @@ class ReAsk:
     path: List[Any] = None
 
     def __repr__(self) -> str:
-        return pretty_repr(self)
+        return pretty_repr(dataclasses.asdict(self))
 
 
 def gather_reasks(validated_output: Dict) -> List[ReAsk]:

--- a/guardrails/utils/reask_utils.py
+++ b/guardrails/utils/reask_utils.py
@@ -136,6 +136,14 @@ def prune_json_for_reasking(json_object: Any) -> Dict:
     Returns:
         The pruned validated JSON.
     """
+
+    def reask_to_dict(reask: ReAsk) -> Dict:
+        return {
+            "incorrect_value": reask.incorrect_value,
+            "error_message": reask.error_message,
+            "fix_value": reask.fix_value,
+        }
+
     if isinstance(json_object, list):
         pruned_list = []
         for item in json_object:
@@ -149,7 +157,7 @@ def prune_json_for_reasking(json_object: Any) -> Dict:
         pruned_json = {}
         for key, value in json_object.items():
             if isinstance(value, ReAsk):
-                pruned_json[key] = value
+                pruned_json[key] = reask_to_dict(value)
             elif isinstance(value, dict):
                 pruned_output = prune_json_for_reasking(value)
                 if pruned_output is not None:
@@ -169,7 +177,7 @@ def prune_json_for_reasking(json_object: Any) -> Dict:
         return None
     else:
         if isinstance(json_object, ReAsk):
-            return json_object
+            return reask_to_dict(json_object)
         return None
 
 

--- a/tests/unit_tests/utils/test_reask_utils.py
+++ b/tests/unit_tests/utils/test_reask_utils.py
@@ -1,5 +1,9 @@
-import pytest
+import json
 
+import pytest
+from lxml import etree as ET
+
+from guardrails.utils import reask_utils
 from guardrails.utils.reask_utils import (
     ReAsk,
     gather_reasks,
@@ -53,3 +57,135 @@ def test_gather_reasks():
         ReAsk("h0", "Error Msg", "h1", ["h", 2, 2]),
     ]
     assert gather_reasks(input_dict) == expected_reasks
+
+
+@pytest.mark.parametrize(
+    "input_dict, expected_dict",
+    [
+        (
+            {"a": 1, "b": reask_utils.ReAsk(-1, "Error Msg", 1)},
+            {
+                "b": {
+                    "incorrect_value": -1,
+                    "error_message": "Error Msg",
+                    "fix_value": 1,
+                }
+            },
+        ),
+        (
+            {"a": 1, "b": {"c": 2, "d": reask_utils.ReAsk(-1, "Error Msg", 2)}},
+            {
+                "b": {
+                    "d": {
+                        "incorrect_value": -1,
+                        "error_message": "Error Msg",
+                        "fix_value": 2,
+                    }
+                }
+            },
+        ),
+        (
+            {"a": [1, 2, reask_utils.ReAsk(-1, "Error Msg", 3)], "b": 4},
+            {
+                "a": [
+                    {
+                        "incorrect_value": -1,
+                        "error_message": "Error Msg",
+                        "fix_value": 3,
+                    }
+                ]
+            },
+        ),
+        (
+            {"a": [1, 2, {"c": reask_utils.ReAsk(-1, "Error Msg", 3)}]},
+            {
+                "a": [
+                    {
+                        "c": {
+                            "incorrect_value": -1,
+                            "error_message": "Error Msg",
+                            "fix_value": 3,
+                        }
+                    }
+                ]
+            },
+        ),
+        ({"a": 1}, None),
+    ],
+)
+def test_prune_json_for_reasking(input_dict, expected_dict):
+    """Test that the prune_json_for_reasking function removes ReAsk objects."""
+    assert reask_utils.prune_json_for_reasking(input_dict) == expected_dict
+
+
+@pytest.mark.parametrize(
+    "example_rail, reasks, reask_json",
+    [
+        (
+            """
+<output>
+    <string name="name" required="true"/>
+</output>
+""",
+            [reask_utils.ReAsk(-1, "Error Msg", "name", ["name"])],
+            {
+                "name": {
+                    "incorrect_value": -1,
+                    "error_message": "Error Msg",
+                    "fix_value": "name",
+                }
+            },
+        ),
+        (
+            """
+<output>
+    <string name="name" required="true"/>
+    <integer name="age" required="true"/>
+</output>
+""",
+            [
+                reask_utils.ReAsk(-1, "Error Msg", "name", ["name"]),
+                reask_utils.ReAsk(-1, "Error Msg", "age", ["age"]),
+            ],
+            {
+                "name": {
+                    "incorrect_value": -1,
+                    "error_message": "Error Msg",
+                    "fix_value": "name",
+                },
+                "age": {
+                    "incorrect_value": -1,
+                    "error_message": "Error Msg",
+                    "fix_value": "age",
+                },
+            },
+        ),
+    ],
+)
+def test_get_reask_prompt(example_rail, reasks, reask_json):
+    """Test that get_reask_prompt function returns the correct prompt."""
+    expected_result_template = """
+I was given the following JSON response, which had problems due to incorrect values.
+
+%s
+
+Help me correct the incorrect values based on the given error messages.
+
+Given below is XML that describes the information to extract from this document and the tags to extract it into.
+%s
+ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `None`.
+
+Here are examples of simple (XML, JSON) pairs that show the expected behavior:
+- `<string name='foo' format='two-words lower-case' />` => `{{'foo': 'example one'}}`
+- `<list name='bar'><string format='upper-case' /></list>` => `{{"bar": ['STRING ONE', 'STRING TWO', etc.]}}`
+- `<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>` => `{{'baz': {{'foo': 'Some String', 'index': 1}}}}`
+
+JSON Object:"""  # noqa: E501
+
+    result_prompt, _ = reask_utils.get_reask_prompt(
+        ET.fromstring(example_rail), reasks, reask_json
+    )
+    assert result_prompt == expected_result_template % (
+        json.dumps(reask_json, indent=2),
+        example_rail,
+    )


### PR DESCRIPTION
Currently `ReAsk.__repr__` (which uses `pretty_repr`) recurses over itself infinitely, and its string value becomes a recursion error.

This PR fixes that by `pretty_repr`ing its dict contents instead. In the other two commits, I removed the use of `pretty_repr` and `rich` package requirement altogether, instead using `json.dumps(indent=2)`.

Feel free to rebase out the latter two commits, the first one's more pertinent.