### PR TITLE
Fail early on missing required metadata keys

### DIFF
--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -2,7 +2,8 @@ import datetime
 import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Dict, Generator
+from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable
+from typing import List
 from typing import List as TypedList
 from typing import Tuple, Type, Union
 
@@ -23,6 +24,22 @@ class FieldValidation:
     value: Any
     validators: TypedList[Validator]
     children: TypedList["FieldValidation"]
+
+
+def verify_metadata_requirements(
+    metadata: dict, datatypes: Iterable["DataType"]
+) -> List[str]:
+    missing_keys = set()
+    for datatype in datatypes:
+        for validator in datatype.validators:
+            for requirement in validator.required_metadata_keys:
+                if requirement not in metadata:
+                    missing_keys.add(requirement)
+        nested_missing_keys = verify_metadata_requirements(
+            metadata, vars(datatype.children).values()
+        )
+        missing_keys.update(nested_missing_keys)
+    return list(missing_keys)
 
 
 class DataType:

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from eliot import add_destinations, start_action
 from pydantic import BaseModel
 
+from guardrails.datatypes import verify_metadata_requirements
 from guardrails.llm_providers import AsyncPromptCallable, PromptCallable
 from guardrails.prompt import Instructions, Prompt
 from guardrails.schema import Schema
@@ -98,6 +99,15 @@ class Runner:
         Returns:
             The guard history.
         """
+        # check if validator requirements are fulfilled
+        missing_keys = verify_metadata_requirements(
+            self.metadata, self.output_schema.to_dict().values()
+        )
+        if missing_keys:
+            raise ValueError(
+                f"Missing required metadata keys: {', '.join(missing_keys)}"
+            )
+
         self._reset_guard_history()
 
         # Figure out if we need to include instructions in the prompt.

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -213,6 +213,7 @@ class Validator:
 
     run_in_separate_process = False
     override_value_on_pass = False
+    required_metadata_keys = []
 
     def __init__(self, on_fail: Optional[Callable] = None, **kwargs):
         if on_fail is None:
@@ -951,6 +952,8 @@ class IsHighQualityTranslation(Validator):
         translation_source (str): The source of the translation.
     """
 
+    required_metadata_keys = ["translation_source"]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         try:
@@ -1042,6 +1045,8 @@ class ExtractedSummarySentencesMatch(Validator):
         vector_db (VectorDBBase, optional): A vector database to use for embeddings.  Defaults to Faiss.
         embedding_model (EmbeddingBase, optional): The embeddig model to use. Defaults to OpenAIEmbedding.
     """  # noqa
+
+    required_metadata_keys = ["filepaths"]
 
     def __init__(
         self,
@@ -1223,6 +1228,8 @@ class ExtractiveSummary(Validator):
 
         filepaths (List[str]): A list of strings that specifies the filepaths for any documents that should be used for asserting the summary's similarity.
     """  # noqa
+
+    required_metadata_keys = ["filepaths"]
 
     def __init__(
         self,
@@ -1524,6 +1531,8 @@ class QARelevanceLLMEval(Validator):
     Other parameters: Metadata
         question (str): The original question the llm was given to answer.
     """
+
+    required_metadata_keys = ["question"]
 
     def __init__(
         self,

--- a/tests/unit_tests/test_guard.py
+++ b/tests/unit_tests/test_guard.py
@@ -1,0 +1,90 @@
+import pytest
+
+import guardrails
+from guardrails import Validator
+from guardrails.datatypes import verify_metadata_requirements
+from guardrails.validators import PassResult, register_validator
+
+
+@register_validator("myrequiringvalidator", data_type="string")
+class RequiringValidator(Validator):
+    required_metadata_keys = ["required_key"]
+
+    def validate(self, value, metadata):
+        return PassResult()
+
+
+@register_validator("myrequiringvalidator2", data_type="string")
+class RequiringValidator2(Validator):
+    required_metadata_keys = ["required_key2"]
+
+    def validate(self, value, metadata):
+        return PassResult()
+
+
+@pytest.mark.parametrize(
+    "spec,metadata",
+    [
+        (
+            """
+<rail version="0.1">
+<output>
+    <string name="string_name" format="myrequiringvalidator" />
+</output>
+</rail>
+        """,
+            {"required_key": "a"},
+        ),
+        (
+            """
+<rail version="0.1">
+<output>
+    <object name="temp_name">
+        <string name="string_name" format="myrequiringvalidator" />
+    </object>
+    <list name="list_name">
+        <string name="string_name" format="myrequiringvalidator2" />
+    </list>
+</output>
+</rail>
+        """,
+            {"required_key": "a", "required_key2": "b"},
+        ),
+        (
+            """
+<rail version="0.1">
+<output>
+    <object name="temp_name">
+    <list name="list_name">
+    <choice name="choice_name" discriminator="hi">
+    <case name="hello">
+        <string name="string_name" />
+    </case>
+    <case name="hiya">
+        <string name="string_name" format="myrequiringvalidator" />
+    </case>
+    </choice>
+    </list>
+    </object>
+</output>
+</rail>
+""",
+            {"required_key": "a"},
+        ),
+    ],
+)
+def test_required_metadata(spec, metadata):
+    guard = guardrails.Guard.from_rail_string(spec)
+
+    with pytest.raises(ValueError):
+        guard.parse("{}")
+    missing_keys = verify_metadata_requirements(
+        {}, guard.output_schema.to_dict().values()
+    )
+    assert set(missing_keys) == set(metadata)
+
+    guard.parse("{}", metadata=metadata, num_reasks=0)
+    not_missing_keys = verify_metadata_requirements(
+        metadata, guard.output_schema.to_dict().values()
+    )
+    assert not_missing_keys == []


### PR DESCRIPTION
Allows validators to specify a `required_metadata_keys` list. If these are not passed in the guard call, `Runner` fails early.