### PR TITLE
Add monitor

### DIFF
--- a/guardrails/monitor.py
+++ b/guardrails/monitor.py
@@ -1,0 +1,82 @@
+import json
+from typing import Any, Dict
+
+class Singleton(type):
+    """A metaclass that ensures only one instance of a class is created.
+
+    Usage:
+
+        >>> class Example(metaclass=Singleton):
+        ...     def __init__(self, x):
+        ...         self.x = x
+        >>> a = Example(1)
+        >>> b = Example(2)
+        >>> print(a, id(a))
+        <__main__.Example object at 0x7f8b8c0b7a90> 140071000000000
+        >>> print(b, id(b))
+        <__main__.Example object at 0x7f8b8c0b7a90> 140071000000000
+    """
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        # Look up if this cls pair has been created before
+        if cls not in cls._instances:
+            # If not, we let a new instance be created
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class JsonLinesFile:
+
+    def __init__(self, filepath: str):
+        if not filepath.endswith(".jsonl"):
+            filepath += ".jsonl"
+
+        self.filepath = filepath
+        self.buffer = {}
+
+    def flush(self):
+        try:
+            with open(self.filepath, "a") as f:
+                f.write(json.dumps(self.buffer) + "\n")
+        except TypeError:
+            # Check which key is not serializable
+            for key, value in self.buffer.items():
+                try:
+                    json.dumps({key: value})
+                except TypeError:
+                    raise TypeError(
+                        f"Data {self.buffer} must be serializable to JSON."
+                        "{key}: {value} is not serializable."
+                        )
+        self.buffer = {}
+
+    def write(self, data: Dict[str, Any]):
+        # If any key conflicts, flush the buffer.
+        if set(self.buffer.keys()).intersection(set(data.keys())):
+            self.flush()
+        self.buffer.update(data)
+
+
+class Sink(metaclass=Singleton):
+
+    def __init__(self, filepath: str):
+        
+        # TODO: add support for writing to a database
+        self.client = JsonLinesFile(filepath)
+
+    def flush(self):
+        self.client.flush()
+
+    def write(self, data: Dict[str, Any]):
+        self.client.write(data)
+
+
+def log(data: Dict[str, Any]) -> None:
+    try:
+        sink = Sink()
+    except TypeError:
+        # No sink has been initialized, so we don't log anything.
+        return
+    sink.write(data)

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 from eliot import start_action
 
 from guardrails.llm_providers import PromptCallable
+from guardrails.monitor import Sink
 from guardrails.prompt import Instructions, Prompt
 from guardrails.schema import InputSchema, OutputSchema
 from guardrails.utils.logs_utils import GuardHistory, GuardLogs
@@ -108,6 +109,11 @@ class Runner:
                     output_schema,
                 )
 
+            # Flushes the sink before returning.
+            try:
+                Sink().flush()
+            except TypeError:
+                pass
             return self.guard_history
 
     def step(

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -292,6 +292,13 @@ class Validator:
         return f"{self.rail_alias}: {params}"
 
 
+    def log(self, data: Dict[str, Any]) -> None:
+        """Log some data to a sink."""
+        from guardrails.monitor import log
+        # Prepend all keys with the validator name.
+        data = {f"{self.rail_alias}/{k}": v for k, v in data.items()}
+        log(data)
+
 # @register_validator('required', 'all')
 # class Required(Validator):
 #     """Validate that a value is not None."""
@@ -1135,6 +1142,7 @@ class ReadingTime(Validator):
 
         # Estimate the reading time of the string
         reading_time = len(value.split()) / 200 * 60
+        self.log({'reading_time': reading_time})
         logger.debug(f"Estimated reading time {reading_time} seconds...")
 
         if abs(reading_time - self._max_time) > 1:

--- a/tests/unit_tests/test_monitor.py
+++ b/tests/unit_tests/test_monitor.py
@@ -1,0 +1,31 @@
+"""Unit tests for prompt and instructions parsing."""
+
+import os
+
+from guardrails.monitor import Sink
+
+
+def test_sink():
+    # Create a temporary file with ".jsonl" suffix
+    tmpfile = './tmpfile.jsonl'
+    sink = Sink(tmpfile)
+
+    # Write a line to the file
+    sink.write({"test": "test"})
+
+    # Flush the file
+    sink.flush()
+
+    # Write multiple lines to the file
+    # The dicts should appear merged as a single line.
+    sink.write({"test": "test"})
+    sink.write({"test2": "test2"})
+    sink.flush()
+
+    # Read the file and check the contents.
+    with open(tmpfile, 'r') as f:
+        contents = f.read()
+        assert contents == '{"test": "test"}\n{"test": "test", "test2": "test2"}\n'
+
+    # Delete the file
+    os.remove(tmpfile)


### PR DESCRIPTION
- Adds `monitor.py` with preliminary logging support for validators. Contains a `Sink` class to dump logs into, a basic sink for logging to json lines and a `log` function that can be used to log any data dict to the sink.
- Adds a `.log` method to the Validator class that can be used inside validators. Includes an example for the `ReadingTime` validator.
- Adds a basic test for the json lines sink.