### PR TITLE
Bugfix - ValidLength and ValidUrl robustness

### DIFF
--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -762,6 +762,22 @@ class ValidUrl(Validator):
                 f"URL {value} could not be reached",
                 None,
             )
+        except requests.exceptions.InvalidSchema:
+            raise EventDetail(
+                key,
+                value,
+                schema,
+                f"URL {value} does not specify a valid connection adapter",
+                None,
+            )
+        except requests.exceptions.MissingSchema:
+            raise EventDetail(
+                key,
+                value,
+                schema,
+                f"URL {value} does not contain a http schema",
+                None,
+            )
 
         return schema
 


### PR DESCRIPTION
Fixes issues mentioned in https://github.com/ShreyaR/guardrails/issues/99

ValidLength and ValidUrl validators now do more checking on the input and can handle the case when the input is not a string.

I'm not sure if https://github.com/ShreyaR/guardrails/issues/99 should be addressed on some higher level, since I can see other validators also running into this issues (LLM output is parsed into nested dictionaries, when strings are expected). But these two validators are now more robust to the input type.

Left one TODO to the ValidLength validator about type hinting as well.