### PR TITLE
Fix typos in `getting_started.ipynb`

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -143,7 +143,7 @@
     "\n",
     "For example, we can specify that if the `affected_area` of a symptom is not one of the valid choices, we should re-prompt the LLM to correct its output.\n",
     "\n",
-    "We do this by adding the `on-fail-valid-choices='reask'` attribute to the `affected_area` field. To see the full list of corrective actions, see [here](#specifying-corrective-actions).\n",
+    "We do this by adding the `on-fail-valid-choices='reask'` attribute to the `affected_area` field. To see the full list of corrective actions, see [here](/rail/output.md#specifying-corrective-actions).\n",
     "\n",
     "\n",
     "Finally, our updated output schema looks like:"

--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -58,11 +58,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creating an `RAIL` spec\n",
+    "## Creating a `RAIL` spec\n",
     "\n",
     "At the heart of `Guardrails` is the `RAIL` spec.\n",
     "\n",
-    "`RAIL` a flavor of XML (standing for **R**eliable **AI** markup **L**anguage) that describes the expected structure and type of the output of the LLM, the quality criteria for the output to be valid and corrective actions to be taken if the output is invalid.\n",
+    "`RAIL` is a flavor of XML (standing for **R**eliable **AI** markup **L**anguage) that describes the expected structure and type of the output of the LLM, the quality criteria for the output to be valid and corrective actions to be taken if the output is invalid.\n",
     "\n",
     "A `RAIL` spec is composed of 3 main components:\n",
     "\n",
@@ -143,10 +143,10 @@
     "\n",
     "For example, we can specify that if the `affected_area` of a symptom is not one of the valid choices, we should re-prompt the LLM to correct its output.\n",
     "\n",
-    "We do this by adding the `on-fail-valid-choices='reask'` attribute to the `affected_area` field. To see the full list of corrective actions, see [here](output.md#specifying-corrective-actions).\n",
+    "We do this by adding the `on-fail-valid-choices='reask'` attribute to the `affected_area` field. To see the full list of corrective actions, see [here](#specifying-corrective-actions).\n",
     "\n",
     "\n",
-    "Finally, out updated output schema looks like:"
+    "Finally, our updated output schema looks like:"
    ]
   },
   {


### PR DESCRIPTION
Hello there 👋🏼 I was running the `Getting Started` notebook locally when I noticed a few typos. So, I figured I'd submit a PR to fix these.

This should fix navigation to the full list of corrective actions as well.