### PR TITLE
datatypes: Always use cast value, even when no validators run

### DIFF
--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -95,7 +95,7 @@ class DataType:
                 f"Validator {validator_class_name} finished, "
                 f"key {key} has value {value}."
             )
-            schema[key] = value
+        schema[key] = value
         return schema
 
     def validate(

--- a/tests/integration_tests/test_assets/python_rail/__init__.py
+++ b/tests/integration_tests/test_assets/python_rail/__init__.py
@@ -1,6 +1,8 @@
 # flake8: noqa: E501
 import os
 
+from tests.integration_tests.test_assets.python_rail.validated_output_2 import llm_2_out
+
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)))
 reader = (
     lambda filename: open(os.path.join(DATA_DIR, filename)).read().replace("\r", "")
@@ -16,6 +18,7 @@ LLM_OUTPUT_1_FAIL_GUARDRAILS_VALIDATION = reader(
 LLM_OUTPUT_2_SUCCEED_GUARDRAILS_BUT_FAIL_PYDANTIC_VALIDATION = reader(
     "llm_output_2_succeed_gd_but_fail_pydantic_validation.txt"
 )
+VALIDATED_OUTPUT_2 = llm_2_out
 LLM_OUTPUT_3_SUCCEED_GUARDRAILS_AND_PYDANTIC = reader(
     "llm_output_3_succeed_gd_and_pydantic.txt"
 )

--- a/tests/integration_tests/test_assets/python_rail/validated_output_2.py
+++ b/tests/integration_tests/test_assets/python_rail/validated_output_2.py
@@ -1,0 +1,92 @@
+import datetime
+
+llm_2_out = {
+    "name": "Christopher Nolan",
+    "movies": [
+        {
+            "rank": 1,
+            "title": "Inception",
+            "details": {
+                "release_date": datetime.date(2010, 7, 16),
+                "duration": datetime.time(2, 28),
+                "budget": 160000000.0,
+                "is_sequel": False,
+                "website": "https://www.inceptionmovie.com",
+                "contact_email": "info@inceptionmovie.com",
+                "revenue_type": "box_office",
+                "box_office": {
+                    "gross": 829895144.0,
+                    "opening_weekend": 62785337.0
+                }
+            }
+        },
+        {
+            "rank": 2,
+            "title": "The Dark Knight",
+            "details": {
+                "release_date": datetime.date(2008, 7, 18),
+                "duration": datetime.time(2, 32),
+                "budget": 185000000.0,
+                "is_sequel": True,
+                "website": "https://www.thedarkknightmovie.com",
+                "contact_email": "info@thedarkknightmovie.com",
+                "revenue_type": "box_office",
+                "box_office": {
+                    "gross": 1004558444.0,
+                    "opening_weekend": 158411483.0
+                }
+            }
+        },
+        {
+            "rank": 3,
+            "title": "The Dark Knight Rises",
+            "details": {
+                "release_date": datetime.date(2012, 7, 20),
+                "duration": datetime.time(2, 44),
+                "budget": 250000000.0,
+                "is_sequel": True,
+                "website": "https://www.thedarkknightrises.com",
+                "contact_email": "info@thedarkknightrises.com",
+                "revenue_type": "streaming",
+                "streaming": {
+                    "subscriptions": 15000000,
+                    "subscription_fee": 9.99
+                }
+            }
+        },
+        {
+            "rank": 4,
+            "title": "Interstellar",
+            "details": {
+                "release_date": datetime.date(2014, 11, 7),
+                "duration": datetime.time(2, 49),
+                "budget": 165000000.0,
+                "is_sequel": False,
+                "website": "https://www.interstellarmovie.com",
+                "contact_email": "info@interstellarmovie.com",
+                "revenue_type": "box_office",
+                "box_office": {
+                    "gross": 115000000.0,
+                    "opening_weekend": 47510360.0
+                }
+            }
+        },
+        {
+            "rank": 5,
+            "title": "Dunkirk",
+            "details": {
+                "release_date": datetime.date(2017, 7, 21),
+                "duration": datetime.time(1, 46),
+                "budget": 100000000.0,
+                "is_sequel": False,
+                "website": "https://www.dunkirkmovie.com",
+                "contact_email": "info@dunkirkmovie.com",
+                "revenue_type": "box_office",
+                "box_office": {
+                    "gross": 526940665.0,
+                    "opening_weekend": 50513488.0
+                }
+            }
+        }
+    ]
+}

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Optional, Union
 
 import openai
@@ -77,8 +78,8 @@ def validated_output():
         "dummy_boolean": True,
         "dummy_email": "example@example.com",
         "dummy_url": "https://www.example.com",
-        "dummy_date": "2020-01-01",
-        "dummy_time": "12:00:00",
+        "dummy_date": datetime.date(2020, 1, 1),
+        "dummy_time": datetime.time(12, 0),
         "dummy_list": ["item1", "item2", "item3"],
         "dummy_object": {"key1": "value1", "key2": "value2"},
     }

--- a/tests/integration_tests/test_python_rail.py
+++ b/tests/integration_tests/test_python_rail.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from datetime import date, time
 from typing import List, Optional
@@ -114,9 +115,7 @@ def test_python_rail(mocker):
     )
 
     # Assertions are made on the guard state object.
-    expected_gd_output = json.loads(
-        python_rail.LLM_OUTPUT_2_SUCCEED_GUARDRAILS_BUT_FAIL_PYDANTIC_VALIDATION
-    )
+    expected_gd_output = python_rail.VALIDATED_OUTPUT_2
     assert final_output == expected_gd_output
 
     guard_history = guard.guard_state.most_recent_call.history
@@ -235,9 +234,7 @@ def test_python_rail_add_validator(mocker):
     )
 
     # Assertions are made on the guard state object.
-    expected_gd_output = json.loads(
-        python_rail.LLM_OUTPUT_2_SUCCEED_GUARDRAILS_BUT_FAIL_PYDANTIC_VALIDATION
-    )
+    expected_gd_output = python_rail.VALIDATED_OUTPUT_2
     assert final_output == expected_gd_output
 
     guard_history = guard.guard_state.most_recent_call.history


### PR DESCRIPTION
According to current behavior on dev and main, if no validators are run, the value is not overwritten. So if a time value like "23:59:59" is generated, and not validated, it would remain a string instead of being cast to `datetime.time`.

This pull request makes sure values are always converted from string to their specified type.