### PR TITLE
Document field validation logs access

### DIFF
--- a/docs/logs.md
+++ b/docs/logs.md
@@ -34,27 +34,10 @@ print(guard.state.most_recent_call.tree)
 To access fine-grained logs on field validation, see the FieldValidationLogs object:
 
 ```python
-from pydantic import BaseModel
-import dataclasses
-import json
-
-
-def to_dict(obj):
-    if isinstance(obj, BaseModel):
-        return obj.dict()
-    elif isinstance(obj, list):
-        return [to_dict(e) for e in obj]
-    elif isinstance(obj, dict):
-        return {key: to_dict(value) for key, value in obj.items()}
-    elif hasattr(obj, "__dataclass_fields__"):
-        return {k: to_dict(v) for k, v in dataclasses.asdict(obj).items()}
-    else:
-        return obj
-
-
 validation_logs = guard.guard_state.all_histories[0].history[0].field_validation_logs
-print(json.dumps(to_dict(validation_logs), indent=2))
+print(validation_logs.json(indent=2))
 ```
+
 ```json
 {
   "validator_logs": [],

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -21,7 +21,7 @@ eliot-tree --output-format=ascii guardrails.log
 1. A list of all `gd.Guard` calls, in the order they were made.
 2. For each call, reasks needed and their results.
 
-In order to access logs, run:
+To pretty print logs, run:
 
 ```python
 from rich import print
@@ -30,3 +30,66 @@ print(guard.state.most_recent_call.tree)
 ```
 
 ![guard_state](img/guard_history.png)
+
+To access fine-grained logs on field validation, see the FieldValidationLogs object:
+
+```python
+from pydantic import BaseModel
+import dataclasses
+import json
+
+
+def to_dict(obj):
+    if isinstance(obj, BaseModel):
+        return obj.dict()
+    elif isinstance(obj, list):
+        return [to_dict(e) for e in obj]
+    elif isinstance(obj, dict):
+        return {key: to_dict(value) for key, value in obj.items()}
+    elif hasattr(obj, "__dataclass_fields__"):
+        return {k: to_dict(v) for k, v in dataclasses.asdict(obj).items()}
+    else:
+        return obj
+
+
+validation_logs = guard.guard_state.all_histories[0].history[0].field_validation_logs
+print(json.dumps(to_dict(validation_logs), indent=2))
+```
+```json
+{
+  "validator_logs": [],
+  "children": {
+    "name": {
+      "validator_logs": [
+        {
+          "validator_name": "TwoWords",
+          "value_before_validation": "peter parker the second",
+          "validation_result": {
+            "outcome": "fail",
+            "metadata": null,
+            "error_message": "must be exactly two words",
+            "fix_value": "peter parker"
+          },
+          "value_after_validation": {
+            "incorrect_value": "peter parker the second",
+            "fail_results": [
+              {
+                "outcome": "fail",
+                "metadata": null,
+                "error_message": "must be exactly two words",
+                "fix_value": "peter parker"
+              }
+            ],
+            "path": [
+              "name"
+            ]
+          }
+        }
+      ],
+      "children": {}
+    }
+  }
+}
+
+
+```

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -41,7 +41,7 @@ class Guard:
         """Initialize the Guard."""
         self.rail = rail
         self.num_reasks = num_reasks
-        self.guard_state = GuardState([])
+        self.guard_state = GuardState(all_histories=[])
         self._reask_prompt = None
         self.base_model = base_model
 

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -54,13 +54,15 @@ class Runner:
     metadata: Dict[str, Any] = field(default_factory=dict)
     output: str = None
     reask_prompt: Optional[Prompt] = None
-    guard_history: GuardHistory = field(default_factory=lambda: GuardHistory([]))
+    guard_history: GuardHistory = field(
+        default_factory=lambda: GuardHistory(history=[])
+    )
     base_model: Optional[BaseModel] = None
     full_schema_reask: bool = False
 
     def _reset_guard_history(self):
         """Reset the guard history."""
-        self.guard_history = GuardHistory([])
+        self.guard_history = GuardHistory(history=[])
         self.guard_state.push(self.guard_history)
 
     def __post_init__(self):


### PR DESCRIPTION
I've added a little section to `docs/logs` detailing how to access FieldValidationLogs.

It was very difficult to print it nicely without a helper function, because they contained a mix of dataclasses and pydantic models. I've refactored all the log objects to pydantic models instead, so now it's as easy as calling the `json` method on the top-level model.