### PR TITLE
Fix the resetting of `guard_history` field for Python 3.11

### DIFF
--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -49,7 +49,7 @@ class Runner:
 
     def _reset_guard_history(self):
         """Reset the guard history."""
-        self.guard_history = GuardHistory([])
+        self.guard_history = field(default_factory=lambda: GuardHistory([]))
 
     def __post_init__(self):
         assert (self.prompt and self.api and not self.output) or (


### PR DESCRIPTION
Minor addition to the fixes in #97