### PR TITLE
Pin minimum tenacity version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRED = [
     "pydantic",
     "typer",
     "griffe",
-    "tenacity",
+    "tenacity>=8.1.0",
 ]
 
 # Read in docs/requirements.txt


### PR DESCRIPTION
tenacity==8.0.1 fails due to missing wait_exponential_jitter tested with tenacity==8.1.0 which is the first version to implement this