### PR TITLE
Python 3.11 support

### DIFF
--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -1,5 +1,5 @@
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
 from eliot import start_action
@@ -44,7 +44,7 @@ class Runner:
     output_schema: OutputSchema
     num_reasks: int = 0
     output: str = None
-    guard_history: GuardHistory = GuardHistory([])
+    guard_history: GuardHistory = field(default_factory=GuardHistory)
 
     def _reset_guard_history(self):
         """Reset the guard history."""

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -44,7 +44,7 @@ class Runner:
     output_schema: OutputSchema
     num_reasks: int = 0
     output: str = None
-    guard_history: GuardHistory = field(default_factory=GuardHistory)
+    guard_history: GuardHistory = field(default_factory=lambda: GuardHistory([]))
 
     def _reset_guard_history(self):
         """Reset the guard history."""


### PR DESCRIPTION
Python 3.11 is more strict about dataclass field initiation than previous versions (https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses). Since `GuardHistory` is an unhashable object it won't be an acceptable default value in 3.11, but the Runner class attempts to initialize it this way.

This would lead importing Guardrails-ai in Python 3.11 to fail.

This PR initializes the Runner class in a way that is supported in 3.11. 

I tested back to 3.7.16 and tests are passing.