### PR TITLE
Add semantic validator for similarity

### DIFF
--- a/docs/examples/data/article1.txt
+++ b/docs/examples/data/article1.txt
@@ -1,0 +1,13 @@
+Section. 1.
+All legislative Powers herein granted shall be vested in a Congress of the United States, which shall consist of a Senate and House of Representatives.
+
+Section. 2.
+The House of Representatives shall be composed of Members chosen every second Year by the People of the several States, and the Electors in each State shall have the Qualifications requisite for Electors of the most numerous Branch of the State Legislature.
+
+No Person shall be a Representative who shall not have attained to the Age of twenty five Years, and been seven Years a Citizen of the United States, and who shall not, when elected, be an Inhabitant of that State in which he shall be chosen.
+
+Representatives and direct Taxes shall be apportioned among the several States which may be included within this Union, according to their respective Numbers, which shall be determined by adding to the whole Number of free Persons, including those bound to Service for a Term of Years, and excluding Indians not taxed, three fifths of all other Persons. The actual Enumeration shall be made within three Years after the first Meeting of the Congress of the United States, and within every subsequent Term of ten Years, in such Manner as they shall by Law direct. The Number of Representatives shall not exceed one for every thirty Thousand, but each State shall have at Least one Representative; and until such enumeration shall be made, the State of New Hampshire shall be entitled to chuse three, Massachusetts eight, Rhode-Island and Providence Plantations one, Connecticut five, New-York six, New Jersey four, Pennsylvania eight, Delaware one, Maryland six, Virginia ten, North Carolina five, South Carolina five, and Georgia three.
+
+When vacancies happen in the Representation from any State, the Executive Authority thereof shall issue Writs of Election to fill such Vacancies.
+
+The House of Representatives shall chuse their Speaker and other Officers; and shall have the sole Power of Impeachment.

--- a/docs/examples/text_summarization_quality.ipynb
+++ b/docs/examples/text_summarization_quality.ipynb
@@ -1,0 +1,347 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Summarize text accurately\n",
+    "\n",
+    "!!! note\n",
+    "    To download this example as a Jupyter notebook, click [here](https://github.com/ShreyaR/guardrails/blob/main/docs/examples/text_summarization_quality.ipynb).\n",
+    "\n",
+    "In this example, we will use Guardrails in the summarization of a text document. We will check whether the summarized document has a high semantic similarity with the original document.\n",
+    "\n",
+    "## Objective\n",
+    "\n",
+    "Summarize a text document and check whether the summarized document has a high semantic similarity with the original document.\n",
+    "\n",
+    "## Step 0: Setup\n",
+    "\n",
+    "In order to run this example, you will need to install the `numpy` package. You can do so by running the following commands:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: numpy in /Users/krandiash/opt/anaconda3/envs/guardrails/lib/python3.9/site-packages (1.24.2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install numpy"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Create the RAIL Spec\n",
+    "\n",
+    "Ordinarily, we would create an RAIL spec in a separate file. For the purposes of this example, we will create the spec in this notebook as a string following the RAIL syntax. For more information on RAIL, see the [RAIL documentation](../rail/output.md).\n",
+    "\n",
+    "In this RAIL spec, we:\n",
+    "\n",
+    "1. Create an `output` schema that returns a single key-value pair. The key should be 'summary', and the value should be the summary of the given document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rail_str = \"\"\"\n",
+    "<rail version=\"0.1\">\n",
+    "\n",
+    "<script language='python'>\n",
+    "document = open(\"data/article1.txt\", \"r\").read()\n",
+    "</script>\n",
+    "\n",
+    "<output>\n",
+    "    <string\n",
+    "        name=\"summary\"\n",
+    "        description=\"Summarize the given document faithfully.\"\n",
+    "        format=\"similar-to-document: {document}, 0.60\"\n",
+    "        on-fail-similar-to-document=\"filter\" \n",
+    "    />\n",
+    "</output>\n",
+    "\n",
+    "<prompt>\n",
+    "Summarize the following document:\n",
+    "\n",
+    "{{document}}\n",
+    "\n",
+    "@complete_json_suffix\n",
+    "</prompt>\n",
+    "</rail>\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "!!! note\n",
+    "\n",
+    "    In order to ensure the summary is similar to the document, we use `similar-to-document` as the validator. This validator embeds the document and the summary and checks whether the cosine similarity between the two embeddings is above a threshold."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Create a `Guard` object with the RAIL Spec\n",
+    "\n",
+    "We create a `gd.Guard` object that will check, validate and correct the output of the LLM. This object:\n",
+    "\n",
+    "1. Enforces the quality criteria specified in the RAIL spec.\n",
+    "2. Takes corrective action when the quality criteria are not met.\n",
+    "3. Compiles the schema and type info from the RAIL spec and adds it to the prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import guardrails as gd\n",
+    "\n",
+    "from rich import print\n",
+    "\n",
+    "guard = gd.Guard.from_rail_string(rail_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see the prompt that will be sent to the LLM:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "Summarize the following document:\n",
+       "\n",
+       "<span style=\"font-weight: bold\">{</span>document<span style=\"font-weight: bold\">}</span>\n",
+       "\n",
+       "\n",
+       "Given below is XML that describes the information to extract from this document and the tags to extract it into.\n",
+       "\n",
+       "<span style=\"font-weight: bold\">&lt;</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold\">output</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">    &lt;string </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"summary\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #808000; text-decoration-color: #808000\">description</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"Summarize the given document faithfully.\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"similar-to-document: </span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">{document}, 0.60\"</span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">&lt;</span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">output</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;</span>\n",
+       "\n",
+       "\n",
+       "\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">ONLY return a valid JSON object </span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">(</span><span style=\"color: #000000; text-decoration-color: #000000\">no other text is necessary</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">)</span><span style=\"color: #000000; text-decoration-color: #000000\">, where the key of the field in JSON is the `name` </span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and </span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">specific types. Be correct and concise. If you are unsure anywhere, enter `</span><span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span><span style=\"color: #000000; text-decoration-color: #000000\">`.</span>\n",
+       "\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">Here are examples of simple </span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">(</span><span style=\"color: #000000; text-decoration-color: #000000\">XML, JSON</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">)</span><span style=\"color: #000000; text-decoration-color: #000000\"> pairs that show the expected behavior:</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">- `&lt;string </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'foo'</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'two-words lower-case'</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;` =&gt; `</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">{{</span><span style=\"color: #008000; text-decoration-color: #008000\">'foo'</span><span style=\"color: #000000; text-decoration-color: #000000\">: </span><span style=\"color: #008000; text-decoration-color: #008000\">'example one'</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">}}</span><span style=\"color: #000000; text-decoration-color: #000000\">`</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">- `&lt;list </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'bar'</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;string </span><span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'upper-case'</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;</span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">list</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;` =&gt; `</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">{{</span><span style=\"color: #008000; text-decoration-color: #008000\">\"bar\"</span><span style=\"color: #000000; text-decoration-color: #000000\">: </span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">[</span><span style=\"color: #008000; text-decoration-color: #008000\">'STRING ONE'</span><span style=\"color: #000000; text-decoration-color: #000000\">, </span><span style=\"color: #008000; text-decoration-color: #008000\">'STRING TWO'</span><span style=\"color: #000000; text-decoration-color: #000000\">, etc.</span><span style=\"color: #000000; text-decoration-color: #000000; font-weight: bold\">]}}</span><span style=\"color: #000000; text-decoration-color: #000000\">`</span>\n",
+       "<span style=\"color: #000000; text-decoration-color: #000000\">- `&lt;object </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">'baz'</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;string </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"foo\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"capitalize two-words\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;integer </span><span style=\"color: #808000; text-decoration-color: #808000\">name</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"index\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span><span style=\"color: #808000; text-decoration-color: #808000\">format</span><span style=\"color: #000000; text-decoration-color: #000000\">=</span><span style=\"color: #008000; text-decoration-color: #008000\">\"1-indexed\"</span><span style=\"color: #000000; text-decoration-color: #000000\"> </span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;&lt;</span><span style=\"color: #800080; text-decoration-color: #800080\">/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">object</span><span style=\"color: #000000; text-decoration-color: #000000\">&gt;` =</span><span style=\"font-weight: bold\">&gt;</span> `<span style=\"font-weight: bold\">{{</span><span style=\"color: #008000; text-decoration-color: #008000\">'baz'</span>: <span style=\"font-weight: bold\">{{</span><span style=\"color: #008000; text-decoration-color: #008000\">'foo'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'Some String'</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'index'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span><span style=\"font-weight: bold\">}}}}</span>`\n",
+       "\n",
+       "JSON Object:\n",
+       "\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n",
+       "Summarize the following document:\n",
+       "\n",
+       "\u001b[1m{\u001b[0mdocument\u001b[1m}\u001b[0m\n",
+       "\n",
+       "\n",
+       "Given below is XML that describes the information to extract from this document and the tags to extract it into.\n",
+       "\n",
+       "\u001b[1m<\u001b[0m\u001b[1;95moutput\u001b[0m\u001b[39m>\u001b[0m\n",
+       "\u001b[39m    <string \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"summary\"\u001b[0m\u001b[39m \u001b[0m\u001b[33mdescription\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"Summarize\u001b[0m\u001b[32m the given document faithfully.\"\u001b[0m\u001b[39m \u001b[0m\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"similar\u001b[0m\u001b[32m-to-document: \u001b[0m\n",
+       "\u001b[32m{\u001b[0m\u001b[32mdocument\u001b[0m\u001b[32m}\u001b[0m\u001b[32m, 0.60\"\u001b[0m\u001b[35m/\u001b[0m\u001b[39m>\u001b[0m\n",
+       "\u001b[39m<\u001b[0m\u001b[35m/\u001b[0m\u001b[95moutput\u001b[0m\u001b[39m>\u001b[0m\n",
+       "\n",
+       "\n",
+       "\n",
+       "\u001b[39mONLY return a valid JSON object \u001b[0m\u001b[1;39m(\u001b[0m\u001b[39mno other text is necessary\u001b[0m\u001b[1;39m)\u001b[0m\u001b[39m, where the key of the field in JSON is the `name` \u001b[0m\n",
+       "\u001b[39mattribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON\u001b[0m\n",
+       "\u001b[39mMUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and \u001b[0m\n",
+       "\u001b[39mspecific types. Be correct and concise. If you are unsure anywhere, enter `\u001b[0m\u001b[3;35mNone\u001b[0m\u001b[39m`.\u001b[0m\n",
+       "\n",
+       "\u001b[39mHere are examples of simple \u001b[0m\u001b[1;39m(\u001b[0m\u001b[39mXML, JSON\u001b[0m\u001b[1;39m)\u001b[0m\u001b[39m pairs that show the expected behavior:\u001b[0m\n",
+       "\u001b[39m- `<string \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'foo'\u001b[0m\u001b[39m \u001b[0m\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'two-words lower-case'\u001b[0m\u001b[39m \u001b[0m\u001b[35m/\u001b[0m\u001b[39m>` => `\u001b[0m\u001b[1;39m{\u001b[0m\u001b[1;39m{\u001b[0m\u001b[32m'foo'\u001b[0m\u001b[39m: \u001b[0m\u001b[32m'example one'\u001b[0m\u001b[1;39m}\u001b[0m\u001b[1;39m}\u001b[0m\u001b[39m`\u001b[0m\n",
+       "\u001b[39m- `<list \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'bar'\u001b[0m\u001b[39m><string \u001b[0m\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'upper-case'\u001b[0m\u001b[39m \u001b[0m\u001b[35m/\u001b[0m\u001b[39m><\u001b[0m\u001b[35m/\u001b[0m\u001b[95mlist\u001b[0m\u001b[39m>` => `\u001b[0m\u001b[1;39m{\u001b[0m\u001b[1;39m{\u001b[0m\u001b[32m\"bar\"\u001b[0m\u001b[39m: \u001b[0m\u001b[1;39m[\u001b[0m\u001b[32m'STRING ONE'\u001b[0m\u001b[39m, \u001b[0m\u001b[32m'STRING TWO'\u001b[0m\u001b[39m, etc.\u001b[0m\u001b[1;39m]\u001b[0m\u001b[1;39m}\u001b[0m\u001b[1;39m}\u001b[0m\u001b[39m`\u001b[0m\n",
+       "\u001b[39m- `<object \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m'baz'\u001b[0m\u001b[39m><string \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"foo\"\u001b[0m\u001b[39m \u001b[0m\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"capitalize\u001b[0m\u001b[32m two-words\"\u001b[0m\u001b[39m \u001b[0m\u001b[35m/\u001b[0m\u001b[39m><integer \u001b[0m\u001b[33mname\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"index\"\u001b[0m\u001b[39m \u001b[0m\u001b[33mformat\u001b[0m\u001b[39m=\u001b[0m\u001b[32m\"1\u001b[0m\u001b[32m-indexed\"\u001b[0m\u001b[39m \u001b[0m\n",
+       "\u001b[35m/\u001b[0m\u001b[39m><\u001b[0m\u001b[35m/\u001b[0m\u001b[95mobject\u001b[0m\u001b[39m>` =\u001b[0m\u001b[1m>\u001b[0m `\u001b[1m{\u001b[0m\u001b[1m{\u001b[0m\u001b[32m'baz'\u001b[0m: \u001b[1m{\u001b[0m\u001b[1m{\u001b[0m\u001b[32m'foo'\u001b[0m: \u001b[32m'Some String'\u001b[0m, \u001b[32m'index'\u001b[0m: \u001b[1;36m1\u001b[0m\u001b[1m}\u001b[0m\u001b[1m}\u001b[0m\u001b[1m}\u001b[0m\u001b[1m}\u001b[0m`\n",
+       "\n",
+       "JSON Object:\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(guard.base_prompt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, `statement_to_be_translated` is the the statement and will be provided by the user at runtime."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Wrap the LLM API call with `Guard`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's try translating a statement that doesn't have any profanity in it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Validated Output: <span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'summary'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'All legislative Powers shall be vested in a Congress of the United States, which </span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">shall consist of a Senate and House of Representatives. The House of Representatives shall be composed of Members </span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">chosen every second Year by the People of the several States, and the Electors in each State shall have the </span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">Qualifications requisite for Electors of the most numerous Branch of the State Legislature. Representatives and </span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">direct Taxes shall be apportioned among the several States according to their respective Numbers, and the Number of</span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">Representatives shall not exceed one for every thirty Thousand. When vacancies happen in the Representation from </span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">any State, the Executive Authority thereof shall issue Writs of Election to fill such Vacancies. The House of </span>\n",
+       "<span style=\"color: #008000; text-decoration-color: #008000\">Representatives shall chuse their Speaker and other Officers; and shall have the sole Power of Impeachment.'</span><span style=\"font-weight: bold\">}</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Validated Output: \u001b[1m{\u001b[0m\u001b[32m'summary'\u001b[0m: \u001b[32m'All legislative Powers shall be vested in a Congress of the United States, which \u001b[0m\n",
+       "\u001b[32mshall consist of a Senate and House of Representatives. The House of Representatives shall be composed of Members \u001b[0m\n",
+       "\u001b[32mchosen every second Year by the People of the several States, and the Electors in each State shall have the \u001b[0m\n",
+       "\u001b[32mQualifications requisite for Electors of the most numerous Branch of the State Legislature. Representatives and \u001b[0m\n",
+       "\u001b[32mdirect Taxes shall be apportioned among the several States according to their respective Numbers, and the Number of\u001b[0m\n",
+       "\u001b[32mRepresentatives shall not exceed one for every thirty Thousand. When vacancies happen in the Representation from \u001b[0m\n",
+       "\u001b[32many State, the Executive Authority thereof shall issue Writs of Election to fill such Vacancies. The House of \u001b[0m\n",
+       "\u001b[32mRepresentatives shall chuse their Speaker and other Officers; and shall have the sole Power of Impeachment.'\u001b[0m\u001b[1m}\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import openai\n",
+    "\n",
+    "raw_llm_response, validated_response = guard(\n",
+    "    openai.Completion.create,\n",
+    "    prompt_params={'document': open(\"data/article1.txt\", \"r\").read()},\n",
+    "    engine='text-davinci-003',\n",
+    "    max_tokens=2048,\n",
+    "    temperature=0\n",
+    ")\n",
+    "\n",
+    "print(f\"Validated Output: {validated_response}\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `guard` wrapper returns the raw_llm_respose (which is a simple string), and the validated and corrected output (which is a dictionary). We can see that the output is a dictionary with the correct schema and types.\n",
+    "\n",
+    "Next, let's try using a smaller model, which is not boing to be good at summarization. We can see that the output is filtered out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Validated Output: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Validated Output: \u001b[3;35mNone\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "raw_llm_response, validated_response = guard(\n",
+    "    openai.Completion.create,\n",
+    "    prompt_params={'document': open(\"data/article1.txt\", \"r\").read()},\n",
+    "    engine='text-ada-001',\n",
+    "    max_tokens=512,\n",
+    "    temperature=0\n",
+    ")\n",
+    "\n",
+    "print(f\"Validated Output: {validated_response}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "guardrails",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -12,10 +12,10 @@ class PromptCallableException(Exception):
 
 @dataclass
 class PromptCallable:
-    """
-    A wrapper around a callable that takes in a prompt.
-    Catches exceptions to let the user know clearly
-    if the callable failed, and how to fix it.
+    """A wrapper around a callable that takes in a prompt.
+
+    Catches exceptions to let the user know clearly if the callable
+    failed, and how to fix it.
     """
 
     fn: Callable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - 'Translate text with profanity filtering': examples/translation_to_specific_language.ipynb
       - 'Generate structured synthetic data': examples/generate_structured_data.ipynb
       - 'Ensure translated text is high quality': examples/translation_with_quality_check.ipynb
+      - 'Check key info present in generated summary': examples/text_summarization_quality.ipynb
       # - 'Natural language to pandas code': examples/nl_to_pandas.md
       # - 'Building EHRs from doctors notes': examples/ehr_from_doctors_notes.md
       # - 'Forcing positive sentiment in chatbots': examples/positive_sentiment.md

--- a/tests/data/article1.txt
+++ b/tests/data/article1.txt
@@ -1,0 +1,13 @@
+Section. 1.
+All legislative Powers herein granted shall be vested in a Congress of the United States, which shall consist of a Senate and House of Representatives.
+
+Section. 2.
+The House of Representatives shall be composed of Members chosen every second Year by the People of the several States, and the Electors in each State shall have the Qualifications requisite for Electors of the most numerous Branch of the State Legislature.
+
+No Person shall be a Representative who shall not have attained to the Age of twenty five Years, and been seven Years a Citizen of the United States, and who shall not, when elected, be an Inhabitant of that State in which he shall be chosen.
+
+Representatives and direct Taxes shall be apportioned among the several States which may be included within this Union, according to their respective Numbers, which shall be determined by adding to the whole Number of free Persons, including those bound to Service for a Term of Years, and excluding Indians not taxed, three fifths of all other Persons. The actual Enumeration shall be made within three Years after the first Meeting of the Congress of the United States, and within every subsequent Term of ten Years, in such Manner as they shall by Law direct. The Number of Representatives shall not exceed one for every thirty Thousand, but each State shall have at Least one Representative; and until such enumeration shall be made, the State of New Hampshire shall be entitled to chuse three, Massachusetts eight, Rhode-Island and Providence Plantations one, Connecticut five, New-York six, New Jersey four, Pennsylvania eight, Delaware one, Maryland six, Virginia ten, North Carolina five, South Carolina five, and Georgia three.
+
+When vacancies happen in the Representation from any State, the Executive Authority thereof shall issue Writs of Election to fill such Vacancies.
+
+The House of Representatives shall chuse their Speaker and other Officers; and shall have the sole Power of Impeachment.

--- a/tests/unit_tests/test_validators.py
+++ b/tests/unit_tests/test_validators.py
@@ -1,6 +1,12 @@
 import pytest
 
-from guardrails.validators import Filter, Refrain, check_refrain_in_dict, filter_in_dict
+from guardrails.validators import (
+    Filter,
+    Refrain,
+    SimilarToDocument,
+    check_refrain_in_dict,
+    filter_in_dict,
+)
 
 
 @pytest.mark.parametrize(
@@ -34,3 +40,23 @@ def test_check_refrain(input_dict, expected):
 )
 def test_filter_in_dict(input_dict, expected_dict):
     assert filter_in_dict(input_dict) == expected_dict
+
+
+# TODO: Implement testing with models on CI
+@pytest.mark.skip(
+    reason="This test requires the text-embedding-ada-002 embedding model."
+    " Testing with models needs to be implemented."
+)
+def test_similar_to_document_validator():
+    import os
+
+    datapath = os.path.abspath(os.path.dirname(__file__) + "/../data/article1.txt")
+    val = SimilarToDocument(
+        document=open(datapath, "r").read(),
+        model="text-embedding-ada-002",
+        threshold=0.85,
+    )
+    summary = "All legislative powers are held by a Congress"
+    " consisting of two chambers, the Senate and the House of Representatives."
+    schema = {"key": summary}
+    assert val.validate("key", summary, schema) == schema


### PR DESCRIPTION
Add a `SimilarToDocument` validator as an example of a "noisy" validator that does semantic checking.

Also includes an example that uses this validator to summarize a document (subset of Article 1 of the US Constitution).