### PR TITLE
callback

### DIFF
--- a/guardrails/callback.py
+++ b/guardrails/callback.py
@@ -1,0 +1,74 @@
+from typing import Callable, Dict, Optional, Tuple, Any
+from guardrails.llm_providers import PromptCallable
+from guardrails.schema import Schema
+from guardrails.prompt import Instructions, Prompt
+
+class Callback():
+
+    def before_prepare(
+        self,
+        index: int,
+        instructions: Optional[Instructions],
+        prompt: Prompt,
+        prompt_params: Dict,
+        api: PromptCallable,
+        input_schema: Schema,
+        output_schema: Schema,
+    ) -> Tuple[Instructions, Prompt]:
+        ...
+
+    def after_prepare(
+        self,
+        instructions: Optional[Instructions],
+        prompt: Prompt,
+    ) -> Any:
+        ...
+
+    def before_call(
+        self,
+        index: int,
+        instructions: Optional[Instructions],
+        prompt: Prompt,
+        api: Callable,
+        output: str = None,
+    ) -> str:
+        ...
+
+    def after_call(
+        self,
+        input: str
+    ) -> Any:
+        ...
+    
+    def before_parse(
+        self,
+        index: int,
+        output: str,
+        output_schema: Schema,
+    ) -> Any:
+        ...
+
+
+    def after_parse(
+        self,
+        *args: Any,
+        **kwargs: Any
+    ) -> Any:
+        ...
+
+
+    def before_validate(
+        self,
+        index: int,
+        parsed_output: Any,
+        output_schema: Schema,
+    ) -> Any:
+        ...
+
+
+    def after_validate(
+        self,
+        *args: Any,
+        **kwargs: Any
+    ) -> Any:
+        ...


### PR DESCRIPTION
@ShreyaR sorry for taking a while, this is kind of what I imagine the callback would look like, also creating an abstract class with `abstractmethod` would mean the user would have to define all the methods in the subclass to be able to use callbacks which is unnecessary. I also have some questions about the arguments

e.g If a user wants a customized logic for preprocessing, does this mean the prepare function for preprocessing in `run.py` should be skipped? In that case, what arguments should the `after_prepare` function take, I assume it should be the return values of `before_prepare` 

I would love to get your thoughts on this