### PR TITLE
Aaron/callback

### DIFF
--- a/guardrails/callback.py
+++ b/guardrails/callback.py
@@ -1,0 +1,21 @@
+from typing import Callable
+
+class Callback:
+    def __init__(self, before_prepare: Callable = None,
+        after_prepare: Callable = None, before_call: Callable = None):
+        self.before_prepare = before_prepare
+        self.after_prepare = after_prepare
+        self.before_call = before_call
+
+    def before_prepare(self, **kwargs):
+        if self.before_prepare is not None:
+            self.before_prepare(**kwargs)
+
+    def after_prepare(self, **kwargs):
+        if self.before_prepare is not None:
+            self.after_prepare(**kwargs)
+
+    def before_call(self, **kwargs):
+        if self.before_prepare is not None:
+            self.before_call(**kwargs)
+

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
 from string import Formatter
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union
+from typing import (
+    Any, Awaitable, Callable, Dict,
+    Optional, Tuple, Union, Iterable)
 
 from eliot import add_destinations, start_action
 from pydantic import BaseModel
@@ -13,6 +15,7 @@ from guardrails.run import AsyncRunner, Runner
 from guardrails.schema import Schema
 from guardrails.utils.logs_utils import GuardState
 from guardrails.utils.reask_utils import sub_reasks_with_fixed_values
+from guardrails.callback import Callback
 
 logger = logging.getLogger(__name__)
 actions_logger = logging.getLogger(f"{__name__}.actions")
@@ -35,6 +38,7 @@ class Guard:
         rail: Rail,
         num_reasks: int = 1,
         base_model: Optional[BaseModel] = None,
+        callbacks: Iterable[Callback] = []
     ):
         """Initialize the Guard."""
         self.rail = rail
@@ -42,6 +46,7 @@ class Guard:
         self.guard_state = GuardState([])
         self._reask_prompt = None
         self.base_model = base_model
+        self.callbacks = callbacks
 
     @property
     def input_schema(self) -> Schema:
@@ -110,7 +115,8 @@ class Guard:
         self.num_reasks = num_reasks
 
     @classmethod
-    def from_rail(cls, rail_file: str, num_reasks: int = 1) -> "Guard":
+    def from_rail(cls, rail_file: str, num_reasks: int = 1,
+        callbacks: Iterable[Callback] = []) -> "Guard":
         """Create a Schema from a `.rail` file.
 
         Args:
@@ -120,10 +126,12 @@ class Guard:
         Returns:
             An instance of the `Guard` class.
         """
-        return cls(Rail.from_file(rail_file), num_reasks=num_reasks)
+        return cls(Rail.from_file(rail_file), num_reasks=num_reasks, 
+            callbacks=callbacks)
 
     @classmethod
-    def from_rail_string(cls, rail_string: str, num_reasks: int = 1) -> "Guard":
+    def from_rail_string(cls, rail_string: str, num_reasks: int = 1
+        callbacks: Iterable[Callback] = []) -> "Guard":
         """Create a Schema from a `.rail` string.
 
         Args:
@@ -133,7 +141,8 @@ class Guard:
         Returns:
             An instance of the `Guard` class.
         """
-        return cls(Rail.from_string(rail_string), num_reasks=num_reasks)
+        return cls(Rail.from_string(rail_string), num_reasks=num_reasks
+            callbacks=callbacks)
 
     @classmethod
     def from_pydantic(
@@ -142,12 +151,14 @@ class Guard:
         prompt: str,
         instructions: Optional[str] = None,
         num_reasks: int = 1,
+        callbacks: Iterable[Callback] = []
     ) -> "Guard":
         """Create a Guard instance from a Pydantic model and prompt."""
         rail = Rail.from_pydantic(
             output_class=output_class, prompt=prompt, instructions=instructions
         )
-        return cls(rail, num_reasks=num_reasks, base_model=output_class)
+        return cls(rail, num_reasks=num_reasks, base_model=output_class, 
+            callbacks=callbacks)
 
     def __call__(
         self,
@@ -211,6 +222,7 @@ class Guard:
                 num_reasks=num_reasks,
                 reask_prompt=self.reask_prompt,
                 base_model=self.base_model,
+                callbacks=self.callbacks
             )
             guard_history = runner(prompt_params=prompt_params)
             self.guard_state = self.guard_state.push(guard_history)
@@ -246,6 +258,7 @@ class Guard:
                 output_schema=self.output_schema,
                 num_reasks=num_reasks,
                 reask_prompt=self.reask_prompt,
+                callbacks=self.callbacks
             )
             guard_history = await runner.async_run(prompt_params=prompt_params)
             self.guard_state = self.guard_state.push(guard_history)


### PR DESCRIPTION
 Run doesn't have method names that match callback method names
- Passed callbacks to logger.. not sure if that makes sense
- after_prepare happens right before before_call.  There is no code inbetween them.  so, can we do them in the same loop?
```
for callback in callbacks:
	callback.after_prepare()
	callback.before_call()

vs

for callback in callbacks:
	callback.after_prepare()

for callback in callbacks:
	callback.before_call()
```
- these implementations are equivalent unless all the after_prepares need to run before any of the before_calls can run.  
- it would save a loop over callbacks, but it's safer to just implement as too loops given I don't know the requirements.  can easily change later
- not sure the arguments passed to Runner callbacks are correct.. still thinking through usage

## TODO
- code has not been run
- write test