### PR TITLE
Api key as kwarg

### DIFF
--- a/guardrails/embedding.py
+++ b/guardrails/embedding.py
@@ -104,10 +104,12 @@ class OpenAIEmbedding(EmbeddingBase):
         encoding_name: Optional[str] = "cl100k_base",
         max_tokens: Optional[int] = 8191,
         api_key: Optional[str] = None,
+        api_base: Optional[str] = None
     ):
         super().__init__(model, encoding_name, max_tokens)
         self._model = model
         self.api_key = api_key
+        self.api_base = api_base
 
     def embed(self, texts: List[str]) -> List[List[float]]:
         embeddings = []
@@ -128,7 +130,7 @@ class OpenAIEmbedding(EmbeddingBase):
             if self.api_key is not None
             else os.environ.get("OPENAI_API_KEY")
         )
-        resp = openai.Embedding.create(api_key=api_key, model=self._model, input=texts)
+        resp = openai.Embedding.create(api_key=api_key, model=self._model, input=texts, api_base=self.api_base)
         return [r["embedding"] for r in resp["data"]]
 
     @property

--- a/guardrails/embedding.py
+++ b/guardrails/embedding.py
@@ -103,9 +103,11 @@ class OpenAIEmbedding(EmbeddingBase):
         model: Optional[str] = "text-embedding-ada-002",
         encoding_name: Optional[str] = "cl100k_base",
         max_tokens: Optional[int] = 8191,
+        api_key: Optional[str] = None,
     ):
         super().__init__(model, encoding_name, max_tokens)
         self._model = model
+        self.api_key = api_key
 
     def embed(self, texts: List[str]) -> List[List[float]]:
         embeddings = []
@@ -121,7 +123,11 @@ class OpenAIEmbedding(EmbeddingBase):
         return resp[0]
 
     def _get_embedding(self, texts: List[str]) -> List[float]:
-        api_key = os.environ.get("OPENAI_API_KEY")
+        api_key = (
+            self.api_key
+            if self.api_key is not None
+            else os.environ.get("OPENAI_API_KEY")
+        )
         resp = openai.Embedding.create(api_key=api_key, model=self._model, input=texts)
         return [r["embedding"] for r in resp["data"]]
 

--- a/guardrails/embedding.py
+++ b/guardrails/embedding.py
@@ -104,7 +104,7 @@ class OpenAIEmbedding(EmbeddingBase):
         encoding_name: Optional[str] = "cl100k_base",
         max_tokens: Optional[int] = 8191,
         api_key: Optional[str] = None,
-        api_base: Optional[str] = None
+        api_base: Optional[str] = None,
     ):
         super().__init__(model, encoding_name, max_tokens)
         self._model = model
@@ -130,7 +130,9 @@ class OpenAIEmbedding(EmbeddingBase):
             if self.api_key is not None
             else os.environ.get("OPENAI_API_KEY")
         )
-        resp = openai.Embedding.create(api_key=api_key, model=self._model, input=texts, api_base=self.api_base)
+        resp = openai.Embedding.create(
+            api_key=api_key, model=self._model, input=texts, api_base=self.api_base
+        )
         return [r["embedding"] for r in resp["data"]]
 
     @property

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import contextvars
 from string import Formatter
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 
@@ -180,6 +181,9 @@ class Guard:
         if metadata is None:
             metadata = {}
 
+        context = contextvars.ContextVar("kwargs")
+        context.set(kwargs)
+
         # If the LLM API is async, return a coroutine
         if asyncio.iscoroutinefunction(llm_api):
             return self._call_async(
@@ -320,6 +324,9 @@ class Guard:
             The validated response.
         """
         metadata = metadata or {}
+
+        context = contextvars.ContextVar("kwargs")
+        context.set(kwargs)
 
         # If the LLM API is async, return a coroutine
         if asyncio.iscoroutinefunction(llm_api):

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -1,6 +1,6 @@
 import asyncio
-import logging
 import contextvars
+import logging
 from string import Formatter
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -109,7 +109,7 @@ def openai_wrapper(
     *args,
     **kwargs,
 ) -> str:
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
     openai_response = openai.Completion.create(
         api_key=api_key,
         engine=engine,
@@ -164,8 +164,9 @@ def openai_chat_wrapper(
         fn_kwargs = {}
 
     # Call OpenAI
+    api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
     openai_response = openai.ChatCompletion.create(
-        api_key=os.environ.get("OPENAI_API_KEY"),
+        api_key=api_key,
         model=model,
         messages=chat_prompt(
             prompt=text, instructions=instructions, msg_history=msg_history
@@ -297,7 +298,7 @@ async def async_openai_wrapper(
     *args,
     **kwargs,
 ):
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
     openai_response = await openai.Completion.acreate(
         api_key=api_key,
         engine=engine,
@@ -315,7 +316,7 @@ async def async_openai_chat_wrapper(
     *args,
     **kwargs,
 ):
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
     openai_response = await openai.ChatCompletion.acreate(
         api_key=api_key,
         model=model,

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -1012,7 +1012,7 @@ class ExtractedSummarySentencesMatch(Validator):
         self._threshold = float(threshold)
 
     @staticmethod
-    def _instantiate_store(metadata, api_key: Optional[str] = None):
+    def _instantiate_store(metadata, api_key: Optional[str] = None, api_base: Optional[str] = None):
         if "document_store" in metadata:
             return metadata["document_store"]
 
@@ -1028,7 +1028,7 @@ class ExtractedSummarySentencesMatch(Validator):
             else:
                 from guardrails.embedding import OpenAIEmbedding
 
-                embedding_model = OpenAIEmbedding(api_key=api_key)
+                embedding_model = OpenAIEmbedding(api_key=api_key, api_base=api_base)
 
             vector_db = Faiss.new_flat_ip_index(
                 embedding_model.output_dim, embedder=embedding_model
@@ -1052,8 +1052,9 @@ class ExtractedSummarySentencesMatch(Validator):
                 break
 
         api_key = kwargs.get("api_key")
+        api_base = kwargs.get("api_base")
 
-        store = self._instantiate_store(metadata, api_key)
+        store = self._instantiate_store(metadata, api_key, api_base)
 
         sources = []
         for filepath in filepaths:

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -1012,7 +1012,9 @@ class ExtractedSummarySentencesMatch(Validator):
         self._threshold = float(threshold)
 
     @staticmethod
-    def _instantiate_store(metadata, api_key: Optional[str] = None, api_base: Optional[str] = None):
+    def _instantiate_store(
+        metadata, api_key: Optional[str] = None, api_base: Optional[str] = None
+    ):
         if "document_store" in metadata:
             return metadata["document_store"]
 

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -1048,9 +1048,9 @@ class ExtractedSummarySentencesMatch(Validator):
 
         kwargs = {}
         context_copy = contextvars.copy_context()
-        for key, value in context_copy.items():
+        for key, context_var in context_copy.items():
             if key.name == "kwargs" and isinstance(kwargs, dict):
-                kwargs = value
+                kwargs = context_var
                 break
 
         api_key = kwargs.get("api_key")

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -1045,7 +1045,7 @@ class ExtractedSummarySentencesMatch(Validator):
         filepaths = metadata["filepaths"]
 
         kwargs = {}
-        context_copy = contextvars.copy_context()        
+        context_copy = contextvars.copy_context()
         for key, value in context_copy.items():
             if key.name == "kwargs" and isinstance(kwargs, dict):
                 kwargs = value

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -4,6 +4,7 @@ The name with which a validator is registered is the name that is used
 in the `RAIL` spec to specify formatters.
 """
 import ast
+import contextvars
 import itertools
 import logging
 import os
@@ -1011,7 +1012,7 @@ class ExtractedSummarySentencesMatch(Validator):
         self._threshold = float(threshold)
 
     @staticmethod
-    def _instantiate_store(metadata):
+    def _instantiate_store(metadata, api_key: Optional[str] = None):
         if "document_store" in metadata:
             return metadata["document_store"]
 
@@ -1027,7 +1028,7 @@ class ExtractedSummarySentencesMatch(Validator):
             else:
                 from guardrails.embedding import OpenAIEmbedding
 
-                embedding_model = OpenAIEmbedding()
+                embedding_model = OpenAIEmbedding(api_key=api_key)
 
             vector_db = Faiss.new_flat_ip_index(
                 embedding_model.output_dim, embedder=embedding_model
@@ -1043,7 +1044,16 @@ class ExtractedSummarySentencesMatch(Validator):
             )
         filepaths = metadata["filepaths"]
 
-        store = self._instantiate_store(metadata)
+        kwargs = {}
+        context_copy = contextvars.copy_context()        
+        for key, value in context_copy.items():
+            if key.name == "kwargs" and isinstance(kwargs, dict):
+                kwargs = value
+                break
+
+        api_key = kwargs.get("api_key")
+
+        store = self._instantiate_store(metadata, api_key)
 
         sources = []
         for filepath in filepaths:


### PR DESCRIPTION
This PR adds the ability to pass in api_key as a kwarg.

Previously, only environment variables were supported (specifically for OPENAI_API_KEY).

Note that passing this value along to the llm wrappers is complete with this PR, but when the OpenAI API Key needs to be used in validators for things like embedding operations, while functional, the current method should be revised in the future as it's only marginally better than a global store or in memory cache.

Ideally we can change where validators are initialized and pass through the kwargs there; there just needs to be more discovery on what side effects that might have.