### PR TITLE
Optimize chat prompts (Remove `JSON Output:`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ Given below is XML that describes the information to extract from this document 
 </output>
 
 ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise.
-
-JSON Output:
 ```
 
 Call the `Guard` object with the LLM API call as the first argument and add any additional arguments to the LLM API call as the remaining arguments.

--- a/docs/rail/prompt.md
+++ b/docs/rail/prompt.md
@@ -46,6 +46,4 @@ Given below is XML that describes the information to extract from this document 
 
 ```
 ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `None`.
-
-JSON Output:
 ```

--- a/guardrails/constants.xml
+++ b/guardrails/constants.xml
@@ -13,15 +13,11 @@ Given below is XML that describes the information to extract from this document 
 
 <json_suffix_prompt_v2>
 ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter "None".
-
-JSON Output:
 </json_suffix_prompt_v2>
 
 
 <json_suffix_prompt_v2_wo_none>
 ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise.
-
-JSON Output:
 </json_suffix_prompt_v2_wo_none>
 
 
@@ -46,8 +42,7 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<![CDATA[<string name='foo' format='two-words lower-case' />`]]> => `{{{{'foo': 'example one'}}}}`
 - `<![CDATA[<list name='bar'><string format='upper-case' /></list>]]>` => `{{{{"bar": ['STRING ONE', 'STRING TWO', etc.]}}}}`
 - `<![CDATA[<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>]]>` => `{{{{'baz': {{{{'foo': 'Some String', 'index': 1}}}}}}}}`
-
-JSON Object:</complete_json_suffix>
+</complete_json_suffix>
 
 <complete_json_suffix_v2>
 Given below is XML that describes the information to extract from this document and the tags to extract it into.
@@ -60,8 +55,7 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<![CDATA[<string name='foo' format='two-words lower-case' />`]]> => `{{{{'foo': 'example one'}}}}`
 - `<![CDATA[<list name='bar'><string format='upper-case' /></list>]]>` => `{{{{"bar": ['STRING ONE', 'STRING TWO', etc.]}}}}`
 - `<![CDATA[<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>]]>` => `{{{{'baz': {{{{'foo': 'Some String', 'index': 1}}}}}}}}`
-
-JSON Object:</complete_json_suffix_v2>
+</complete_json_suffix_v2>
 
 
 </constants>

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -46,7 +46,7 @@ def openai_wrapper(text: str, *args, **kwargs):
     api_key = os.environ.get("OPENAI_API_KEY")
     openai_response = openai.Completion.create(
         api_key=api_key,
-        prompt=text,
+        prompt=text + "\n\nJson Output:\n\n",
         *args,
         **kwargs,
     )

--- a/tests/integration_tests/test_cases/entity_extraction/compiled_prompt.txt
+++ b/tests/integration_tests/test_cases/entity_extraction/compiled_prompt.txt
@@ -131,5 +131,3 @@ Given below is XML that describes the information to extract from this document 
 
 
 ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise.
-
-JSON Output:

--- a/tests/integration_tests/test_cases/entity_extraction/compiled_prompt_reask.txt
+++ b/tests/integration_tests/test_cases/entity_extraction/compiled_prompt_reask.txt
@@ -37,5 +37,3 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<string name='foo' format='two-words lower-case' />` => `{{'foo': 'example one'}}`
 - `<list name='bar'><string format='upper-case' /></list>` => `{{"bar": ['STRING ONE', 'STRING TWO', etc.]}}`
 - `<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>` => `{{'baz': {{'foo': 'Some String', 'index': 1}}}}`
-
-JSON Object:

--- a/tests/integration_tests/test_cases/pydantic/compiled_prompt.txt
+++ b/tests/integration_tests/test_cases/pydantic/compiled_prompt.txt
@@ -24,5 +24,3 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<string name='foo' format='two-words lower-case' />` => `{'foo': 'example one'}`
 - `<list name='bar'><string format='upper-case' /></list>` => `{"bar": ['STRING ONE', 'STRING TWO', etc.]}`
 - `<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>` => `{'baz': {'foo': 'Some String', 'index': 1}}`
-
-JSON Object:

--- a/tests/integration_tests/test_cases/pydantic/compiled_prompt_reask_1.txt
+++ b/tests/integration_tests/test_cases/pydantic/compiled_prompt_reask_1.txt
@@ -29,5 +29,3 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<string name='foo' format='two-words lower-case' />` => `{{'foo': 'example one'}}`
 - `<list name='bar'><string format='upper-case' /></list>` => `{{"bar": ['STRING ONE', 'STRING TWO', etc.]}}`
 - `<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>` => `{{'baz': {{'foo': 'Some String', 'index': 1}}}}`
-
-JSON Object:

--- a/tests/integration_tests/test_cases/pydantic/compiled_prompt_reask_2.txt
+++ b/tests/integration_tests/test_cases/pydantic/compiled_prompt_reask_2.txt
@@ -29,5 +29,3 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<string name='foo' format='two-words lower-case' />` => `{{'foo': 'example one'}}`
 - `<list name='bar'><string format='upper-case' /></list>` => `{{"bar": ['STRING ONE', 'STRING TWO', etc.]}}`
 - `<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>` => `{{'baz': {{'foo': 'Some String', 'index': 1}}}}`
-
-JSON Object:

--- a/tests/unit_tests/utils/test_reask_utils.py
+++ b/tests/unit_tests/utils/test_reask_utils.py
@@ -157,8 +157,7 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<string name='foo' format='two-words lower-case' />` => `{{'foo': 'example one'}}`
 - `<list name='bar'><string format='upper-case' /></list>` => `{{"bar": ['STRING ONE', 'STRING TWO', etc.]}}`
 - `<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>` => `{{'baz': {{'foo': 'Some String', 'index': 1}}}}`
-
-JSON Object:"""  # noqa: E501
+"""  # noqa: E501
 
     result_prompt, _ = reask_utils.get_reask_prompt(
         ET.fromstring(example_rail), reasks, reask_json


### PR DESCRIPTION
It feels unnecessary/erroneous to add "\n\nJSON Output:\n\n" at the end of the prompt in a chat context. I assume it's there to guide a string completion model's response, I'm unsure if it's still relevant in chat completions.