### PR TITLE
Refactor OutputSchema, implement StringOutputSchema

### DIFF
--- a/docs/rail/output.md
+++ b/docs/rail/output.md
@@ -9,7 +9,7 @@ The `<output>...</output>` element of a `RAIL` spec is used to give precise spec
 
 Example:
 
-=== "RAIL Spec"
+=== "JSON RAIL Spec"
 
     ```xml
     <rail version="0.1">
@@ -37,87 +37,23 @@ Example:
     }
     ```
 
+=== "String RAIL Spec"
 
-## 🏷️ `RAIL` Elements
-
-At the heart of the `RAIL` specification is the use of elements. Each element's tag represents a type of data. For example, in the element `<string ... />`, the tag represents a string, the `<integer ... />` elements represents an integer, the `<object ...></object>` element represents an object, etc.
-
-
-!!! note
-    The tag of RAIL element is the same as the "type" of the data it represents.
-
-    E.g. `<string .../>` element will generate a string, `<integer .../>` element will generate an integer, etc.
-
-### Supported types
-
-Guardrails supports many data types, including:, `string`, `integer`, `float`, `boolean`, `list`, `object`, `url`, `email` and many more.
-
-Check out the [RAIL Data Types](../data_types.md) page for a list of supported data types.
-
-
-#### Scalar vs Non-scalar types
-
-Guardrails supports two types of data types: scalar and non-scalar.
-
-
-| Scalar                                                                  | Non Scalar                                                                           |
-|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| Scalar types are void elements, and can't have any child elements.      | Non-scalar types can be non-void, and can have closing tags and child elements.                       |
-| Syntax:   ``` <string ... /> ```                                        | Syntax: <list ...>     <string /> </list>|
-| Examples: `string`, `integer`, `float`, `boolean`, `url`, `email`, etc. | Examples: `list` and `object` are the only non-scalar types supported by Guardrails. |
-
-
-### Supported attributes
-
-Each element can have attributes that specify additional information about the data, such as:
-
-1. `name` attribute that specifies the name of the field. This will be the key in the output JSON. E.g.
-
-    === "RAIL Spec"
-        ```xml
-        <rail version="0.1">
-            <output>
-                <string name="some_key" />
-            </output>
-        </rail>
-        ```
-    === "Output JSON"
-        ```json
-        {
-            "some_key": "..."
-        }
-        ```
-
-2. `description` attribute that specifies the description of the field. This is similar to a prompt that will be provided to the LLM. It can contain more context to help the LLM generate the correct output.
-3. (Coming soon!) `required` attribute that specifies whether the field is required or not. If the field is required, the LLM will be asked to generate the field until it is generated correctly. If the field is not required, the LLM will not be asked to generate the field if it is not generated correctly.
-4. `format` attribute that specifies the quality criteria that the field should respect. The `format` attribute can contain multiple quality criteria separated by a colon (`;`). For example, `two-words; upper-case`.
-5. `on-fail-{quality-criteria}` attribute that specifies the corrective action to take in case the quality criteria is not met. For example, `on-fail-two-words="reask"` specifies that if the field does not have two words, the LLM should be asked to re-generate the field.
-
-
-E.g.,
-
-=== "RAIL Spec"
     ```xml
     <rail version="0.1">
-        <output>
-            <string
-                name="some_key"
-                description="Detailed description of what the value of the key should be"
-                required="true"
-                format="two-words; upper-case"
-                on-fail-two-words="reask"
-                on-fail-upper-case="noop" 
-            />
-        </output>
+        <output
+            type="string"
+            description="The generated text"
+            format="two-words"
+            on-fail-two-words="reask"
+        />
     </rail>
     ```
 
-=== "Output JSON"
-
-    ```json
-    {
-        "some_key": "SOME STRING"
-    }
+=== "Output String"
+    
+    ```
+    string output
     ```
 
 ## ⚡ Specifying output structure
@@ -222,6 +158,109 @@ In the above example, `"SOME STRING"` is the value for the `some_str_key` key, a
 
     Providing a child element is useful when you want to have more control over the values that the LLM should generate.
 
+### String output
+
+Generate simple strings by specifying `type="string"` in the `<output ... />` element.
+All the formatters supported by the `string` element can be used to specify the quality criteria for the generated string.
+
+=== "RAIL Spec"
+
+    ```xml
+    <rail version="0.1">
+        <output
+            type="string" 
+            format="two-words" 
+            on-fail-two-words="reask"
+        />
+    </rail>
+    ```
+
+=== "Output"
+    ```
+    string output
+    ```
+
+## 🏷️ `RAIL` Elements
+
+At the heart of the `RAIL` specification is the use of elements. Each element's tag represents a type of data. For example, in the element `<string ... />`, the tag represents a string, the `<integer ... />` elements represents an integer, the `<object ...></object>` element represents an object, etc.
+
+
+!!! note
+    The tag of RAIL element is the same as the "type" of the data it represents.
+
+    E.g. `<string .../>` element will generate a string, `<integer .../>` element will generate an integer, etc.
+
+### Supported types
+
+Guardrails supports many data types, including:, `string`, `integer`, `float`, `boolean`, `list`, `object`, `url`, `email` and many more.
+
+Check out the [RAIL Data Types](../data_types.md) page for a list of supported data types.
+
+
+#### Scalar vs Non-scalar types
+
+Guardrails supports two types of data types: scalar and non-scalar.
+
+
+| Scalar                                                                  | Non Scalar                                                                           |
+|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| Scalar types are void elements, and can't have any child elements.      | Non-scalar types can be non-void, and can have closing tags and child elements.                       |
+| Syntax:   ``` <string ... /> ```                                        | Syntax: <list ...>     <string /> </list>|
+| Examples: `string`, `integer`, `float`, `boolean`, `url`, `email`, etc. | Examples: `list` and `object` are the only non-scalar types supported by Guardrails. |
+
+
+### Supported attributes
+
+Each element can have attributes that specify additional information about the data, such as:
+
+1. `name` attribute that specifies the name of the field. This will be the key in the output JSON. E.g.
+
+    === "RAIL Spec"
+        ```xml
+        <rail version="0.1">
+            <output>
+                <string name="some_key" />
+            </output>
+        </rail>
+        ```
+    === "Output JSON"
+        ```json
+        {
+            "some_key": "..."
+        }
+        ```
+
+2. `description` attribute that specifies the description of the field. This is similar to a prompt that will be provided to the LLM. It can contain more context to help the LLM generate the correct output.
+3. (Coming soon!) `required` attribute that specifies whether the field is required or not. If the field is required, the LLM will be asked to generate the field until it is generated correctly. If the field is not required, the LLM will not be asked to generate the field if it is not generated correctly.
+4. `format` attribute that specifies the quality criteria that the field should respect. The `format` attribute can contain multiple quality criteria separated by a colon (`;`). For example, `two-words; upper-case`.
+5. `on-fail-{quality-criteria}` attribute that specifies the corrective action to take in case the quality criteria is not met. For example, `on-fail-two-words="reask"` specifies that if the field does not have two words, the LLM should be asked to re-generate the field.
+
+
+E.g.,
+
+=== "RAIL Spec"
+    ```xml
+    <rail version="0.1">
+        <output>
+            <string
+                name="some_key"
+                description="Detailed description of what the value of the key should be"
+                required="true"
+                format="two-words; upper-case"
+                on-fail-two-words="reask"
+                on-fail-upper-case="noop" 
+            />
+        </output>
+    </rail>
+    ```
+
+=== "Output JSON"
+
+    ```json
+    {
+        "some_key": "SOME STRING"
+    }
+    ```
 
 ## 🍀 Specifying quality criteria
 

--- a/docs/rail/output.md
+++ b/docs/rail/output.md
@@ -8,6 +8,7 @@ The `<output>...</output>` element of a `RAIL` spec is used to give precise spec
 4. the corrective action to take in case the quality criteria is not met (e.g. reask the question to the LLM, filter offending values, progrmatically fix, etc.)
 
 Example:
+<!-- TODO add formatting so that there's nesting between the spec and outputs for each output type -->
 
 === "JSON RAIL Spec"
 

--- a/guardrails/constants.xml
+++ b/guardrails/constants.xml
@@ -80,8 +80,8 @@ Given below is XML that describes the information to extract from this document 
 ONLY return a valid string answer (no other text is necessary), where the string is formatted according to the XML format. Be correct and concise.
 
 Here are examples of simple (XML, string) pairs that show the expected behavior:
-- `<![CDATA[<string name='foo' format='two-words lower-case' />`]]> => `{{{{'foo': 'example one'}}}}`
-- `<![CDATA[<string name='bar' format='upper-case' />]]>` => `{{{{'bar': 'STRING ONE'}}}}`
+- `<![CDATA[<string format='two-words lower-case' />`]]> => `{{{{'foo': 'example one'}}}}`
+- `<![CDATA[<string format='upper-case' />]]>` => `{{{{'bar': 'STRING ONE'}}}}`
 </complete_string_suffix>
 
 </constants>

--- a/guardrails/constants.xml
+++ b/guardrails/constants.xml
@@ -65,23 +65,18 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 </json_suffix_prompt_examples>
 
 <high_level_string_reask_prompt>
-I was given the following string, which had problems due to incorrect values.
+I was given the following string, delimited by +++:
 
++++
 {previous_response}
++++
 
-Help me correct the incorrect values based on the given error messages.
+It had the following problems:
+{error_messages}
 </high_level_string_reask_prompt>
 
 <complete_string_suffix>
-Given below is XML that describes the information to extract from this document and the tags to extract it into.
-
 {output_schema}
-
-ONLY return a valid string answer (no other text is necessary), where the string is formatted according to the XML format. Be correct and concise.
-
-Here are examples of simple (XML, string) pairs that show the expected behavior:
-- `<![CDATA[<output format='two-words lower-case' />`]]> => `{{{{'foo': 'example one'}}}}`
-- `<![CDATA[<output format='upper-case' />]]>` => `{{{{'bar': 'STRING ONE'}}}}`
 </complete_string_suffix>
 
 </constants>

--- a/guardrails/constants.xml
+++ b/guardrails/constants.xml
@@ -64,5 +64,24 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<![CDATA[<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>]]>` => `{{{{'baz': {{{{'foo': 'Some String', 'index': 1}}}}}}}}`
 </json_suffix_prompt_examples>
 
+<high_level_string_reask_prompt>
+I was given the following string, which had problems due to incorrect values.
+
+{previous_response}
+
+Help me correct the incorrect values based on the given error messages.
+</high_level_string_reask_prompt>
+
+<complete_string_suffix>
+Given below is XML that describes the information to extract from this document and the tags to extract it into.
+
+{output_schema}
+
+ONLY return a valid string answer (no other text is necessary), where the string is formatted according to the XML format. Be correct and concise.
+
+Here are examples of simple (XML, string) pairs that show the expected behavior:
+- `<![CDATA[<string name='foo' format='two-words lower-case' />`]]> => `{{{{'foo': 'example one'}}}}`
+- `<![CDATA[<string name='bar' format='upper-case' />]]>` => `{{{{'bar': 'STRING ONE'}}}}`
+</complete_string_suffix>
 
 </constants>

--- a/guardrails/constants.xml
+++ b/guardrails/constants.xml
@@ -80,8 +80,8 @@ Given below is XML that describes the information to extract from this document 
 ONLY return a valid string answer (no other text is necessary), where the string is formatted according to the XML format. Be correct and concise.
 
 Here are examples of simple (XML, string) pairs that show the expected behavior:
-- `<![CDATA[<string format='two-words lower-case' />`]]> => `{{{{'foo': 'example one'}}}}`
-- `<![CDATA[<string format='upper-case' />]]>` => `{{{{'bar': 'STRING ONE'}}}}`
+- `<![CDATA[<output format='two-words lower-case' />`]]> => `{{{{'foo': 'example one'}}}}`
+- `<![CDATA[<output format='upper-case' />]]>` => `{{{{'bar': 'STRING ONE'}}}}`
 </complete_string_suffix>
 
 </constants>

--- a/guardrails/constants.xml
+++ b/guardrails/constants.xml
@@ -20,16 +20,13 @@ ONLY return a valid JSON object (no other text is necessary). The JSON MUST conf
 ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise.
 </json_suffix_prompt_v2_wo_none>
 
-
-
-<high_level_reask_prompt>
+<high_level_json_reask_prompt>
 I was given the following JSON response, which had problems due to incorrect values.
 
 {previous_response}
 
 Help me correct the incorrect values based on the given error messages.
-</high_level_reask_prompt>
-
+</high_level_json_reask_prompt>
 
 <complete_json_suffix>
 Given below is XML that describes the information to extract from this document and the tags to extract it into.

--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -42,10 +42,10 @@ class DataType:
     def iter(
         self, element: ET._Element
     ) -> Generator[Tuple[str, "DataType", ET._Element], None, None]:
-        """
-        Iterate over the children of an element.
+        """Iterate over the children of an element.
 
-        Yields tuples of (name, child_data_type, child_element) for each child.
+        Yields tuples of (name, child_data_type, child_element) for each
+        child.
         """
         for el_child in element:
             if element.tag == "list":
@@ -175,8 +175,8 @@ class Boolean(ScalarType):
 class Date(ScalarType):
     """Element tag: `<date>`
 
-    To configure the date format, create a date-format attribute on the element.
-    E.g. `<date name="..." ... date-format="%Y-%m-%d" />`
+    To configure the date format, create a date-format attribute on the
+    element. E.g. `<date name="..." ... date-format="%Y-%m-%d" />`
     """
 
     def __init__(
@@ -206,8 +206,8 @@ class Date(ScalarType):
 class Time(ScalarType):
     """Element tag: `<time>`
 
-    To configure the date format, create a date-format attribute on the element.
-    E.g. `<time name="..." ... time-format="%H:%M:%S" />`
+    To configure the date format, create a date-format attribute on the
+    element. E.g. `<time name="..." ... time-format="%H:%M:%S" />`
     """
 
     def __init__(

--- a/guardrails/document_store.py
+++ b/guardrails/document_store.py
@@ -18,8 +18,9 @@ except ImportError:
 class Document:
     """Document holds text and metadata of a document.
 
-    Examples of documents are PDFs, Word documents, etc. A collection of related text
-    in an NLP application can be thought of a document as well.
+    Examples of documents are PDFs, Word documents, etc. A collection of
+    related text in an NLP application can be thought of a document as
+    well.
     """
 
     id: str
@@ -36,7 +37,8 @@ PageCoordinates = namedtuple("PageCoordinates", ["doc_id", "page_num"])
 class Page:
     """Page holds text and metadata of a page in a document.
 
-    It also containts the coordinates of the page in the document."""
+    It also containts the coordinates of the page in the document.
+    """
 
     cordinates: PageCoordinates
     text: str
@@ -44,8 +46,8 @@ class Page:
 
 
 class DocumentStoreBase(ABC):
-    """
-    Abstract class for a store that can store text, and metadata from documents.
+    """Abstract class for a store that can store text, and metadata from
+    documents.
 
     The store can be queried by text for similar documents.
     """
@@ -64,8 +66,7 @@ class DocumentStoreBase(ABC):
 
     @abstractmethod
     def search(self, query: str, k: int = 4) -> List[Page]:
-        """Searches for pages which contain the text similar to
-        the query.
+        """Searches for pages which contain the text similar to the query.
 
         Args:
             query: Text to search for.
@@ -106,10 +107,8 @@ class DocumentStoreBase(ABC):
 
 
 class EphemeralDocumentStore(DocumentStoreBase):
-    """
-    EphemeralDocumentStore is a document store that stores the documents on
-    local disk and use a ephemeral vector store like Faiss
-    """
+    """EphemeralDocumentStore is a document store that stores the documents on
+    local disk and use a ephemeral vector store like Faiss."""
 
     def __init__(self, vector_db: VectorDBBase, path: Optional[str] = None):
         """Creates a new EphemeralDocumentStore.

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -8,7 +8,7 @@ from guardrails.llm_providers import PromptCallable, get_llm_ask
 from guardrails.prompt import Instructions, Prompt
 from guardrails.rail import Rail
 from guardrails.run import Runner
-from guardrails.schema import InputSchema, OutputSchema
+from guardrails.schema import InputSchema, BaseOutputSchema
 from guardrails.utils.logs_utils import GuardState
 from guardrails.utils.reask_utils import sub_reasks_with_fixed_values
 
@@ -45,7 +45,7 @@ class Guard:
         return self.rail.input_schema
 
     @property
-    def output_schema(self) -> OutputSchema:
+    def output_schema(self) -> BaseOutputSchema:
         """Return the output schema."""
         return self.rail.output_schema
 

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -8,7 +8,7 @@ from guardrails.llm_providers import PromptCallable, get_llm_ask
 from guardrails.prompt import Instructions, Prompt
 from guardrails.rail import Rail
 from guardrails.run import Runner
-from guardrails.schema import InputSchema, BaseOutputSchema
+from guardrails.schema import BaseOutputSchema, InputSchema
 from guardrails.utils.logs_utils import GuardState
 from guardrails.utils.reask_utils import sub_reasks_with_fixed_values
 

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -8,7 +8,7 @@ from guardrails.llm_providers import PromptCallable, get_llm_ask
 from guardrails.prompt import Instructions, Prompt
 from guardrails.rail import Rail
 from guardrails.run import Runner
-from guardrails.schema import BaseOutputSchema, InputSchema
+from guardrails.schema import Schema, Schema
 from guardrails.utils.logs_utils import GuardState
 from guardrails.utils.reask_utils import sub_reasks_with_fixed_values
 
@@ -40,12 +40,12 @@ class Guard:
         self._reask_prompt = None
 
     @property
-    def input_schema(self) -> InputSchema:
+    def input_schema(self) -> Schema:
         """Return the input schema."""
         return self.rail.input_schema
 
     @property
-    def output_schema(self) -> BaseOutputSchema:
+    def output_schema(self) -> Schema:
         """Return the output schema."""
         return self.rail.output_schema
 

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -8,7 +8,7 @@ from guardrails.llm_providers import PromptCallable, get_llm_ask
 from guardrails.prompt import Instructions, Prompt
 from guardrails.rail import Rail
 from guardrails.run import Runner
-from guardrails.schema import Schema, Schema
+from guardrails.schema import Schema
 from guardrails.utils.logs_utils import GuardState
 from guardrails.utils.reask_utils import sub_reasks_with_fixed_values
 

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -68,7 +68,7 @@ def nonchat_prompt(prompt: str, instructions: Optional[str] = None, **kwargs) ->
     if instructions:
         prompt = "\n\n".join([instructions, prompt])
 
-    return prompt + "\n\nJson Output:\n\n"
+    return prompt
 
 
 def chat_prompt(
@@ -77,9 +77,7 @@ def chat_prompt(
     """Prepare final prompt for chat engine."""
     if not instructions:
         instructions = (
-            "You are a helpful assistant, "
-            "able to express yourself purely through JSON, "
-            "strictly and precisely adhering to the provided XML schemas."
+            "You are a helpful assistant."
         )
     return [
         {"role": "system", "content": instructions},

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -76,9 +76,7 @@ def chat_prompt(
 ) -> List[Dict[str, str]]:
     """Prepare final prompt for chat engine."""
     if not instructions:
-        instructions = (
-            "You are a helpful assistant."
-        )
+        instructions = "You are a helpful assistant."
     return [
         {"role": "system", "content": instructions},
         {"role": "user", "content": prompt},

--- a/guardrails/prompt/instructions.py
+++ b/guardrails/prompt/instructions.py
@@ -7,9 +7,9 @@ from .base_prompt import BasePrompt
 class Instructions(BasePrompt):
     """Instructions class.
 
-    The instructions are passed to the LLM as secondary input.
-    Different model may use these differently. For example, chat models may receive
-    instructions in the system-prompt.
+    The instructions are passed to the LLM as secondary input. Different
+    model may use these differently. For example, chat models may
+    receive instructions in the system-prompt.
     """
 
     def __repr__(self) -> str:

--- a/guardrails/rail.py
+++ b/guardrails/rail.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from lxml import etree as ET
 
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import InputSchema, BaseOutputSchema, Schema, JsonOutputSchema
+from guardrails.schema import InputSchema, BaseOutputSchema, Schema, JsonOutputSchema, StringOutputSchema
 
 # TODO: Logging
 XMLPARSER = ET.XMLParser(encoding="utf-8")
@@ -176,7 +176,9 @@ class Rail:
     @staticmethod
     def load_output_schema(root: ET._Element) -> BaseOutputSchema:
         """Given the RAIL <output> element, create a Schema object."""
-        # TODO if root is a single <string> element, return a StringOutputSchema
+        # if root is a single <string> element, return a StringOutputSchema
+        if len(root) == 1 and root[0].tag == "string":
+            return StringOutputSchema(root)
         return JsonOutputSchema(root)
 
     @staticmethod

--- a/guardrails/rail.py
+++ b/guardrails/rail.py
@@ -182,8 +182,8 @@ class Rail:
     @staticmethod
     def load_output_schema(root: ET._Element) -> Schema:
         """Given the RAIL <output> element, create a Schema object."""
-        # if root is a single <string> element, return a StringOutputSchema
-        if len(root) == 1 and root[0].tag == "string":
+        # If root contains a `type="string"` attribute, then it's a StringSchema
+        if "type" in root.attrib and root.attrib["type"] == "string":
             return StringSchema(root)
         return JsonSchema(root)
 

--- a/guardrails/rail.py
+++ b/guardrails/rail.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from lxml import etree as ET
 
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import InputSchema, OutputSchema, Schema
+from guardrails.schema import InputSchema, BaseOutputSchema, Schema, JsonOutputSchema
 
 # TODO: Logging
 XMLPARSER = ET.XMLParser(encoding="utf-8")
@@ -91,7 +91,7 @@ class Rail:
     """
 
     input_schema: Optional[InputSchema] = (None,)
-    output_schema: Optional[OutputSchema] = (None,)
+    output_schema: Optional[BaseOutputSchema] = (None,)
     instructions: Optional[Instructions] = (None,)
     prompt: Optional[Prompt] = (None,)
     script: Optional[Script] = (None,)
@@ -174,14 +174,14 @@ class Rail:
         return InputSchema(root)
 
     @staticmethod
-    def load_output_schema(root: ET._Element) -> OutputSchema:
+    def load_output_schema(root: ET._Element) -> BaseOutputSchema:
         """Given the RAIL <output> element, create a Schema object."""
-        # Recast the schema as an OutputSchema.
-        return OutputSchema(root)
+        # TODO if root is a single <string> element, return a StringOutputSchema
+        return JsonOutputSchema(root)
 
     @staticmethod
     def load_instructions(
-        root: ET._Element, output_schema: OutputSchema
+        root: ET._Element, output_schema: BaseOutputSchema
     ) -> Instructions:
         """Given the RAIL <instructions> element, create Instructions."""
         return Instructions(
@@ -190,7 +190,7 @@ class Rail:
         )
 
     @staticmethod
-    def load_prompt(root: ET._Element, output_schema: OutputSchema) -> Prompt:
+    def load_prompt(root: ET._Element, output_schema: BaseOutputSchema) -> Prompt:
         """Given the RAIL <prompt> element, create a Prompt object."""
         return Prompt(
             source=root.text,

--- a/guardrails/rail.py
+++ b/guardrails/rail.py
@@ -5,13 +5,7 @@ from typing import List, Optional
 from lxml import etree as ET
 
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import (
-    Schema,
-    Schema,
-    JsonSchema,
-    Schema,
-    StringSchema,
-)
+from guardrails.schema import JsonSchema, Schema, StringSchema
 
 # TODO: Logging
 XMLPARSER = ET.XMLParser(encoding="utf-8")
@@ -188,9 +182,7 @@ class Rail:
         return JsonSchema(root)
 
     @staticmethod
-    def load_instructions(
-        root: ET._Element, output_schema: Schema
-    ) -> Instructions:
+    def load_instructions(root: ET._Element, output_schema: Schema) -> Instructions:
         """Given the RAIL <instructions> element, create Instructions."""
         return Instructions(
             source=root.text,

--- a/guardrails/rail.py
+++ b/guardrails/rail.py
@@ -6,11 +6,11 @@ from lxml import etree as ET
 
 from guardrails.prompt import Instructions, Prompt
 from guardrails.schema import (
-    BaseOutputSchema,
-    InputSchema,
-    JsonOutputSchema,
     Schema,
-    StringOutputSchema,
+    Schema,
+    JsonSchema,
+    Schema,
+    StringSchema,
 )
 
 # TODO: Logging
@@ -96,8 +96,8 @@ class Rail:
         4. `<prompt>`, which contains the prompt to be passed to the LLM
     """
 
-    input_schema: Optional[InputSchema] = (None,)
-    output_schema: Optional[BaseOutputSchema] = (None,)
+    input_schema: Optional[Schema] = (None,)
+    output_schema: Optional[Schema] = (None,)
     instructions: Optional[Instructions] = (None,)
     prompt: Optional[Prompt] = (None,)
     script: Optional[Script] = (None,)
@@ -132,7 +132,7 @@ class Rail:
         raw_input_schema = xml.find("input")
         if raw_input_schema is None:
             # No input schema, so do no input checking.
-            input_schema = InputSchema()
+            input_schema = Schema()
         else:
             input_schema = cls.load_input_schema(raw_input_schema)
 
@@ -174,22 +174,22 @@ class Rail:
         return Schema(root)
 
     @staticmethod
-    def load_input_schema(root: ET._Element) -> InputSchema:
+    def load_input_schema(root: ET._Element) -> Schema:
         """Given the RAIL <input> element, create a Schema object."""
         # Recast the schema as an InputSchema.
-        return InputSchema(root)
+        return Schema(root)
 
     @staticmethod
-    def load_output_schema(root: ET._Element) -> BaseOutputSchema:
+    def load_output_schema(root: ET._Element) -> Schema:
         """Given the RAIL <output> element, create a Schema object."""
         # if root is a single <string> element, return a StringOutputSchema
         if len(root) == 1 and root[0].tag == "string":
-            return StringOutputSchema(root)
-        return JsonOutputSchema(root)
+            return StringSchema(root)
+        return JsonSchema(root)
 
     @staticmethod
     def load_instructions(
-        root: ET._Element, output_schema: BaseOutputSchema
+        root: ET._Element, output_schema: Schema
     ) -> Instructions:
         """Given the RAIL <instructions> element, create Instructions."""
         return Instructions(
@@ -198,7 +198,7 @@ class Rail:
         )
 
     @staticmethod
-    def load_prompt(root: ET._Element, output_schema: BaseOutputSchema) -> Prompt:
+    def load_prompt(root: ET._Element, output_schema: Schema) -> Prompt:
         """Given the RAIL <prompt> element, create a Prompt object."""
         return Prompt(
             source=root.text,

--- a/guardrails/rail.py
+++ b/guardrails/rail.py
@@ -5,7 +5,13 @@ from typing import List, Optional
 from lxml import etree as ET
 
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import InputSchema, BaseOutputSchema, Schema, JsonOutputSchema, StringOutputSchema
+from guardrails.schema import (
+    BaseOutputSchema,
+    InputSchema,
+    JsonOutputSchema,
+    Schema,
+    StringOutputSchema,
+)
 
 # TODO: Logging
 XMLPARSER = ET.XMLParser(encoding="utf-8")

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -6,7 +6,7 @@ from eliot import add_destinations, start_action
 
 from guardrails.llm_providers import PromptCallable
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import BaseOutputSchema, InputSchema
+from guardrails.schema import Schema, Schema
 from guardrails.utils.logs_utils import GuardHistory, GuardLogs
 from guardrails.utils.reask_utils import (
     ReAsk,
@@ -43,8 +43,8 @@ class Runner:
     instructions: Optional[Instructions]
     prompt: Prompt
     api: PromptCallable
-    input_schema: InputSchema
-    output_schema: BaseOutputSchema
+    input_schema: Schema
+    output_schema: Schema
     num_reasks: int = 0
     output: str = None
     reask_prompt: Optional[Prompt] = None
@@ -119,8 +119,8 @@ class Runner:
         instructions: Optional[Instructions],
         prompt: Prompt,
         prompt_params: Dict,
-        input_schema: InputSchema,
-        output_schema: BaseOutputSchema,
+        input_schema: Schema,
+        output_schema: Schema,
         output: str = None,
     ):
         """Run a full step."""
@@ -176,7 +176,7 @@ class Runner:
         instructions: Optional[Instructions],
         prompt: Prompt,
         prompt_params: Dict,
-        input_schema: InputSchema,
+        input_schema: Schema,
     ) -> Tuple[Instructions, Prompt]:
         """Prepare by running pre-processing and input validation."""
         with start_action(action_type="prepare", index=index) as action:
@@ -238,7 +238,7 @@ class Runner:
         self,
         index: int,
         output: str,
-        output_schema: BaseOutputSchema,
+        output_schema: Schema,
     ):
         with start_action(action_type="parse", index=index) as action:
             parsed_output, error = output_schema.parse(output)
@@ -255,7 +255,7 @@ class Runner:
         self,
         index: int,
         parsed_output: Any,
-        output_schema: BaseOutputSchema,
+        output_schema: Schema,
     ):
         """Validate the output."""
         with start_action(action_type="validate", index=index) as action:
@@ -272,7 +272,7 @@ class Runner:
         self,
         index: int,
         validated_output: Any,
-        output_schema: BaseOutputSchema,
+        output_schema: Schema,
     ) -> List[ReAsk]:
         """Introspect the validated output."""
         with start_action(action_type="introspect", index=index) as action:
@@ -318,8 +318,8 @@ class Runner:
         self,
         reasks: list,
         validated_output: Optional[Dict],
-        output_schema: BaseOutputSchema,
-    ) -> Tuple[Prompt, BaseOutputSchema]:
+        output_schema: Schema,
+    ) -> Tuple[Prompt, Schema]:
         """Prepare to loop again."""
         output_schema = output_schema.get_reask_schema(
             reasks=reasks,

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -6,7 +6,7 @@ from eliot import add_destinations, start_action
 
 from guardrails.llm_providers import PromptCallable
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import Schema, JsonSchema
+from guardrails.schema import JsonSchema, Schema
 from guardrails.utils.logs_utils import GuardHistory, GuardLogs
 from guardrails.utils.reask_utils import (
     ReAsk,
@@ -136,7 +136,12 @@ class Runner:
             # Prepare: run pre-processing, and input validation.
             if not output:
                 instructions, prompt = self.prepare(
-                    index, instructions, prompt, prompt_params, input_schema, output_schema
+                    index,
+                    instructions,
+                    prompt,
+                    prompt_params,
+                    input_schema,
+                    output_schema,
                 )
             else:
                 instructions = None

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -328,7 +328,7 @@ class Runner:
             reasks=reasks,
         )
         prompt = output_schema.get_reask_prompt(
-            reask_json=prune_obj_for_reasking(validated_output),
+            reask_value=prune_obj_for_reasking(validated_output),
             reask_prompt_template=self.reask_prompt,
         )
         return prompt, output_schema

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -6,7 +6,7 @@ from eliot import add_destinations, start_action
 
 from guardrails.llm_providers import PromptCallable
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import JsonSchema, Schema
+from guardrails.schema import Schema
 from guardrails.utils.logs_utils import GuardHistory, GuardLogs
 from guardrails.utils.reask_utils import (
     ReAsk,
@@ -115,7 +115,7 @@ class Runner:
     def step(
         self,
         index: int,
-        api: Callable,
+        api: PromptCallable,
         instructions: Optional[Instructions],
         prompt: Prompt,
         prompt_params: Dict,
@@ -140,6 +140,7 @@ class Runner:
                     instructions,
                     prompt,
                     prompt_params,
+                    api,
                     input_schema,
                     output_schema,
                 )
@@ -181,6 +182,7 @@ class Runner:
         instructions: Optional[Instructions],
         prompt: Prompt,
         prompt_params: Dict,
+        api: PromptCallable,
         input_schema: Schema,
         output_schema: Schema,
     ) -> Tuple[Instructions, Prompt]:
@@ -203,7 +205,9 @@ class Runner:
             if instructions is not None and isinstance(instructions, Instructions):
                 instructions = instructions.format(**validated_prompt_params)
 
-            instructions, prompt = output_schema.preprocess_prompt(instructions, prompt)
+            instructions, prompt = output_schema.preprocess_prompt(
+                api, instructions, prompt
+            )
 
             action.log(
                 message_type="info",

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -183,10 +183,10 @@ class Runner:
             if prompt_params is None:
                 prompt_params = {}
 
-            if input_schema:
-                validated_prompt_params = input_schema.validate(prompt_params)
-            else:
-                validated_prompt_params = prompt_params
+            # if input_schema:
+            #     validated_prompt_params = input_schema.validate(prompt_params)
+            # else:
+            validated_prompt_params = prompt_params
 
             if isinstance(prompt, str):
                 prompt = Prompt(prompt)

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -6,7 +6,7 @@ from eliot import add_destinations, start_action
 
 from guardrails.llm_providers import PromptCallable
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import Schema
+from guardrails.schema import Schema, JsonSchema
 from guardrails.utils.logs_utils import GuardHistory, GuardLogs
 from guardrails.utils.reask_utils import (
     ReAsk,
@@ -136,7 +136,7 @@ class Runner:
             # Prepare: run pre-processing, and input validation.
             if not output:
                 instructions, prompt = self.prepare(
-                    index, instructions, prompt, prompt_params, input_schema
+                    index, instructions, prompt, prompt_params, input_schema, output_schema
                 )
             else:
                 instructions = None
@@ -177,6 +177,7 @@ class Runner:
         prompt: Prompt,
         prompt_params: Dict,
         input_schema: Schema,
+        output_schema: Schema,
     ) -> Tuple[Instructions, Prompt]:
         """Prepare by running pre-processing and input validation."""
         with start_action(action_type="prepare", index=index) as action:
@@ -196,6 +197,8 @@ class Runner:
             # TODO(shreya): should there be any difference to parsing params for prompt?
             if instructions is not None and isinstance(instructions, Instructions):
                 instructions = instructions.format(**validated_prompt_params)
+
+            instructions, prompt = output_schema.preprocess_prompt(instructions, prompt)
 
             action.log(
                 message_type="info",

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -6,7 +6,7 @@ from eliot import add_destinations, start_action
 
 from guardrails.llm_providers import PromptCallable
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import Schema, Schema
+from guardrails.schema import Schema
 from guardrails.utils.logs_utils import GuardHistory, GuardLogs
 from guardrails.utils.reask_utils import (
     ReAsk,

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -1,18 +1,18 @@
-import json
 import logging
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional, Tuple, Any
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from eliot import add_destinations, start_action
 
 from guardrails.llm_providers import PromptCallable
 from guardrails.prompt import Instructions, Prompt
-from guardrails.schema import InputSchema, BaseOutputSchema
+from guardrails.schema import BaseOutputSchema, InputSchema
 from guardrails.utils.logs_utils import GuardHistory, GuardLogs
 from guardrails.utils.reask_utils import (
     ReAsk,
     prune_obj_for_reasking,
-    sub_reasks_with_fixed_values, reasks_to_dict,
+    reasks_to_dict,
+    sub_reasks_with_fixed_values,
 )
 
 logger = logging.getLogger(__name__)

--- a/guardrails/schema.py
+++ b/guardrails/schema.py
@@ -319,14 +319,6 @@ class Schema:
         """
         raise NotImplementedError
 
-
-class InputSchema(Schema):
-    """Input schema class that holds a _schema attribute."""
-
-
-class BaseOutputSchema(Schema):
-    """Output schema class that holds a _schema attribute."""
-
     def transpile(self, method: str = "default") -> str:
         """Convert the XML schema to a string that is used for prompting a
         large language model.
@@ -340,7 +332,7 @@ class BaseOutputSchema(Schema):
     def get_reask_schema(
         self,
         reasks: List[ReAsk],
-    ) -> "BaseOutputSchema":
+    ) -> "Schema":
         """Construct a schema for reasking.
 
         Args:
@@ -415,11 +407,11 @@ class BaseOutputSchema(Schema):
         )
 
 
-class JsonOutputSchema(BaseOutputSchema):
+class JsonSchema(Schema):
     def get_reask_schema(
         self,
         reasks: List[ReAsk],
-    ) -> "BaseOutputSchema":
+    ) -> "Schema":
         parsed_rail = deepcopy(self.root)
 
         # Get the elements that are to be reasked
@@ -518,7 +510,7 @@ class JsonOutputSchema(BaseOutputSchema):
         return gather_reasks(data)
 
 
-class StringOutputSchema(BaseOutputSchema):
+class StringSchema(Schema):
     def __init__(self, root: ET._Element) -> None:
         self.string_key = "string"
         super().__init__(root)
@@ -543,7 +535,7 @@ class StringOutputSchema(BaseOutputSchema):
     def get_reask_schema(
         self,
         reasks: List[ReAsk],
-    ) -> "BaseOutputSchema":
+    ) -> "Schema":
         return self
 
     def get_default_reask_prompt(self):

--- a/guardrails/schema.py
+++ b/guardrails/schema.py
@@ -12,7 +12,7 @@ from lxml import etree as ET
 from lxml.builder import E
 
 from guardrails.datatypes import DataType, String
-from guardrails.prompt import Prompt, Instructions
+from guardrails.prompt import Instructions, Prompt
 from guardrails.utils.constants import constants
 from guardrails.utils.reask_utils import (
     ReAsk,
@@ -391,8 +391,8 @@ class Schema:
         raise NotImplementedError
 
     def preprocess_prompt(self, instructions: Instructions, prompt: Prompt):
-        """
-        Preprocess the instructions and prompt before sending it to the model.
+        """Preprocess the instructions and prompt before sending it to the
+        model.
 
         Args:
             instructions: The instructions to preprocess.
@@ -657,7 +657,9 @@ class StringSchema(Schema):
 {obj.element.attrib["description"]}
 +++"""
         if not obj.format_attr.empty:
-            schema += "\n\nYour generated response should satisfy the following properties:"
+            schema += (
+                "\n\nYour generated response should satisfy the following properties:"
+            )
             for validator in obj.format_attr.validators:
                 schema += f"\n- {validator.to_prompt()}"
         return schema

--- a/guardrails/schema.py
+++ b/guardrails/schema.py
@@ -516,21 +516,17 @@ class StringSchema(Schema):
         super().__init__(root)
 
     def parse_spec(self, root: ET._Element) -> None:
-        if len(root) != 1:
-            raise ValueError("String output schemas must have exactly one child.")
+        if len(root) != 0:
+            raise ValueError("String output schemas must not have children.")
 
-        child = root[0]
-        if child.tag != "string":
-            raise ValueError(
-                "String output schemas must have exactly one child of type `string`."
-            )
-
-        if "name" in child.attrib:
-            self.string_key = child.attrib["name"]
+        if "name" in root.attrib:
+            self.string_key = root.attrib["name"]
         else:
-            self.string_key = child.attrib["name"] = "string"
+            self.string_key = root.attrib["name"] = "string"
 
-        self[self.string_key] = String.from_xml(root[0])
+        # make root tag into a string tag
+        root_string = ET.Element("string", root.attrib)
+        self[self.string_key] = String.from_xml(root_string)
 
     def get_reask_schema(
         self,
@@ -563,7 +559,7 @@ class StringSchema(Schema):
             return None
 
         if not isinstance(data, str):
-            raise TypeError(f"Argument `data` must be a dictionary, not {type(data)}.")
+            raise TypeError(f"Argument `data` must be a string, not {type(data)}.")
 
         validated_response = self[self.string_key].validate(
             key=self.string_key,

--- a/guardrails/schema.py
+++ b/guardrails/schema.py
@@ -265,7 +265,7 @@ class Schema:
         self.root = root
 
         if root is not None:
-            self.parse_spec(root)
+            self.setup_schema(root)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({pprint.pformat(vars(self._schema))})"
@@ -300,7 +300,7 @@ class Schema:
     def parsed_rail(self) -> Optional[ET._Element]:
         return self.root
 
-    def parse_spec(self, root: ET._Element) -> None:
+    def setup_schema(self, root: ET._Element) -> None:
         """Parse the schema specification.
 
         Args:
@@ -423,7 +423,7 @@ class JsonSchema(Schema):
 
         return pruned_tree_schema
 
-    def parse_spec(self, root: ET._Element) -> None:
+    def setup_schema(self, root: ET._Element) -> None:
         from guardrails.datatypes import registry as types_registry
 
         strict = False
@@ -515,7 +515,7 @@ class StringSchema(Schema):
         self.string_key = "string"
         super().__init__(root)
 
-    def parse_spec(self, root: ET._Element) -> None:
+    def setup_schema(self, root: ET._Element) -> None:
         if len(root) != 0:
             raise ValueError("String output schemas must not have children.")
 

--- a/guardrails/utils/logs_utils.py
+++ b/guardrails/utils/logs_utils.py
@@ -144,6 +144,9 @@ def merge_reask_output(prev_logs: GuardLogs, current_logs: GuardLogs) -> Dict:
     pruned_reask_json = prune_obj_for_reasking(previous_response)
     reask_response = current_logs.validated_output
 
+    if isinstance(pruned_reask_json, ReAsk):
+        return reask_response
+
     # Reask output and reask json have the same structure, except that values
     # of the reask json are ReAsk objects. We want to replace the ReAsk objects
     # with the values from the reask output.

--- a/guardrails/utils/logs_utils.py
+++ b/guardrails/utils/logs_utils.py
@@ -141,11 +141,11 @@ def merge_reask_output(prev_logs: GuardLogs, current_logs: GuardLogs) -> Dict:
     from guardrails.validators import PydanticReAsk
 
     previous_response = prev_logs.validated_output
-    pruned_reask_json = prune_obj_for_reasking(previous_response)
     reask_response = current_logs.validated_output
-
-    if isinstance(pruned_reask_json, ReAsk):
+    if isinstance(previous_response, ReAsk):
         return reask_response
+
+    pruned_reask_json = prune_obj_for_reasking(previous_response)
 
     # Reask output and reask json have the same structure, except that values
     # of the reask json are ReAsk objects. We want to replace the ReAsk objects

--- a/guardrails/utils/logs_utils.py
+++ b/guardrails/utils/logs_utils.py
@@ -8,7 +8,7 @@ from rich.pretty import pretty_repr
 from rich.tree import Tree
 
 from guardrails.prompt import Prompt
-from guardrails.utils.reask_utils import ReAsk, gather_reasks, prune_json_for_reasking
+from guardrails.utils.reask_utils import ReAsk, gather_reasks, prune_obj_for_reasking
 
 
 @dataclass
@@ -16,7 +16,7 @@ class GuardLogs:
     prompt: Prompt
     instructions: Optional[str]
     output: str
-    output_as_dict: dict
+    parsed_output: dict
     validated_output: dict
     reasks: List[ReAsk]
 
@@ -92,7 +92,7 @@ class GuardHistory:
     @property
     def output_as_dict(self) -> dict:
         """Returns the latest output as a dict."""
-        return self.history[-1].output_as_dict
+        return self.history[-1].parsed_output
 
     @property
     def failed_validations(self) -> List[ReAsk]:
@@ -141,7 +141,7 @@ def merge_reask_output(prev_logs: GuardLogs, current_logs: GuardLogs) -> Dict:
     from guardrails.validators import PydanticReAsk
 
     previous_response = prev_logs.validated_output
-    pruned_reask_json = prune_json_for_reasking(previous_response)
+    pruned_reask_json = prune_obj_for_reasking(previous_response)
     reask_response = current_logs.validated_output
 
     # Reask output and reask json have the same structure, except that values

--- a/guardrails/utils/reask_utils.py
+++ b/guardrails/utils/reask_utils.py
@@ -139,45 +139,44 @@ def get_pruned_tree(
     return root
 
 
-def prune_json_for_reasking(json_object: Any) -> Union[None, Dict, List]:
-    """Validated JSON is a nested dictionary where some keys may be ReAsk
-    objects.
+def prune_obj_for_reasking(obj: Any) -> Union[None, Dict, List]:
+    """After validation, we get a nested dictionary where some keys may be ReAsk objects.
 
-    This function prunes the validated JSON of any object that is not a ReAsk object.
+    This function prunes the validated form of any object that is not a ReAsk object.
     It also keeps all of the ancestors of the ReAsk objects.
 
     Args:
-        json_object: The validated JSON.
+        obj: The validated object.
 
     Returns:
-        The pruned validated JSON.
+        The pruned validated object.
     """
     from guardrails.validators import PydanticReAsk
 
-    if isinstance(json_object, ReAsk) or isinstance(json_object, PydanticReAsk):
-        return json_object
-    elif isinstance(json_object, list):
+    if isinstance(obj, ReAsk) or isinstance(obj, PydanticReAsk):
+        return obj
+    elif isinstance(obj, list):
         pruned_list = []
-        for item in json_object:
-            pruned_output = prune_json_for_reasking(item)
+        for item in obj:
+            pruned_output = prune_obj_for_reasking(item)
             if pruned_output is not None:
                 pruned_list.append(pruned_output)
         if len(pruned_list):
             return pruned_list
         return None
-    elif isinstance(json_object, dict):
+    elif isinstance(obj, dict):
         pruned_json = {}
-        for key, value in json_object.items():
+        for key, value in obj.items():
             if isinstance(value, ReAsk) or isinstance(value, PydanticReAsk):
                 pruned_json[key] = value
             elif isinstance(value, dict):
-                pruned_output = prune_json_for_reasking(value)
+                pruned_output = prune_obj_for_reasking(value)
                 if pruned_output is not None:
                     pruned_json[key] = pruned_output
             elif isinstance(value, list):
                 pruned_list = []
                 for item in value:
-                    pruned_output = prune_json_for_reasking(item)
+                    pruned_output = prune_obj_for_reasking(item)
                     if pruned_output is not None:
                         pruned_list.append(pruned_output)
                 if len(pruned_list):
@@ -189,70 +188,22 @@ def prune_json_for_reasking(json_object: Any) -> Union[None, Dict, List]:
         return None
 
 
-def get_reask_prompt(
-    parsed_rail: ET._Element,
-    reasks: List[ReAsk],
-    reask_json: Dict,
-    reask_prompt_template: Optional[Prompt] = None,
-) -> Tuple[Prompt, ET._Element]:
-    """Construct a prompt for reasking.
+def reasks_to_dict(dict_with_reasks: Dict) -> Dict:
+    """If a ReAsk object exists in the dict, return it as a dictionary."""
 
-    Args:
-        parsed_rail: The parsed RAIL.
-        reasks: List of tuples, where each tuple contains the path to the
-            reasked element, and the ReAsk object (which contains the error
-            message describing why the reask is necessary).
-        reask_json: Pruned JSON that contains only ReAsk objects.
-
-    Returns:
-        The prompt.
-    """
-    from guardrails.schema import OutputSchema
-
-    parsed_rail_copy = deepcopy(parsed_rail)
-
-    # Get the elements that are to be reasked
-    reask_elements = get_reasks_by_element(reasks, parsed_rail_copy)
-
-    # Get the pruned JSON so that it only contains ReAsk objects
-    # Get the pruned tree
-    pruned_tree = get_pruned_tree(parsed_rail_copy, list(reask_elements.keys()))
-    pruned_tree_string = OutputSchema(pruned_tree).transpile()
-
-    if reask_prompt_template is None:
-        reask_prompt_template = Prompt(
-            constants["high_level_reask_prompt"] + constants["complete_json_suffix"]
-        )
-
-    def reask_decoder(obj):
-        return {k: v for k, v in obj.__dict__.items() if k not in ["path", "fix_value"]}
-
-    reask_prompt = reask_prompt_template.format(
-        previous_response=json.dumps(reask_json, indent=2, default=reask_decoder)
-        .replace("{", "{{")
-        .replace("}", "}}"),
-        output_schema=pruned_tree_string,
-    )
-
-    return reask_prompt, pruned_tree
-
-
-def reask_json_as_dict(json: Dict) -> Dict:
-    """If a ReAsk object exists in the JSON, return it as a dictionary."""
-
-    def _reask_json_as_dict(json_object: Any) -> Any:
-        if isinstance(json_object, dict):
+    def _(dict_object: Any) -> Any:
+        if isinstance(dict_object, dict):
             return {
-                key: _reask_json_as_dict(value) for key, value in json_object.items()
+                key: _(value) for key, value in dict_object.items()
             }
-        elif isinstance(json_object, list):
-            return [_reask_json_as_dict(item) for item in json_object]
-        elif isinstance(json_object, ReAsk):
-            return json_object.__dict__
+        elif isinstance(dict_object, list):
+            return [_(item) for item in dict_object]
+        elif isinstance(dict_object, ReAsk):
+            return dict_object.__dict__
         else:
-            return json_object
+            return dict_object
 
-    return _reask_json_as_dict(json)
+    return _(dict_with_reasks)
 
 
 def sub_reasks_with_fixed_values(value: Any) -> Any:

--- a/guardrails/utils/reask_utils.py
+++ b/guardrails/utils/reask_utils.py
@@ -1,13 +1,8 @@
-import json
 from collections import defaultdict
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Union
 
 from lxml import etree as ET
-
-from guardrails.prompt import Prompt
-from guardrails.utils.constants import constants
 
 
 @dataclass
@@ -140,7 +135,8 @@ def get_pruned_tree(
 
 
 def prune_obj_for_reasking(obj: Any) -> Union[None, Dict, List]:
-    """After validation, we get a nested dictionary where some keys may be ReAsk objects.
+    """After validation, we get a nested dictionary where some keys may be
+    ReAsk objects.
 
     This function prunes the validated form of any object that is not a ReAsk object.
     It also keeps all of the ancestors of the ReAsk objects.
@@ -193,9 +189,7 @@ def reasks_to_dict(dict_with_reasks: Dict) -> Dict:
 
     def _(dict_object: Any) -> Any:
         if isinstance(dict_object, dict):
-            return {
-                key: _(value) for key, value in dict_object.items()
-            }
+            return {key: _(value) for key, value in dict_object.items()}
         elif isinstance(dict_object, list):
             return [_(item) for item in dict_object]
         elif isinstance(dict_object, ReAsk):

--- a/guardrails/utils/sql_utils.py
+++ b/guardrails/utils/sql_utils.py
@@ -14,9 +14,9 @@ except ImportError:
 
 
 class SQLDriver(ABC):
-    """
-    Abstract class for SQL drivers. The expose common functionality
-    for validating SQL queries.
+    """Abstract class for SQL drivers.
+
+    The expose common functionality for validating SQL queries.
     """
 
     @abstractmethod
@@ -29,8 +29,8 @@ class SQLDriver(ABC):
 
 
 class SimpleSqlDriver(SQLDriver):
-    """
-    Simple SQL driver which uses sqlvalidator to validate SQL queries.
+    """Simple SQL driver which uses sqlvalidator to validate SQL queries.
+
     Does not understands dialects and is not connected to a database.
     """
 
@@ -47,8 +47,8 @@ class SimpleSqlDriver(SQLDriver):
 
 
 class SqlAlchemyDriver(SQLDriver):
-    """
-    SQL driver which uses sqlalchemy to validate SQL queries.
+    """SQL driver which uses sqlalchemy to validate SQL queries.
+
     It can setup the database schema and check if the queries are valid
     by connecting to the database.
     """

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -1122,7 +1122,8 @@ class ExtractedSummarySentencesMatch(Validator):
 
 @register_validator(name="reading-time", data_type="string")
 class ReadingTime(Validator):
-    """Validate that the a string can be read in less than a certain amount of time."""
+    """Validate that the a string can be read in less than a certain amount of
+    time."""
 
     def __init__(self, reading_time: int, on_fail: str = "fix"):
         super().__init__(on_fail=on_fail, max_time=reading_time)
@@ -1152,13 +1153,15 @@ class ReadingTime(Validator):
 
 @register_validator(name="extractive-summary", data_type="string")
 class ExtractiveSummary(Validator):
-    """Validate that a string is a valid extractive summary of a given document.
+    """Validate that a string is a valid extractive summary of a given
+    document.
 
-    This validator does a fuzzy match between the sentences in the summary and the
-    sentences in the document. Each sentence in the summary must be similar to at
-    least one sentence in the document. After the validation, the summary is updated
-    to include the sentences from the document that were matched, and the citations
-    for those sentences are added to the end of the summary.
+    This validator does a fuzzy match between the sentences in the
+    summary and the sentences in the document. Each sentence in the
+    summary must be similar to at least one sentence in the document.
+    After the validation, the summary is updated to include the
+    sentences from the document that were matched, and the citations for
+    those sentences are added to the end of the summary.
     """
 
     def __init__(
@@ -1244,8 +1247,9 @@ class ExtractiveSummary(Validator):
 class RemoveRedundantSentences(Validator):
     """Remove redundant sentences from a string.
 
-    This validator removes sentences from a string that are similar to other sentences
-    in the string. This is useful for removing repetitive sentences from a string.
+    This validator removes sentences from a string that are similar to
+    other sentences in the string. This is useful for removing
+    repetitive sentences from a string.
     """
 
     def __init__(
@@ -1307,7 +1311,8 @@ class RemoveRedundantSentences(Validator):
 
 @register_validator(name="saliency-check", data_type="string")
 class SaliencyCheck(Validator):
-    """Check that the summary covers the list of topics present in the document."""
+    """Check that the summary covers the list of topics present in the
+    document."""
 
     def __init__(
         self,

--- a/guardrails/vectordb/base.py
+++ b/guardrails/vectordb/base.py
@@ -10,6 +10,7 @@ class VectorDBBase(ABC):
 
     def __init__(self, embedder: EmbeddingBase, path: str = None) -> None:
         """Creates a new VectorDBBase.
+
         Args:
             embedder: EmbeddingBase instance to use for embedding the text.
             path: Path to store or load the vector database.
@@ -20,6 +21,7 @@ class VectorDBBase(ABC):
     @abstractmethod
     def add_vectors(self, vectors: List[List[float]]) -> None:
         """Adds a list of vectors to the store.
+
         Args:
             vectors: List of vectors to add.
         Returns:
@@ -30,6 +32,7 @@ class VectorDBBase(ABC):
     @abstractmethod
     def similarity_search_vector(self, vector: List[float], k: int) -> List[int]:
         """Searches for vectors which are similar to the given vector.
+
         Args:
             vector: Vector to search for.
             k: Number of similar vectors to return.

--- a/tests/integration_tests/mock_llm_outputs.py
+++ b/tests/integration_tests/mock_llm_outputs.py
@@ -16,6 +16,7 @@ def openai_completion_create(prompt, *args, **kwargs):
     try:
         return mock_llm_responses[prompt]
     except KeyError:
+        print(prompt)
         raise ValueError("Compiled prompt not found")
 
 

--- a/tests/integration_tests/mock_llm_outputs.py
+++ b/tests/integration_tests/mock_llm_outputs.py
@@ -10,6 +10,7 @@ def openai_completion_create(prompt, *args, **kwargs):
         pydantic.COMPILED_PROMPT_REASK_1: pydantic.LLM_OUTPUT_REASK_1,
         pydantic.COMPILED_PROMPT_REASK_2: pydantic.LLM_OUTPUT_REASK_2,
         string.COMPILED_PROMPT: string.LLM_OUTPUT,
+        string.COMPILED_PROMPT_REASK: string.LLM_OUTPUT_REASK,
     }
 
     try:

--- a/tests/integration_tests/mock_llm_outputs.py
+++ b/tests/integration_tests/mock_llm_outputs.py
@@ -1,4 +1,4 @@
-from .test_assets import entity_extraction, pydantic
+from .test_assets import entity_extraction, pydantic, string
 
 
 def openai_completion_create(prompt, *args, **kwargs):
@@ -9,6 +9,7 @@ def openai_completion_create(prompt, *args, **kwargs):
         pydantic.COMPILED_PROMPT: pydantic.LLM_OUTPUT,
         pydantic.COMPILED_PROMPT_REASK_1: pydantic.LLM_OUTPUT_REASK_1,
         pydantic.COMPILED_PROMPT_REASK_2: pydantic.LLM_OUTPUT_REASK_2,
+        string.COMPILED_PROMPT: string.LLM_OUTPUT,
     }
 
     try:

--- a/tests/integration_tests/test_assets/string/__init__.py
+++ b/tests/integration_tests/test_assets/string/__init__.py
@@ -9,7 +9,4 @@ COMPILED_PROMPT = reader("compiled_prompt.txt")
 LLM_OUTPUT = reader("llm_output.txt")
 RAIL_SPEC_FOR_STRING = reader("string.rail")
 
-__all__ = [
-    "COMPILED_PROMPT",
-    "RAIL_SPEC_FOR_STRING"
-]
+__all__ = ["COMPILED_PROMPT", "RAIL_SPEC_FOR_STRING"]

--- a/tests/integration_tests/test_assets/string/__init__.py
+++ b/tests/integration_tests/test_assets/string/__init__.py
@@ -8,6 +8,7 @@ reader = (
     lambda filename: open(os.path.join(DATA_DIR, filename)).read().replace("\r", "")
 )
 
+COMPILED_INSTRUCTIONS = reader("compiled_instructions.txt")
 COMPILED_PROMPT = reader("compiled_prompt.txt")
 LLM_OUTPUT = reader("llm_output.txt")
 RAIL_SPEC_FOR_STRING = reader("string.rail")

--- a/tests/integration_tests/test_assets/string/__init__.py
+++ b/tests/integration_tests/test_assets/string/__init__.py
@@ -1,0 +1,15 @@
+import os
+
+DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)))
+reader = (
+    lambda filename: open(os.path.join(DATA_DIR, filename)).read().replace("\r", "")
+)
+
+COMPILED_PROMPT = reader("compiled_prompt.txt")
+LLM_OUTPUT = reader("llm_output.txt")
+RAIL_SPEC_FOR_STRING = reader("string.rail")
+
+__all__ = [
+    "COMPILED_PROMPT",
+    "RAIL_SPEC_FOR_STRING"
+]

--- a/tests/integration_tests/test_assets/string/__init__.py
+++ b/tests/integration_tests/test_assets/string/__init__.py
@@ -1,6 +1,7 @@
+# flake8: noqa: E501
 import os
 
-from tests.integration_tests.test_assets.string.validated_output_reask import VALIDATED_OUTPUT_REASK
+from .validated_output_reask import VALIDATED_OUTPUT_REASK
 
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)))
 reader = (

--- a/tests/integration_tests/test_assets/string/__init__.py
+++ b/tests/integration_tests/test_assets/string/__init__.py
@@ -1,5 +1,7 @@
 import os
 
+from tests.integration_tests.test_assets.string.validated_output_reask import VALIDATED_OUTPUT_REASK
+
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)))
 reader = (
     lambda filename: open(os.path.join(DATA_DIR, filename)).read().replace("\r", "")
@@ -9,4 +11,16 @@ COMPILED_PROMPT = reader("compiled_prompt.txt")
 LLM_OUTPUT = reader("llm_output.txt")
 RAIL_SPEC_FOR_STRING = reader("string.rail")
 
-__all__ = ["COMPILED_PROMPT", "RAIL_SPEC_FOR_STRING"]
+COMPILED_PROMPT_REASK = reader("compiled_prompt_reask.txt")
+RAIL_SPEC_FOR_STRING_REASK = reader("string_reask.rail")
+LLM_OUTPUT_REASK = reader("llm_output_reask.txt")
+
+__all__ = [
+    "COMPILED_PROMPT",
+    "LLM_OUTPUT",
+    "RAIL_SPEC_FOR_STRING",
+    "COMPILED_PROMPT_REASK",
+    "RAIL_SPEC_FOR_STRING_REASK",
+    "LLM_OUTPUT_REASK",
+    "VALIDATED_OUTPUT_REASK",
+]

--- a/tests/integration_tests/test_assets/string/compiled_instructions.txt
+++ b/tests/integration_tests/test_assets/string/compiled_instructions.txt
@@ -1,0 +1,13 @@
+
+You are a helpful assistant, and you are helping me come up with a name for a pizza.
+
+
+String description, delimited by +++:
+
++++
+Name for the pizza
++++
+
+Your generated response should satisfy the following properties:
+- two-words
+

--- a/tests/integration_tests/test_assets/string/compiled_prompt.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt.txt
@@ -2,3 +2,7 @@
 Given the following ingredients, what would you call this pizza?
 
 tomato, cheese, sour cream
+
+
+String Output:
+

--- a/tests/integration_tests/test_assets/string/compiled_prompt.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt.txt
@@ -2,7 +2,3 @@
 Given the following ingredients, what would you call this pizza?
 
 tomato, cheese, sour cream
-
-
-String Output:
-

--- a/tests/integration_tests/test_assets/string/compiled_prompt.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt.txt
@@ -1,0 +1,4 @@
+
+Given the following ingredients, what would you call this pizza?
+
+tomato, cheese, sour cream

--- a/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
@@ -16,7 +16,3 @@ Name for the pizza
 
 Your generated response should satisfy the following properties:
 - two-words
-
-
-String Output:
-

--- a/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
@@ -16,5 +16,5 @@ Given below is XML that describes the information to extract from this document 
 ONLY return a valid string answer (no other text is necessary), where the string is formatted according to the XML format. Be correct and concise.
 
 Here are examples of simple (XML, string) pairs that show the expected behavior:
-- `<string format='two-words lower-case' />` => `{'foo': 'example one'}`
-- `<string format='upper-case' />` => `{'bar': 'STRING ONE'}`
+- `<output format='two-words lower-case' />` => `{'foo': 'example one'}`
+- `<output format='upper-case' />` => `{'bar': 'STRING ONE'}`

--- a/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
@@ -1,0 +1,22 @@
+
+I was given the following string, which had problems due to incorrect values.
+
+{
+  "incorrect_value": "sour cream tomata",
+  "error_message": "must be exactly two words"
+}
+
+Help me correct the incorrect values based on the given error messages.
+
+Given below is XML that describes the information to extract from this document and the tags to extract it into.
+
+<output>
+    <string description="Name for the pizza" format="two-words" name="string"/>
+</output>
+
+
+ONLY return a valid string answer (no other text is necessary), where the string is formatted according to the XML format. Be correct and concise.
+
+Here are examples of simple (XML, string) pairs that show the expected behavior:
+- `<string format='two-words lower-case' />` => `{'foo': 'example one'}`
+- `<string format='upper-case' />` => `{'bar': 'STRING ONE'}`

--- a/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
@@ -1,20 +1,22 @@
 
-I was given the following string, which had problems due to incorrect values.
+I was given the following string, delimited by +++:
 
-{
-  "incorrect_value": "sour cream tomata",
-  "error_message": "must be exactly two words"
-}
++++
+Tomato Cheese Pizza
++++
 
-Help me correct the incorrect values based on the given error messages.
+It had the following problems:
+- must be exactly two words
 
-Given below is XML that describes the information to extract from this document and the tags to extract it into.
+String description, delimited by +++:
 
-<output type="string" description="Name for the pizza" format="two-words" name="string"/>
++++
+Name for the pizza
++++
+
+Your generated response should satisfy the following properties:
+- two-words
 
 
-ONLY return a valid string answer (no other text is necessary), where the string is formatted according to the XML format. Be correct and concise.
+String Output:
 
-Here are examples of simple (XML, string) pairs that show the expected behavior:
-- `<output format='two-words lower-case' />` => `{'foo': 'example one'}`
-- `<output format='upper-case' />` => `{'bar': 'STRING ONE'}`

--- a/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
@@ -10,9 +10,7 @@ Help me correct the incorrect values based on the given error messages.
 
 Given below is XML that describes the information to extract from this document and the tags to extract it into.
 
-<output>
-    <string description="Name for the pizza" format="two-words" name="string"/>
-</output>
+<output type="string" description="Name for the pizza" format="two-words" name="string"/>
 
 
 ONLY return a valid string answer (no other text is necessary), where the string is formatted according to the XML format. Be correct and concise.

--- a/tests/integration_tests/test_assets/string/llm_output.txt
+++ b/tests/integration_tests/test_assets/string/llm_output.txt
@@ -1,0 +1,1 @@
+sour cream tomata

--- a/tests/integration_tests/test_assets/string/llm_output.txt
+++ b/tests/integration_tests/test_assets/string/llm_output.txt
@@ -1,1 +1,1 @@
-sour cream tomata
+Tomato Cheese Pizza

--- a/tests/integration_tests/test_assets/string/llm_output_reask.txt
+++ b/tests/integration_tests/test_assets/string/llm_output_reask.txt
@@ -1,0 +1,1 @@
+sour tomata

--- a/tests/integration_tests/test_assets/string/llm_output_reask.txt
+++ b/tests/integration_tests/test_assets/string/llm_output_reask.txt
@@ -1,1 +1,1 @@
-sour tomata
+Cheese Pizza

--- a/tests/integration_tests/test_assets/string/string.rail
+++ b/tests/integration_tests/test_assets/string/string.rail
@@ -1,9 +1,8 @@
 <rail version="0.1">
-<output>
-    <string
-        description="Name for the pizza"
-    />
-</output>
+<output
+    type="string"
+    description="Name for the pizza"
+/>
 
 <instructions>
 You are a helpful assistant, and you are helping me come up with a name for a pizza.

--- a/tests/integration_tests/test_assets/string/string.rail
+++ b/tests/integration_tests/test_assets/string/string.rail
@@ -1,0 +1,20 @@
+<rail version="0.1">
+<output>
+    <string
+        description="Name for the pizza"
+    />
+</output>
+
+<instructions>
+You are a helpful assistant, and you are helping me come up with a name for a pizza.
+
+@complete_string_suffix
+</instructions>
+
+<prompt>
+Given the following ingredients, what would you call this pizza?
+
+{{ingredients}}
+</prompt>
+
+</rail>

--- a/tests/integration_tests/test_assets/string/string_reask.rail
+++ b/tests/integration_tests/test_assets/string/string_reask.rail
@@ -1,0 +1,22 @@
+<rail version="0.1">
+<output>
+    <string
+        description="Name for the pizza"
+        format="two-words"
+        on-fail-two-words="reask"
+    />
+</output>
+
+<instructions>
+You are a helpful assistant, and you are helping me come up with a name for a pizza.
+
+@complete_string_suffix
+</instructions>
+
+<prompt>
+Given the following ingredients, what would you call this pizza?
+
+{{ingredients}}
+</prompt>
+
+</rail>

--- a/tests/integration_tests/test_assets/string/string_reask.rail
+++ b/tests/integration_tests/test_assets/string/string_reask.rail
@@ -1,11 +1,10 @@
 <rail version="0.1">
-<output>
-    <string
-        description="Name for the pizza"
-        format="two-words"
-        on-fail-two-words="reask"
-    />
-</output>
+<output
+    type="string"
+    description="Name for the pizza"
+    format="two-words"
+    on-fail-two-words="reask"
+/>
 
 <instructions>
 You are a helpful assistant, and you are helping me come up with a name for a pizza.

--- a/tests/integration_tests/test_assets/string/validated_output_reask.py
+++ b/tests/integration_tests/test_assets/string/validated_output_reask.py
@@ -1,7 +1,7 @@
 from guardrails.utils.reask_utils import ReAsk
 
 VALIDATED_OUTPUT_REASK = ReAsk(
-    incorrect_value="sour cream tomata",
+    incorrect_value="Tomato Cheese Pizza",
     error_message="must be exactly two words",
-    fix_value="sour cream",
+    fix_value="Tomato Cheese",
 )

--- a/tests/integration_tests/test_assets/string/validated_output_reask.py
+++ b/tests/integration_tests/test_assets/string/validated_output_reask.py
@@ -1,0 +1,7 @@
+from guardrails.utils.reask_utils import ReAsk
+
+VALIDATED_OUTPUT_REASK = ReAsk(
+    incorrect_value="sour cream tomata",
+    error_message="must be exactly two words",
+    fix_value="sour cream",
+)

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -321,13 +321,9 @@ def test_string_reask(mocker):
     # For orginal prompt and output
     assert guard_history[0].prompt == gd.Prompt(string.COMPILED_PROMPT)
     assert guard_history[0].output == string.LLM_OUTPUT
-    assert (
-        guard_history[0].validated_output == string.VALIDATED_OUTPUT_REASK
-    )
+    assert guard_history[0].validated_output == string.VALIDATED_OUTPUT_REASK
 
     # For re-asked prompt and output
     assert guard_history[1].prompt == gd.Prompt(string.COMPILED_PROMPT_REASK)
     assert guard_history[1].output == string.LLM_OUTPUT_REASK
-    assert (
-        guard_history[1].validated_output == string.LLM_OUTPUT_REASK
-    )
+    assert guard_history[1].validated_output == string.LLM_OUTPUT_REASK

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -276,8 +276,7 @@ def test_entity_extraction_with_fix_chat_models(mocker):
 def test_string_output(mocker):
     """Test single string (non-JSON) generation."""
     mocker.patch(
-        "guardrails.llm_providers.openai_wrapper",
-        new=openai_completion_create
+        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
     )
 
     guard = gd.Guard.from_rail_string(string.RAIL_SPEC_FOR_STRING)

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -320,7 +320,9 @@ def test_string_reask(mocker):
     assert len(guard_history) == 2
 
     # For orginal prompt and output
-    assert guard_history[0].instructions == gd.Instructions(string.COMPILED_INSTRUCTIONS)
+    assert guard_history[0].instructions == gd.Instructions(
+        string.COMPILED_INSTRUCTIONS
+    )
     assert guard_history[0].prompt == gd.Prompt(string.COMPILED_PROMPT)
     assert guard_history[0].output == string.LLM_OUTPUT
     assert guard_history[0].validated_output == string.VALIDATED_OUTPUT_REASK
@@ -329,4 +331,3 @@ def test_string_reask(mocker):
     assert guard_history[1].prompt == gd.Prompt(string.COMPILED_PROMPT_REASK)
     assert guard_history[1].output == string.LLM_OUTPUT_REASK
     assert guard_history[1].validated_output == string.LLM_OUTPUT_REASK
-

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -309,6 +309,7 @@ def test_string_reask(mocker):
         llm_api=openai.Completion.create,
         prompt_params={"ingredients": "tomato, cheese, sour cream"},
         num_reasks=1,
+        max_tokens=100,
     )
 
     assert final_output == string.LLM_OUTPUT_REASK
@@ -319,6 +320,7 @@ def test_string_reask(mocker):
     assert len(guard_history) == 2
 
     # For orginal prompt and output
+    assert guard_history[0].instructions == gd.Instructions(string.COMPILED_INSTRUCTIONS)
     assert guard_history[0].prompt == gd.Prompt(string.COMPILED_PROMPT)
     assert guard_history[0].output == string.LLM_OUTPUT
     assert guard_history[0].validated_output == string.VALIDATED_OUTPUT_REASK
@@ -327,3 +329,4 @@ def test_string_reask(mocker):
     assert guard_history[1].prompt == gd.Prompt(string.COMPILED_PROMPT_REASK)
     assert guard_history[1].output == string.LLM_OUTPUT_REASK
     assert guard_history[1].validated_output == string.LLM_OUTPUT_REASK
+

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -293,6 +293,41 @@ def test_string_output(mocker):
     # Check that the guard state object has the correct number of re-asks.
     assert len(guard_history) == 1
 
+    # For original prompt and output
+    assert guard_history[0].prompt == gd.Prompt(string.COMPILED_PROMPT)
+    assert guard_history[0].output == string.LLM_OUTPUT
+
+
+def test_string_reask(mocker):
+    """Test single string (non-JSON) generation with re-asking."""
+    mocker.patch(
+        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
+    )
+
+    guard = gd.Guard.from_rail_string(string.RAIL_SPEC_FOR_STRING_REASK)
+    _, final_output = guard(
+        llm_api=openai.Completion.create,
+        prompt_params={"ingredients": "tomato, cheese, sour cream"},
+        num_reasks=1,
+    )
+
+    assert final_output == string.LLM_OUTPUT_REASK
+
+    guard_history = guard.guard_state.most_recent_call.history
+
+    # Check that the guard state object has the correct number of re-asks.
+    assert len(guard_history) == 2
+
     # For orginal prompt and output
     assert guard_history[0].prompt == gd.Prompt(string.COMPILED_PROMPT)
     assert guard_history[0].output == string.LLM_OUTPUT
+    assert (
+        guard_history[0].validated_output == string.VALIDATED_OUTPUT_REASK
+    )
+
+    # For re-asked prompt and output
+    assert guard_history[1].prompt == gd.Prompt(string.COMPILED_PROMPT_REASK)
+    assert guard_history[1].output == string.LLM_OUTPUT_REASK
+    assert (
+        guard_history[1].validated_output == string.LLM_OUTPUT_REASK
+    )

--- a/tests/unit_tests/utils/test_reask_utils.py
+++ b/tests/unit_tests/utils/test_reask_utils.py
@@ -4,7 +4,7 @@ import pytest
 from lxml import etree as ET
 
 from guardrails import Prompt
-from guardrails.schema import JsonOutputSchema
+from guardrails.schema import JsonSchema
 from guardrails.utils import reask_utils
 from guardrails.utils.reask_utils import (
     ReAsk,
@@ -161,7 +161,7 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<list name='bar'><string format='upper-case' /></list>` => `{{"bar": ['STRING ONE', 'STRING TWO', etc.]}}`
 - `<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>` => `{{'baz': {{'foo': 'Some String', 'index': 1}}}}`
 """  # noqa: E501
-    output_schema = JsonOutputSchema(ET.fromstring(example_rail))
+    output_schema = JsonSchema(ET.fromstring(example_rail))
     reask_schema = output_schema.get_reask_schema(reasks)
     result_prompt = reask_schema.get_reask_prompt(reask_json)
 

--- a/tests/unit_tests/utils/test_reask_utils.py
+++ b/tests/unit_tests/utils/test_reask_utils.py
@@ -4,6 +4,7 @@ import pytest
 from lxml import etree as ET
 
 from guardrails import Prompt
+from guardrails.schema import JsonOutputSchema
 from guardrails.utils import reask_utils
 from guardrails.utils.reask_utils import (
     ReAsk,
@@ -93,8 +94,8 @@ def test_gather_reasks():
     ],
 )
 def test_prune_json_for_reasking(input_dict, expected_dict):
-    """Test that the prune_json_for_reasking function removes ReAsk objects."""
-    assert reask_utils.prune_json_for_reasking(input_dict) == expected_dict
+    """Test that the prune_obj_for_reasking function removes ReAsk objects."""
+    assert reask_utils.prune_obj_for_reasking(input_dict) == expected_dict
 
 
 @pytest.mark.parametrize(
@@ -160,10 +161,9 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<list name='bar'><string format='upper-case' /></list>` => `{{"bar": ['STRING ONE', 'STRING TWO', etc.]}}`
 - `<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>` => `{{'baz': {{'foo': 'Some String', 'index': 1}}}}`
 """  # noqa: E501
-
-    result_prompt, _ = reask_utils.get_reask_prompt(
-        ET.fromstring(example_rail), reasks, reask_json
-    )
+    output_schema = JsonOutputSchema(ET.fromstring(example_rail))
+    reask_schema = output_schema.get_reask_schema(reasks)
+    result_prompt = reask_schema.get_reask_prompt(reask_json)
 
     assert result_prompt == Prompt(
         expected_result_template


### PR DESCRIPTION
This PR moves JSON-specific logic from the `run.py` file into `JsonOutputSchema`, and proposes a `StringOutputSchema` for output a string instead of a JSON dictionary.

I've left validators alone, letting them still validate over a "fake" dictionary with one key.

I've disabled InputSchema for now, thinking maybe it would make sense to have a `JsonInputSchema` and `JsonOutputSchema` inherit the same class?

