### PR TITLE
added support for setting schema and connection string in sql validator

### DIFF
--- a/guardrails/utils/sql_utils.py
+++ b/guardrails/utils/sql_utils.py
@@ -1,0 +1,61 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import List, Optional
+
+from pydantic import ValidationError
+
+
+class SQLDriver(ABC):
+    @abstractmethod
+    def validate_sql(self, query: str) -> List[str]:
+        ...
+
+
+class SimpleSqlDriver(SQLDriver):
+    def validate_sql(self, query: str) -> List[str]:
+        import sqlvalidator
+
+        sql_query = sqlvalidator.parse(query)
+        if not sql_query.is_valid():
+            return sql_query.errors
+        return sql_query.errors
+
+
+class SqlAlchemyDriver(SQLDriver):
+    def __init__(self, schema_file: Optional[str], conn: Optional[str]) -> None:
+        import sqlalchemy as db
+        from sqlalchemy import text
+
+        if schema_file is not None and conn is None:
+            raise ValidationError(
+                """schema_file should accompany a sql connection string for
+           guardrails to apply it to a database backend.
+           Use sqlite for ex: sqlite://"""
+            )
+
+        if conn is not None:
+            try:
+                self._engine = db.create_engine(conn)
+                self._conn = self._engine.connect()
+            except Exception as ex:
+                raise ValueError(ex)
+
+        if schema_file is not None:
+            schema = Path(schema_file).read_text()
+            self._conn.execute(text(schema))
+
+    def validate_sql(self, query: str) -> List[str]:
+        from sqlalchemy import text
+
+        exceptions: List[str] = []
+        try:
+            self._conn.execute(text(query))
+        except Exception as ex:
+            exceptions.append(str(ex))
+        return exceptions
+
+
+def create_sql_driver(schema_file: Optional[str], conn: Optional[str]) -> SQLDriver:
+    if schema_file is None and conn is None:
+        return SimpleSqlDriver()
+    return SqlAlchemyDriver(schema_file=schema_file, conn=conn)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ REQUIRED = [
 with open("docs/requirements.txt") as f:
     DOCS_REQUIREMENTS = f.read().splitlines()
 
-
+SQL_REQUIREMENTS = ["sqlvalidator", "sqlalchemy"]
 # What packages are optional?
 EXTRAS = {
     "dev": [
@@ -55,9 +55,10 @@ EXTRAS = {
         "twine",
         "pytest-mock",
         "pypdfium2",
+        *SQL_REQUIREMENTS,
     ]
     + DOCS_REQUIREMENTS,
-    "sql": ["sqlvalidator"],
+    "sql": SQL_REQUIREMENTS,
     "profanity": ["alt-profanity-check"],
     "critique": ["inspiredco"],
 }

--- a/tests/unit_tests/test_assets/valid_schema.sql
+++ b/tests/unit_tests/test_assets/valid_schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS employees (
+    id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);


### PR DESCRIPTION
Starting a PR to discuss adding support for more comprehensive support for sql query correctness. 

New Features -
1. Developers can pass in a connection string of a test database that the sql query generated by LLM is tested against.
2. An optional schema defintion which we will execute against the database specified on the connection string to do any kind of setup of schema and test data. The file should contain valid sql statements understood by the database.
3. An abstract sql driver class allows us to add more database backends(like snowflake) and based on the connection string we can instantiate the appropriate one.

Bug Fixes - 
1. The sqlvalidator doesn't populate errors until .is_valid is called so we were not really failing when incorrect sql was passed.