### PR TITLE
Keep token counts, refactor LLM wrappers to subclasses

### DIFF
--- a/guardrails/__init__.py
+++ b/guardrails/__init__.py
@@ -1,7 +1,7 @@
 # Set up __init__.py so that users can do from guardrails import Response, Schema, etc.
 
 from guardrails.guard import Guard
-from guardrails.llm_providers import PromptCallable
+from guardrails.llm_providers import PromptCallableBase
 from guardrails.logging_utils import configure_logging
 from guardrails.prompt import Instructions, Prompt
 from guardrails.rail import Rail
@@ -10,7 +10,7 @@ from guardrails.validators import Validator, register_validator
 
 __all__ = [
     "Guard",
-    "PromptCallable",
+    "PromptCallableBase",
     "Rail",
     "Validator",
     "register_validator",

--- a/guardrails/applications/text2sql.py
+++ b/guardrails/applications/text2sql.py
@@ -8,7 +8,6 @@ import openai
 from guardrails.document_store import DocumentStoreBase, EphemeralDocumentStore
 from guardrails.embedding import EmbeddingBase, OpenAIEmbedding
 from guardrails.guard import Guard
-from guardrails.llm_providers import PromptCallable
 from guardrails.utils.sql_utils import create_sql_driver
 from guardrails.vectordb import Faiss, VectorDBBase
 
@@ -71,7 +70,7 @@ class Text2Sql:
         rail_params: Optional[Dict] = None,
         example_formatter: Optional[Callable] = example_formatter,
         reask_prompt: Optional[str] = REASK_PROMPT,
-        llm_api: Optional[PromptCallable] = openai.Completion.create,
+        llm_api: Optional[Callable] = openai.Completion.create,
         llm_api_kwargs: Optional[Dict] = None,
         num_relevant_examples: int = 2,
     ):

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -1,12 +1,11 @@
 import os
-from dataclasses import dataclass
-from functools import partial
 from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
 
 import openai
 from pydantic import BaseModel
 from tenacity import retry, retry_if_exception_type, wait_exponential_jitter
 
+from guardrails.utils.logs_utils import LLMResponse
 from guardrails.utils.pydantic_utils import convert_pydantic_model_to_openai_fn
 
 try:
@@ -41,23 +40,29 @@ class PromptCallableException(Exception):
 ###
 
 
-@dataclass
-class PromptCallable:
+class PromptCallableBase:
     """A wrapper around a callable that takes in a prompt.
 
     Catches exceptions to let the user know clearly if the callable
     failed, and how to fix it.
     """
 
-    fn: Callable
+    def __init__(self, *args, **kwargs):
+        self.init_args = args
+        self.init_kwargs = kwargs
+
+    def invoke_llm(self, *args, **kwargs) -> LLMResponse:
+        raise NotImplementedError
 
     @retry(
         wait=wait_exponential_jitter(max=60),
         retry=retry_if_exception_type(RETRYABLE_ERRORS),
     )
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> LLMResponse:
         try:
-            result = self.fn(*args, **kwargs)
+            result = self.invoke_llm(
+                *self.init_args, *args, **self.init_kwargs, **kwargs
+            )
         except Exception as e:
             raise PromptCallableException(
                 "The callable `fn` passed to `Guard(fn, ...)` failed"
@@ -66,26 +71,15 @@ class PromptCallable:
                 " takes in a single prompt string "
                 "and returns a string."
             )
-        # if not isinstance(result, str):
-        #     raise PromptCallableException(
-        #         "The callable `fn` passed to `Guard(fn, ...)` returned"
-        #         f" a non-string value: {result}. "
-        #         "Make sure that `fn` can be called as a function that"
-        #         " takes in a single prompt string "
-        #         "and returns a string."
-        #     )
-        if hasattr(self.fn, "func") and self.fn.func in [
-            openai_wrapper,
-            openai_chat_wrapper,
-        ]:
-            text_result = result["choices"][0]["text"]
-            prompt_token_count = result["usage"]["prompt_tokens"]
-            response_token_count = result["usage"]["completion_tokens"]
-        else:
-            text_result = result
-            prompt_token_count = None
-            response_token_count = None
-        return text_result, prompt_token_count, response_token_count
+        if not isinstance(result, LLMResponse):
+            raise PromptCallableException(
+                "The callable `fn` passed to `Guard(fn, ...)` returned"
+                f" a non-string value: {result}. "
+                "Make sure that `fn` can be called as a function that"
+                " takes in a single prompt string "
+                "and returns a string."
+            )
+        return result
 
 
 def nonchat_prompt(prompt: str, instructions: Optional[str] = None) -> str:
@@ -113,156 +107,202 @@ def chat_prompt(
     ]
 
 
-def openai_wrapper(
-    text: str,
-    engine: str = "text-davinci-003",
-    instructions: Optional[str] = None,
-    *args,
-    **kwargs,
-) -> dict[str, Any]:
-    api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
-    openai_response = openai.Completion.create(
-        api_key=api_key,
-        engine=engine,
-        prompt=nonchat_prompt(prompt=text, instructions=instructions),
+class OpenAICallable(PromptCallableBase):
+    def invoke_llm(
+        self,
+        text: str,
+        engine: str = "text-davinci-003",
+        instructions: Optional[str] = None,
         *args,
         **kwargs,
-    )
-    return openai_response
-
-
-def openai_chat_wrapper(
-    text: Optional[str] = None,
-    model: str = "gpt-3.5-turbo",
-    instructions: Optional[str] = None,
-    msg_history: Optional[List[Dict]] = None,
-    base_model: Optional[BaseModel] = None,
-    function_call: Optional[str] = None,
-    *args,
-    **kwargs,
-) -> str:
-    """Wrapper for OpenAI chat engines.
-
-    Use Guardrails with OpenAI chat engines by doing
-    ```
-    raw_llm_response, validated_response = guard(
-        openai.ChatCompletion.create,
-        prompt_params={...},
-        text=...,
-        instructions=...,
-        msg_history=...,
-        temperature=...,
-        ...
-    )
-    ```
-
-    If `base_model` is passed, the chat engine will be used as a function
-    on the base model.
-    """
-
-    if msg_history is None and text is None:
-        raise PromptCallableException(
-            "You must pass in either `text` or `msg_history` to `guard.__call__`."
+    ) -> LLMResponse:
+        api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
+        openai_response = openai.Completion.create(
+            api_key=api_key,
+            engine=engine,
+            prompt=nonchat_prompt(prompt=text, instructions=instructions),
+            *args,
+            **kwargs,
+        )
+        return LLMResponse(
+            output=openai_response["choices"][0]["text"],
+            prompt_token_count=openai_response["usage"]["prompt_tokens"],
+            response_token_count=openai_response["usage"]["completion_tokens"],
         )
 
-    # Configure function calling if applicable
-    if base_model:
-        function_params = [convert_pydantic_model_to_openai_fn(base_model)]
-        if function_call is None:
-            function_call = {"name": function_params[0]["name"]}
-        fn_kwargs = {"functions": function_params, "function_call": function_call}
-    else:
-        fn_kwargs = {}
 
-    # Call OpenAI
-    api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
-    openai_response = openai.ChatCompletion.create(
-        api_key=api_key,
-        model=model,
-        messages=chat_prompt(
-            prompt=text, instructions=instructions, msg_history=msg_history
-        ),
+class OpenAIChatCallable(PromptCallableBase):
+    def invoke_llm(
+        self,
+        text: Optional[str] = None,
+        model: str = "gpt-3.5-turbo",
+        instructions: Optional[str] = None,
+        msg_history: Optional[List[Dict]] = None,
+        base_model: Optional[BaseModel] = None,
+        function_call: Optional[str] = None,
         *args,
-        **fn_kwargs,
         **kwargs,
-    )
+    ) -> LLMResponse:
+        """Wrapper for OpenAI chat engines.
 
-    # Extract string from response
-    if "function_call" in openai_response["choices"][0]["message"]:
-        return openai_response["choices"][0]["message"]["function_call"]["arguments"]
-    else:
-        return openai_response["choices"][0]["message"]["content"]
-
-
-def manifest_wrapper(
-    text: str, client: Any, instructions: Optional[str] = None, *args, **kwargs
-) -> str:
-    """Wrapper for manifest client.
-
-    To use manifest for guardrailse, do
-    ```
-    client = Manifest(client_name=..., client_connection=...)
-    raw_llm_response, validated_response = guard(
-        client,
-        prompt_params={...},
-        ...
-    ```
-    """
-    if not MANIFEST:
-        raise PromptCallableException(
-            "The `manifest` package is not installed. "
-            "Install with `pip install manifest-ml`"
+        Use Guardrails with OpenAI chat engines by doing
+        ```
+        raw_llm_response, validated_response = guard(
+            openai.ChatCompletion.create,
+            prompt_params={...},
+            text=...,
+            instructions=...,
+            msg_history=...,
+            temperature=...,
+            ...
         )
-    client = cast(manifest.Manifest, client)
-    manifest_response = client.run(
-        nonchat_prompt(prompt=text, instructions=instructions), *args, **kwargs
-    )
-    return manifest_response
+        ```
+
+        If `base_model` is passed, the chat engine will be used as a function
+        on the base model.
+        """
+
+        if msg_history is None and text is None:
+            raise PromptCallableException(
+                "You must pass in either `text` or `msg_history` to `guard.__call__`."
+            )
+
+        # Configure function calling if applicable
+        if base_model:
+            function_params = [convert_pydantic_model_to_openai_fn(base_model)]
+            if function_call is None:
+                function_call = {"name": function_params[0]["name"]}
+            fn_kwargs = {"functions": function_params, "function_call": function_call}
+        else:
+            fn_kwargs = {}
+
+        # Call OpenAI
+        api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
+        openai_response = openai.ChatCompletion.create(
+            api_key=api_key,
+            model=model,
+            messages=chat_prompt(
+                prompt=text, instructions=instructions, msg_history=msg_history
+            ),
+            *args,
+            **fn_kwargs,
+            **kwargs,
+        )
+
+        # Extract string from response
+        if "function_call" in openai_response["choices"][0]["message"]:
+            output = openai_response["choices"][0]["message"]["function_call"][
+                "arguments"
+            ]
+        else:
+            output = openai_response["choices"][0]["message"]["content"]
+
+        return LLMResponse(
+            output=output,
+            prompt_token_count=openai_response["choices"][0]["tokens"],
+            response_token_count=openai_response["choices"][0]["tokens"],
+        )
 
 
-def cohere_wrapper(
-    prompt: str, client_callable: Any, model: str, *args, **kwargs
-) -> str:
-    """Wrapper for cohere client.
+class ManifestCallable(PromptCallableBase):
+    def invoke_llm(
+        self,
+        text: str,
+        client: Any,
+        instructions: Optional[str] = None,
+        *args,
+        **kwargs,
+    ) -> LLMResponse:
+        """Wrapper for manifest client.
 
-    To use cohere for guardrails, do
-    ```
-    client = cohere.Client(api_key=...)
+        To use manifest for guardrailse, do
+        ```
+        client = Manifest(client_name=..., client_connection=...)
+        raw_llm_response, validated_response = guard(
+            client,
+            prompt_params={...},
+            ...
+        ```
+        """
+        if not MANIFEST:
+            raise PromptCallableException(
+                "The `manifest` package is not installed. "
+                "Install with `pip install manifest-ml`"
+            )
+        client = cast(manifest.Manifest, client)
+        manifest_response = client.run(
+            nonchat_prompt(prompt=text, instructions=instructions), *args, **kwargs
+        )
+        return LLMResponse(
+            output=manifest_response,
+        )
 
-    raw_llm_response, validated_response = guard(
-        client.generate,
-        prompt_params={...},
-        model="command-nightly",
-        ...
-    )
-    ```
-    """
 
-    if "instructions" in kwargs:
-        prompt = kwargs.pop("instructions") + "\n\n" + prompt
+class CohereCallable(PromptCallableBase):
+    def invoke_llm(
+        self, prompt: str, client_callable: Any, model: str, *args, **kwargs
+    ) -> LLMResponse:
+        """
+        To use cohere for guardrails, do
+        ```
+        client = cohere.Client(api_key=...)
 
-    cohere_response = client_callable(prompt=prompt, model=model, *args, **kwargs)
-    return cohere_response[0].text
+        raw_llm_response, validated_response = guard(
+            client.generate,
+            prompt_params={...},
+            model="command-nightly",
+            ...
+        )
+        ```
+        """
+
+        if "instructions" in kwargs:
+            prompt = kwargs.pop("instructions") + "\n\n" + prompt
+
+        cohere_response = client_callable(prompt=prompt, model=model, *args, **kwargs)
+        return LLMResponse(
+            output=cohere_response[0].text,
+        )
 
 
-def get_llm_ask(llm_api: Callable, *args, **kwargs) -> PromptCallable:
+class ArbitraryCallable(PromptCallableBase):
+    def __init__(self, llm_api: Callable, *args, **kwargs):
+        self.llm_api = llm_api
+        super().__init__(*args, **kwargs)
+
+    def invoke_llm(self, *args, **kwargs) -> LLMResponse:
+        """Wrapper for arbitrary callable.
+
+        To use an arbitrary callable for guardrails, do
+        ```
+        raw_llm_response, validated_response = guard(
+            my_callable,
+            prompt_params={...},
+            ...
+        )
+        ```
+        """
+        return LLMResponse(
+            output=self.llm_api(*args, **kwargs),
+        )
+
+
+def get_llm_ask(llm_api: Callable, *args, **kwargs) -> PromptCallableBase:
     if llm_api == openai.Completion.create:
-        fn = partial(openai_wrapper, *args, **kwargs)
+        return OpenAICallable(*args, **kwargs)
     elif llm_api == openai.ChatCompletion.create:
-        fn = partial(openai_chat_wrapper, *args, **kwargs)
+        return OpenAIChatCallable(*args, **kwargs)
     elif MANIFEST and isinstance(llm_api, manifest.Manifest):
-        fn = partial(manifest_wrapper, client=llm_api, *args, **kwargs)
+        return ManifestCallable(*args, client=llm_api, **kwargs)
     elif (
         cohere
         and isinstance(getattr(llm_api, "__self__", None), cohere.Client)
         and getattr(llm_api, "__name__", None) == "generate"
     ):
-        fn = partial(cohere_wrapper, client_callable=llm_api, *args, **kwargs)
-    else:
-        # Let the user pass in an arbitrary callable.
-        fn = partial(llm_api, *args, **kwargs)
+        return CohereCallable(*args, client_callable=llm_api, **kwargs)
 
-    return PromptCallable(fn=fn)
+    # Let the user pass in an arbitrary callable.
+    return ArbitraryCallable(*args, llm_api=llm_api, **kwargs)
 
 
 ###
@@ -270,23 +310,27 @@ def get_llm_ask(llm_api: Callable, *args, **kwargs) -> PromptCallable:
 ###
 
 
-@dataclass
-class AsyncPromptCallable:
-    """A wrapper around a callable that takes in a prompt.
+class AsyncPromptCallableBase:
+    def __init__(self, *args, **kwargs):
+        self.init_args = args
+        self.init_kwargs = kwargs
 
-    Catches exceptions to let the user know clearly if the callable
-    failed, and how to fix it.
-    """
-
-    fn: Callable[[Any], Awaitable[Any]]
+    async def invoke_llm(
+        self,
+        *args,
+        **kwargs,
+    ) -> LLMResponse:
+        raise NotImplementedError
 
     @retry(
         wait=wait_exponential_jitter(max=60),
         retry=retry_if_exception_type(RETRYABLE_ERRORS),
     )
-    async def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> LLMResponse:
         try:
-            result = await self.fn(*args, **kwargs)
+            result = self.invoke_llm(
+                *self.init_args, *args, **self.init_kwargs, **kwargs
+            )
         except Exception as e:
             raise PromptCallableException(
                 "The callable `fn` passed to `Guard(fn, ...)` failed"
@@ -295,99 +339,176 @@ class AsyncPromptCallable:
                 " takes in a single prompt string "
                 "and returns a string."
             )
-        # if not isinstance(result, str):
-        #     raise PromptCallableException(
-        #         "The callable `fn` passed to `Guard(fn, ...)` returned"
-        #         f" a non-string value: {result}. "
-        #         "Make sure that `fn` can be called as a function that"
-        #         " takes in a single prompt string "
-        #         "and returns a string."
-        #     )
-        if hasattr(self.fn, "func") and self.fn.func in [
-            async_openai_wrapper,
-            async_openai_chat_wrapper,
-        ]:
-            text_result = result["choices"][0]["text"]
-            prompt_token_count = result["usage"]["prompt_tokens"]
-            response_token_count = result["usage"]["completion_tokens"]
-        else:
-            text_result = result
-            prompt_token_count = None
-            response_token_count = None
-        return text_result, prompt_token_count, response_token_count
+        if not isinstance(result, LLMResponse):
+            raise PromptCallableException(
+                "The callable `fn` passed to `Guard(fn, ...)` returned"
+                f" a non-string value: {result}. "
+                "Make sure that `fn` can be called as a function that"
+                " takes in a single prompt string "
+                "and returns a string."
+            )
+        return result
 
 
-async def async_openai_wrapper(
-    text: str,
-    engine: str = "text-davinci-003",
-    instructions: Optional[str] = None,
-    *args,
-    **kwargs,
-):
-    api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
-    openai_response = await openai.Completion.acreate(
-        api_key=api_key,
-        engine=engine,
-        prompt=nonchat_prompt(prompt=text, instructions=instructions),
+class AsyncOpenAICallable(AsyncPromptCallableBase):
+    async def invoke_llm(
+        self,
+        text: str,
+        engine: str = "text-davinci-003",
+        instructions: Optional[str] = None,
         *args,
         **kwargs,
-    )
-    return openai_response["choices"][0]["text"]
-
-
-async def async_openai_chat_wrapper(
-    text: str,
-    model="gpt-3.5-turbo",
-    instructions: Optional[str] = None,
-    *args,
-    **kwargs,
-):
-    api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
-    openai_response = await openai.ChatCompletion.acreate(
-        api_key=api_key,
-        model=model,
-        messages=chat_prompt(prompt=text, instructions=instructions),
-        *args,
-        **kwargs,
-    )
-    return openai_response["choices"][0]["message"]["content"]
-
-
-async def async_manifest_wrapper(
-    text: str, client: Any, instructions: Optional[str] = None, *args, **kwargs
-):
-    """Async wrapper for manifest client.
-
-    To use manifest for guardrails, do
-    ```
-    client = Manifest(client_name=..., client_connection=...)
-    raw_llm_response, validated_response = guard(
-        client,
-        prompt_params={...},
-        ...
-    ```
-    """
-    if not MANIFEST:
-        raise PromptCallableException(
-            "The `manifest` package is not installed. "
-            "Install with `pip install manifest-ml`"
+    ):
+        api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
+        openai_response = await openai.Completion.acreate(
+            api_key=api_key,
+            engine=engine,
+            prompt=nonchat_prompt(prompt=text, instructions=instructions),
+            *args,
+            **kwargs,
         )
-    client = cast(manifest.Manifest, client)
-    manifest_response = await client.run(
-        nonchat_prompt(prompt=text, instructions=instructions), *args, **kwargs
-    )
-    return manifest_response
+        return LLMResponse(
+            output=openai_response["choices"][0]["text"],
+            prompt_token_count=openai_response["usage"]["prompt_tokens"],
+            response_token_count=openai_response["usage"]["completion_tokens"],
+        )
+
+
+class AsyncOpenAIChatCallable(AsyncPromptCallableBase):
+    async def invoke_llm(
+        self,
+        text: Optional[str] = None,
+        model: str = "gpt-3.5-turbo",
+        instructions: Optional[str] = None,
+        msg_history: Optional[List[Dict]] = None,
+        base_model: Optional[BaseModel] = None,
+        function_call: Optional[str] = None,
+        *args,
+        **kwargs,
+    ) -> LLMResponse:
+        """Wrapper for OpenAI chat engines.
+
+        Use Guardrails with OpenAI chat engines by doing
+        ```
+        raw_llm_response, validated_response = guard(
+            openai.ChatCompletion.create,
+            prompt_params={...},
+            text=...,
+            instructions=...,
+            msg_history=...,
+            temperature=...,
+            ...
+        )
+        ```
+
+        If `base_model` is passed, the chat engine will be used as a function
+        on the base model.
+        """
+
+        if msg_history is None and text is None:
+            raise PromptCallableException(
+                "You must pass in either `text` or `msg_history` to `guard.__call__`."
+            )
+
+        # Configure function calling if applicable
+        if base_model:
+            function_params = [convert_pydantic_model_to_openai_fn(base_model)]
+            if function_call is None:
+                function_call = {"name": function_params[0]["name"]}
+            fn_kwargs = {"functions": function_params, "function_call": function_call}
+        else:
+            fn_kwargs = {}
+
+        # Call OpenAI
+        api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
+        openai_response = await openai.ChatCompletion.acreate(
+            api_key=api_key,
+            model=model,
+            messages=chat_prompt(
+                prompt=text, instructions=instructions, msg_history=msg_history
+            ),
+            *args,
+            **fn_kwargs,
+            **kwargs,
+        )
+
+        # Extract string from response
+        if "function_call" in openai_response["choices"][0]["message"]:
+            output = openai_response["choices"][0]["message"]["function_call"][
+                "arguments"
+            ]
+        else:
+            output = openai_response["choices"][0]["message"]["content"]
+
+        return LLMResponse(
+            output=output,
+            prompt_token_count=openai_response["choices"][0]["tokens"],
+            response_token_count=openai_response["choices"][0]["tokens"],
+        )
+
+
+class AsyncManifestCallable(AsyncPromptCallableBase):
+    async def invoke_llm(
+        self,
+        text: str,
+        client: Any,
+        instructions: Optional[str] = None,
+        *args,
+        **kwargs,
+    ):
+        """Async wrapper for manifest client.
+
+        To use manifest for guardrails, do
+        ```
+        client = Manifest(client_name=..., client_connection=...)
+        raw_llm_response, validated_response = guard(
+            client,
+            prompt_params={...},
+            ...
+        ```
+        """
+        if not MANIFEST:
+            raise PromptCallableException(
+                "The `manifest` package is not installed. "
+                "Install with `pip install manifest-ml`"
+            )
+        client = cast(manifest.Manifest, client)
+        manifest_response = await client.run(
+            nonchat_prompt(prompt=text, instructions=instructions), *args, **kwargs
+        )
+        return LLMResponse(
+            output=manifest_response,
+        )
+
+
+class AsyncArbitraryCallable(AsyncPromptCallableBase):
+    def __init__(self, llm_api: Callable, *args, **kwargs):
+        self.llm_api = llm_api
+        super().__init__(*args, **kwargs)
+
+    async def invoke_llm(self, *args, **kwargs) -> LLMResponse:
+        """Wrapper for arbitrary callable.
+
+        To use an arbitrary callable for guardrails, do
+        ```
+        raw_llm_response, validated_response = guard(
+            my_callable,
+            prompt_params={...},
+            ...
+        )
+        ```
+        """
+        return LLMResponse(
+            output=self.llm_api(*args, **kwargs),
+        )
 
 
 def get_async_llm_ask(llm_api: Callable[[Any], Awaitable[Any]], *args, **kwargs):
     if llm_api == openai.Completion.acreate:
-        fn = partial(async_openai_wrapper, *args, **kwargs)
+        return AsyncOpenAICallable(*args, **kwargs)
     elif llm_api == openai.ChatCompletion.acreate:
-        fn = partial(async_openai_chat_wrapper, *args, **kwargs)
+        return AsyncOpenAIChatCallable(*args, **kwargs)
     elif MANIFEST and isinstance(llm_api, manifest.Manifest):
-        fn = partial(async_manifest_wrapper, client=llm_api, *args, **kwargs)
-    else:
-        # Let the user pass in an arbitrary callable.
-        fn = partial(llm_api, *args, **kwargs)
+        return AsyncManifestCallable(*args, client=llm_api, **kwargs)
 
-    return AsyncPromptCallable(fn=fn)
+    return AsyncArbitraryCallable(*args, llm_api=llm_api, **kwargs)

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -66,15 +66,26 @@ class PromptCallable:
                 " takes in a single prompt string "
                 "and returns a string."
             )
-        if not isinstance(result, str):
-            raise PromptCallableException(
-                "The callable `fn` passed to `Guard(fn, ...)` returned"
-                f" a non-string value: {result}. "
-                "Make sure that `fn` can be called as a function that"
-                " takes in a single prompt string "
-                "and returns a string."
-            )
-        return result
+        # if not isinstance(result, str):
+        #     raise PromptCallableException(
+        #         "The callable `fn` passed to `Guard(fn, ...)` returned"
+        #         f" a non-string value: {result}. "
+        #         "Make sure that `fn` can be called as a function that"
+        #         " takes in a single prompt string "
+        #         "and returns a string."
+        #     )
+        if hasattr(self.fn, "func") and self.fn.func in [
+            openai_wrapper,
+            openai_chat_wrapper,
+        ]:
+            text_result = result["choices"][0]["text"]
+            prompt_token_count = result["usage"]["prompt_tokens"]
+            response_token_count = result["usage"]["completion_tokens"]
+        else:
+            text_result = result
+            prompt_token_count = None
+            response_token_count = None
+        return text_result, prompt_token_count, response_token_count
 
 
 def nonchat_prompt(prompt: str, instructions: Optional[str] = None) -> str:
@@ -108,7 +119,7 @@ def openai_wrapper(
     instructions: Optional[str] = None,
     *args,
     **kwargs,
-) -> str:
+) -> dict[str, Any]:
     api_key = kwargs.pop("api_key", os.environ.get("OPENAI_API_KEY"))
     openai_response = openai.Completion.create(
         api_key=api_key,
@@ -117,7 +128,7 @@ def openai_wrapper(
         *args,
         **kwargs,
     )
-    return openai_response["choices"][0]["text"]
+    return openai_response
 
 
 def openai_chat_wrapper(
@@ -284,15 +295,26 @@ class AsyncPromptCallable:
                 " takes in a single prompt string "
                 "and returns a string."
             )
-        if not isinstance(result, str):
-            raise PromptCallableException(
-                "The callable `fn` passed to `Guard(fn, ...)` returned"
-                f" a non-string value: {result}. "
-                "Make sure that `fn` can be called as a function that"
-                " takes in a single prompt string "
-                "and returns a string."
-            )
-        return result
+        # if not isinstance(result, str):
+        #     raise PromptCallableException(
+        #         "The callable `fn` passed to `Guard(fn, ...)` returned"
+        #         f" a non-string value: {result}. "
+        #         "Make sure that `fn` can be called as a function that"
+        #         " takes in a single prompt string "
+        #         "and returns a string."
+        #     )
+        if hasattr(self.fn, "func") and self.fn.func in [
+            async_openai_wrapper,
+            async_openai_chat_wrapper,
+        ]:
+            text_result = result["choices"][0]["text"]
+            prompt_token_count = result["usage"]["prompt_tokens"]
+            response_token_count = result["usage"]["completion_tokens"]
+        else:
+            text_result = result
+            prompt_token_count = None
+            response_token_count = None
+        return text_result, prompt_token_count, response_token_count
 
 
 async def async_openai_wrapper(

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -207,7 +207,9 @@ class Runner:
             guard_logs.msg_history = msg_history
 
             # Call: run the API.
-            output = self.call(index, instructions, prompt, msg_history, api, output)
+            output = self.call(
+                guard_logs, index, instructions, prompt, msg_history, api, output
+            )
 
             guard_logs.output = output
 
@@ -290,6 +292,7 @@ class Runner:
 
     def call(
         self,
+        guard_logs: GuardLogs,
         index: int,
         instructions: Optional[Instructions],
         prompt: Prompt,
@@ -310,36 +313,48 @@ class Runner:
                 msg["content"] = msg["content"].source
             return msg_history_copy
 
+        prompt_tokens = None
+        response_tokens = None
+
         with start_action(action_type="call", index=index, prompt=prompt) as action:
             try:
                 if msg_history:
-                    output = api(
+                    output, prompt_tokens, response_tokens = api(
                         msg_history=msg_history_source(msg_history),
                         base_model=self.base_model,
                     )
                 else:
                     if prompt and instructions:
-                        output = api(
+                        output, prompt_tokens, response_tokens = api(
                             prompt.source,
                             instructions=instructions.source,
                             base_model=self.base_model,
                         )
                     elif prompt:
-                        output = api(prompt.source, base_model=self.base_model)
+                        output, prompt_tokens, response_tokens = api(
+                            prompt.source, base_model=self.base_model
+                        )
             except Exception:
                 # If the API call fails, try calling again without the base model.
                 if msg_history:
-                    output = api(msg_history=msg_history_source(msg_history))
+                    output, prompt_tokens, response_tokens = api(
+                        msg_history=msg_history_source(msg_history)
+                    )
                 else:
                     if prompt and instructions:
-                        output = api(prompt.source, instructions=instructions.source)
+                        output, prompt_tokens, response_tokens = api(
+                            prompt.source, instructions=instructions.source
+                        )
                     elif prompt:
-                        output = api(prompt.source)
+                        output, prompt_tokens, response_tokens = api(prompt.source)
 
             action.log(
                 message_type="info",
                 output=output,
             )
+
+            guard_logs.prompt_token_count = prompt_tokens
+            guard_logs.response_token_count = response_tokens
 
             return output
 
@@ -529,7 +544,7 @@ class AsyncRunner(Runner):
 
             # Call: run the API.
             output = await self.async_call(
-                index, instructions, prompt, msg_history, api, output
+                guard_logs, index, instructions, prompt, msg_history, api, output
             )
 
             guard_logs.output = output
@@ -561,6 +576,7 @@ class AsyncRunner(Runner):
 
     async def async_call(
         self,
+        guard_logs: GuardLogs,
         index: int,
         instructions: Optional[Instructions],
         prompt: Prompt,
@@ -574,44 +590,49 @@ class AsyncRunner(Runner):
         2. Convert the response string to a dict,
         3. Log the output
         """
-        """Run a step.
-
-        1. Query the LLM API,
-        2. Convert the response string to a dict,
-        3. Log the output
-        """
+        prompt_tokens = None
+        response_tokens = None
         with start_action(action_type="call", index=index, prompt=prompt) as action:
             try:
                 if msg_history:
-                    output = await api(
+                    output, prompt_tokens, response_tokens = await api(
                         msg_history=msg_history,
                         base_model=self.base_model,
                     )
                 else:
                     if prompt and instructions:
-                        output = await api(
+                        output, prompt_tokens, response_tokens = await api(
                             prompt.source,
                             instructions=instructions.source,
                             base_model=self.base_model,
                         )
                     elif prompt:
-                        output = await api(prompt.source, base_model=self.base_model)
+                        output, prompt_tokens, response_tokens = await api(
+                            prompt.source, base_model=self.base_model
+                        )
             except Exception:
                 # If the API call fails, try calling again without the base model.
                 if msg_history:
-                    output = await api(msg_history=msg_history)
+                    output, prompt_tokens, response_tokens = await api(
+                        msg_history=msg_history
+                    )
                 else:
                     if prompt and instructions:
-                        output = await api(
+                        output, prompt_tokens, response_tokens = await api(
                             prompt.source, instructions=instructions.source
                         )
                     elif prompt:
-                        output = await api(prompt.source)
+                        output, prompt_tokens, response_tokens = await api(
+                            prompt.source
+                        )
 
             action.log(
                 message_type="info",
                 output=output,
             )
+
+            guard_logs.prompt_token_count = prompt_tokens
+            guard_logs.response_token_count = response_tokens
 
             return output
 

--- a/guardrails/schema.py
+++ b/guardrails/schema.py
@@ -13,7 +13,11 @@ from lxml import etree as ET
 
 from guardrails import validator_service
 from guardrails.datatypes import DataType, String
-from guardrails.llm_providers import PromptCallable, openai_chat_wrapper, openai_wrapper
+from guardrails.llm_providers import (
+    OpenAICallable,
+    OpenAIChatCallable,
+    PromptCallableBase,
+)
 from guardrails.prompt import Instructions, Prompt
 from guardrails.utils.constants import constants
 from guardrails.utils.json_utils import verify_schema_against_json
@@ -414,7 +418,7 @@ class Schema:
 
     def preprocess_prompt(
         self,
-        prompt_callable: PromptCallable,
+        prompt_callable: PromptCallableBase,
         instructions: Optional[Instructions],
         prompt: Prompt,
     ):
@@ -720,17 +724,13 @@ class JsonSchema(Schema):
 
     def preprocess_prompt(
         self,
-        prompt_callable: PromptCallable,
+        prompt_callable: PromptCallableBase,
         instructions: Optional[Instructions],
         prompt: Prompt,
     ):
-        if not hasattr(prompt_callable.fn, "func"):
-            # Only apply preprocessing to guardrails wrappers.
-            return instructions, prompt
-
-        if prompt_callable.fn.func is openai_wrapper:
+        if isinstance(prompt_callable, OpenAICallable):
             prompt.source += "\n\nJson Output:\n\n"
-        if prompt_callable.fn.func is openai_chat_wrapper and not instructions:
+        if isinstance(prompt_callable, OpenAIChatCallable) and not instructions:
             instructions = Instructions(
                 "You are a helpful assistant, "
                 "able to express yourself purely through JSON, "
@@ -929,7 +929,7 @@ class StringSchema(Schema):
 
     def preprocess_prompt(
         self,
-        prompt_callable: PromptCallable,
+        prompt_callable: PromptCallableBase,
         instructions: Optional[Instructions],
         prompt: Prompt,
     ):
@@ -938,13 +938,9 @@ class StringSchema(Schema):
                 "In order to support reasking, a `prompt_callable` is required."
             )
 
-        if not hasattr(prompt_callable.fn, "func"):
-            # Only apply preprocessing to guardrails wrappers.
-            return instructions, prompt
-
-        if prompt_callable.fn.func is openai_wrapper:
+        if isinstance(prompt_callable, OpenAICallable):
             prompt.source += "\n\nString Output:\n\n"
-        if prompt_callable.fn.func is openai_chat_wrapper and not instructions:
+        if isinstance(prompt_callable, OpenAIChatCallable) and not instructions:
             instructions = Instructions(
                 "You are a helpful assistant, expressing yourself through a string."
             )

--- a/guardrails/schema.py
+++ b/guardrails/schema.py
@@ -14,6 +14,8 @@ from lxml import etree as ET
 from guardrails import validator_service
 from guardrails.datatypes import DataType, String
 from guardrails.llm_providers import (
+    AsyncOpenAICallable,
+    AsyncOpenAIChatCallable,
     OpenAICallable,
     OpenAIChatCallable,
     PromptCallableBase,
@@ -728,9 +730,14 @@ class JsonSchema(Schema):
         instructions: Optional[Instructions],
         prompt: Prompt,
     ):
-        if isinstance(prompt_callable, OpenAICallable):
+        if isinstance(prompt_callable, OpenAICallable) or isinstance(
+            prompt_callable, AsyncOpenAICallable
+        ):
             prompt.source += "\n\nJson Output:\n\n"
-        if isinstance(prompt_callable, OpenAIChatCallable) and not instructions:
+        if (
+            isinstance(prompt_callable, OpenAIChatCallable)
+            or isinstance(prompt_callable, AsyncOpenAIChatCallable)
+        ) and not instructions:
             instructions = Instructions(
                 "You are a helpful assistant, "
                 "able to express yourself purely through JSON, "
@@ -933,14 +940,14 @@ class StringSchema(Schema):
         instructions: Optional[Instructions],
         prompt: Prompt,
     ):
-        if prompt_callable is None:
-            raise RuntimeError(
-                "In order to support reasking, a `prompt_callable` is required."
-            )
-
-        if isinstance(prompt_callable, OpenAICallable):
+        if isinstance(prompt_callable, OpenAICallable) or isinstance(
+            prompt_callable, AsyncOpenAICallable
+        ):
             prompt.source += "\n\nString Output:\n\n"
-        if isinstance(prompt_callable, OpenAIChatCallable) and not instructions:
+        if (
+            isinstance(prompt_callable, OpenAIChatCallable)
+            or isinstance(prompt_callable, AsyncOpenAIChatCallable)
+        ) and not instructions:
             instructions = Instructions(
                 "You are a helpful assistant, expressing yourself through a string."
             )

--- a/guardrails/utils/logs_utils.py
+++ b/guardrails/utils/logs_utils.py
@@ -75,6 +75,12 @@ class GuardLogs(ArbitraryModel):
         return gather_reasks(self.validated_output)
 
     @property
+    def output(self) -> Optional[str]:
+        if self.llm_response is None:
+            return None
+        return self.llm_response.output
+
+    @property
     def rich_group(self) -> Group:
         def create_msg_history_table(
             msg_history: Optional[List[Dict[str, Prompt]]]

--- a/guardrails/utils/logs_utils.py
+++ b/guardrails/utils/logs_utils.py
@@ -39,13 +39,17 @@ class FieldValidationLogs(ArbitraryModel):
     children: Dict[Union[int, str], "FieldValidationLogs"] = Field(default_factory=dict)
 
 
+class LLMResponse(ArbitraryModel):
+    prompt_token_count: Optional[int] = None
+    response_token_count: Optional[int] = None
+    output: Optional[str] = None
+
+
 class GuardLogs(ArbitraryModel):
     prompt: Optional[Prompt] = None
     instructions: Optional[Instructions] = None
-    prompt_token_count: Optional[int] = None
-    response_token_count: Optional[int] = None
+    llm_response: Optional[LLMResponse] = None
     msg_history: Optional[List[Dict[str, Prompt]]] = None
-    output: Optional[str] = None
     parsed_output: Optional[dict] = None
     validated_output: Optional[dict] = None
     reasks: Optional[List[ReAsk]] = None

--- a/guardrails/utils/logs_utils.py
+++ b/guardrails/utils/logs_utils.py
@@ -42,6 +42,8 @@ class FieldValidationLogs(ArbitraryModel):
 class GuardLogs(ArbitraryModel):
     prompt: Optional[Prompt] = None
     instructions: Optional[Instructions] = None
+    prompt_token_count: Optional[int] = None
+    response_token_count: Optional[int] = None
     msg_history: Optional[List[Dict[str, Prompt]]] = None
     output: Optional[str] = None
     parsed_output: Optional[dict] = None

--- a/tests/integration_tests/mock_llm_outputs.py
+++ b/tests/integration_tests/mock_llm_outputs.py
@@ -1,97 +1,115 @@
+from guardrails.llm_providers import (
+    AsyncOpenAICallable,
+    OpenAICallable,
+    OpenAIChatCallable,
+)
+from guardrails.utils.logs_utils import LLMResponse
+
 from .test_assets import entity_extraction, pydantic, python_rail, string
 
 
-def openai_completion_create(prompt, *args, **kwargs):
-    """Mock the OpenAI API call to Completion.create."""
-    # NOTE: this function normally overrides `llm_providers.openai_wrapper`,
-    # which compiles instructions and prompt into a single prompt
+class MockOpenAICallable(OpenAICallable):
+    # NOTE: this class normally overrides `llm_providers.OpenAICallable`,
+    # which compiles instructions and prompt into a single prompt;
     # here the instructions are passed into kwargs and ignored
+    def invoke_llm(self, prompt, *args, **kwargs):
+        """Mock the OpenAI API call to Completion.create."""
 
-    mock_llm_responses = {
-        entity_extraction.COMPILED_PROMPT: entity_extraction.LLM_OUTPUT,
-        entity_extraction.COMPILED_PROMPT_REASK: entity_extraction.LLM_OUTPUT_REASK,
-        entity_extraction.COMPILED_PROMPT_FULL_REASK: entity_extraction.LLM_OUTPUT_FULL_REASK,  # noqa: E501
-        entity_extraction.COMPILED_PROMPT_SKELETON_REASK_1: entity_extraction.LLM_OUTPUT_SKELETON_REASK_1,  # noqa: E501
-        entity_extraction.COMPILED_PROMPT_SKELETON_REASK_2: entity_extraction.LLM_OUTPUT_SKELETON_REASK_2,  # noqa: E501
-        pydantic.COMPILED_PROMPT: pydantic.LLM_OUTPUT,
-        pydantic.COMPILED_PROMPT_REASK_1: pydantic.LLM_OUTPUT_REASK_1,
-        pydantic.COMPILED_PROMPT_REASK_2: pydantic.LLM_OUTPUT_REASK_2,
-        string.COMPILED_PROMPT: string.LLM_OUTPUT,
-        string.COMPILED_PROMPT_REASK: string.LLM_OUTPUT_REASK,
-        python_rail.VALIDATOR_PARALLELISM_PROMPT_1: python_rail.VALIDATOR_PARALLELISM_RESPONSE_1,  # noqa: E501
-        python_rail.VALIDATOR_PARALLELISM_PROMPT_2: python_rail.VALIDATOR_PARALLELISM_RESPONSE_2,  # noqa: E501
-        python_rail.VALIDATOR_PARALLELISM_PROMPT_3: python_rail.VALIDATOR_PARALLELISM_RESPONSE_3,  # noqa: E501
-    }
-
-    try:
-        return {
-            "choices": [{"text": mock_llm_responses[prompt]}],
-            "usage": {
-                "prompt_tokens": 123,
-                "completion_tokens": 1234,
-            },
+        mock_llm_responses = {
+            entity_extraction.COMPILED_PROMPT: entity_extraction.LLM_OUTPUT,
+            entity_extraction.COMPILED_PROMPT_REASK: entity_extraction.LLM_OUTPUT_REASK,
+            entity_extraction.COMPILED_PROMPT_FULL_REASK: entity_extraction.LLM_OUTPUT_FULL_REASK,  # noqa: E501
+            entity_extraction.COMPILED_PROMPT_SKELETON_REASK_1: entity_extraction.LLM_OUTPUT_SKELETON_REASK_1,  # noqa: E501
+            entity_extraction.COMPILED_PROMPT_SKELETON_REASK_2: entity_extraction.LLM_OUTPUT_SKELETON_REASK_2,  # noqa: E501
+            pydantic.COMPILED_PROMPT: pydantic.LLM_OUTPUT,
+            pydantic.COMPILED_PROMPT_REASK_1: pydantic.LLM_OUTPUT_REASK_1,
+            pydantic.COMPILED_PROMPT_REASK_2: pydantic.LLM_OUTPUT_REASK_2,
+            string.COMPILED_PROMPT: string.LLM_OUTPUT,
+            string.COMPILED_PROMPT_REASK: string.LLM_OUTPUT_REASK,
+            python_rail.VALIDATOR_PARALLELISM_PROMPT_1: python_rail.VALIDATOR_PARALLELISM_RESPONSE_1,  # noqa: E501
+            python_rail.VALIDATOR_PARALLELISM_PROMPT_2: python_rail.VALIDATOR_PARALLELISM_RESPONSE_2,  # noqa: E501
+            python_rail.VALIDATOR_PARALLELISM_PROMPT_3: python_rail.VALIDATOR_PARALLELISM_RESPONSE_3,  # noqa: E501
         }
-    except KeyError:
-        print(prompt)
-        raise ValueError("Compiled prompt not found")
+
+        try:
+            return LLMResponse(
+                output=mock_llm_responses[prompt],
+                prompt_token_count=123,
+                response_token_count=1234,
+            )
+        except KeyError:
+            print(prompt)
+            raise ValueError("Compiled prompt not found")
 
 
-async def async_openai_completion_create(prompt, *args, **kwargs):
-    return openai_completion_create(prompt, *args, **kwargs)
+class MockAsyncOpenAICallable(AsyncOpenAICallable):
+    async def invoke_llm(self, prompt, *args, **kwargs):
+        sync_mock = MockOpenAICallable()
+        return sync_mock.invoke_llm(prompt, *args, **kwargs)
 
 
-def openai_chat_completion_create(
-    prompt=None, instructions=None, msg_history=None, base_model=None, *args, **kwargs
-):
-    """Mock the OpenAI API call to ChatCompletion.create."""
+class MockOpenAIChatCallable(OpenAIChatCallable):
+    def invoke_llm(
+        self,
+        prompt=None,
+        instructions=None,
+        msg_history=None,
+        base_model=None,
+        *args,
+        **kwargs
+    ):
+        """Mock the OpenAI API call to ChatCompletion.create."""
 
-    mock_llm_responses = {
-        (
-            entity_extraction.COMPILED_PROMPT_WITHOUT_INSTRUCTIONS,
-            entity_extraction.COMPILED_INSTRUCTIONS,
-        ): entity_extraction.LLM_OUTPUT,
-        (
-            entity_extraction.COMPILED_PROMPT_REASK,
-            entity_extraction.COMPILED_INSTRUCTIONS_REASK,
-        ): entity_extraction.LLM_OUTPUT_REASK,
-        (
-            python_rail.COMPILED_PROMPT_1_WITHOUT_INSTRUCTIONS,
-            python_rail.COMPILED_INSTRUCTIONS,
-        ): python_rail.LLM_OUTPUT_1_FAIL_GUARDRAILS_VALIDATION,
-        (
-            python_rail.COMPILED_PROMPT_2_WITHOUT_INSTRUCTIONS,
-            python_rail.COMPILED_INSTRUCTIONS,
-        ): python_rail.LLM_OUTPUT_2_SUCCEED_GUARDRAILS_BUT_FAIL_PYDANTIC_VALIDATION,
-        (
-            string.MSG_COMPILED_PROMPT_REASK,
-            string.MSG_COMPILED_INSTRUCTIONS_REASK,
-        ): string.MSG_LLM_OUTPUT_CORRECT,
-        (
-            pydantic.MSG_COMPILED_PROMPT_REASK,
-            pydantic.MSG_COMPILED_INSTRUCTIONS_REASK,
-        ): pydantic.MSG_HISTORY_LLM_OUTPUT_CORRECT,
-    }
-    try:
-        if prompt and instructions and not msg_history:
-            out_text = mock_llm_responses[(prompt, instructions)]
-        elif msg_history and not prompt and not instructions:
-            if msg_history == entity_extraction.COMPILED_MSG_HISTORY:
-                out_text = entity_extraction.LLM_OUTPUT
-            elif (
-                msg_history == string.MOVIE_MSG_HISTORY
-                and base_model == pydantic.WITH_MSG_HISTORY
-            ):
-                out_text = pydantic.MSG_HISTORY_LLM_OUTPUT_INCORRECT
-            elif msg_history == string.MOVIE_MSG_HISTORY:
-                out_text = string.MSG_LLM_OUTPUT_INCORRECT
+        mock_llm_responses = {
+            (
+                entity_extraction.COMPILED_PROMPT_WITHOUT_INSTRUCTIONS,
+                entity_extraction.COMPILED_INSTRUCTIONS,
+            ): entity_extraction.LLM_OUTPUT,
+            (
+                entity_extraction.COMPILED_PROMPT_REASK_WITHOUT_INSTRUCTIONS,
+                entity_extraction.COMPILED_INSTRUCTIONS_REASK,
+            ): entity_extraction.LLM_OUTPUT_REASK,
+            (
+                python_rail.COMPILED_PROMPT_1_WITHOUT_INSTRUCTIONS,
+                python_rail.COMPILED_INSTRUCTIONS,
+            ): python_rail.LLM_OUTPUT_1_FAIL_GUARDRAILS_VALIDATION,
+            (
+                python_rail.COMPILED_PROMPT_2_WITHOUT_INSTRUCTIONS,
+                python_rail.COMPILED_INSTRUCTIONS,
+            ): python_rail.LLM_OUTPUT_2_SUCCEED_GUARDRAILS_BUT_FAIL_PYDANTIC_VALIDATION,
+            (
+                string.MSG_COMPILED_PROMPT_REASK,
+                string.MSG_COMPILED_INSTRUCTIONS_REASK,
+            ): string.MSG_LLM_OUTPUT_CORRECT,
+            (
+                pydantic.MSG_COMPILED_PROMPT_REASK,
+                pydantic.MSG_COMPILED_INSTRUCTIONS_REASK,
+            ): pydantic.MSG_HISTORY_LLM_OUTPUT_CORRECT,
+        }
+
+        try:
+            if prompt and instructions and not msg_history:
+                out_text = mock_llm_responses[(prompt, instructions)]
+            elif msg_history and not prompt and not instructions:
+                if msg_history == entity_extraction.COMPILED_MSG_HISTORY:
+                    out_text = entity_extraction.LLM_OUTPUT
+                elif (
+                    msg_history == string.MOVIE_MSG_HISTORY
+                    and base_model == pydantic.WITH_MSG_HISTORY
+                ):
+                    out_text = pydantic.MSG_HISTORY_LLM_OUTPUT_INCORRECT
+                elif msg_history == string.MOVIE_MSG_HISTORY:
+                    out_text = string.MSG_LLM_OUTPUT_INCORRECT
+                else:
+                    raise ValueError("msg_history not found")
             else:
-                raise ValueError("msg_history not found")
-        return {
-            "choices": [{"text": out_text}],
-            "usage": {
-                "prompt_tokens": 123,
-                "completion_tokens": 1234,
-            },
-        }
-    except KeyError:
-        raise ValueError("Compiled prompt not found")
+                raise ValueError(
+                    "specify either prompt and instructions " "or msg_history"
+                )
+            return LLMResponse(
+                output=out_text,
+                prompt_token_count=123,
+                response_token_count=1234,
+            )
+        except KeyError:
+            raise ValueError("Compiled prompt not found")

--- a/tests/integration_tests/mock_llm_outputs.py
+++ b/tests/integration_tests/mock_llm_outputs.py
@@ -24,7 +24,13 @@ def openai_completion_create(prompt, *args, **kwargs):
     }
 
     try:
-        return mock_llm_responses[prompt]
+        return {
+            "choices": [{"text": mock_llm_responses[prompt]}],
+            "usage": {
+                "prompt_tokens": 123,
+                "completion_tokens": 1234,
+            },
+        }
     except KeyError:
         print(prompt)
         raise ValueError("Compiled prompt not found")
@@ -67,18 +73,25 @@ def openai_chat_completion_create(
     }
     try:
         if prompt and instructions and not msg_history:
-            return mock_llm_responses[(prompt, instructions)]
+            out_text = mock_llm_responses[(prompt, instructions)]
         elif msg_history and not prompt and not instructions:
             if msg_history == entity_extraction.COMPILED_MSG_HISTORY:
-                return entity_extraction.LLM_OUTPUT
+                out_text = entity_extraction.LLM_OUTPUT
             elif (
                 msg_history == string.MOVIE_MSG_HISTORY
                 and base_model == pydantic.WITH_MSG_HISTORY
             ):
-                return pydantic.MSG_HISTORY_LLM_OUTPUT_INCORRECT
+                out_text = pydantic.MSG_HISTORY_LLM_OUTPUT_INCORRECT
             elif msg_history == string.MOVIE_MSG_HISTORY:
-                return string.MSG_LLM_OUTPUT_INCORRECT
+                out_text = string.MSG_LLM_OUTPUT_INCORRECT
             else:
                 raise ValueError("msg_history not found")
+        return {
+            "choices": [{"text": out_text}],
+            "usage": {
+                "prompt_tokens": 123,
+                "completion_tokens": 1234,
+            },
+        }
     except KeyError:
         raise ValueError("Compiled prompt not found")

--- a/tests/integration_tests/test_assets/entity_extraction/__init__.py
+++ b/tests/integration_tests/test_assets/entity_extraction/__init__.py
@@ -33,18 +33,21 @@ reader = (
 
 # Compiled prompts
 COMPILED_PROMPT = reader("compiled_prompt.txt")
-COMPILED_PROMPT_REASK = reader("compiled_prompt_reask.txt")
-COMPILED_PROMPT_FULL_REASK = reader("compiled_prompt_full_reask.txt")
 COMPILED_PROMPT_WITHOUT_INSTRUCTIONS = reader(
     "compiled_prompt_without_instructions.txt"
 )
+COMPILED_PROMPT_REASK = reader("compiled_prompt_reask.txt")
+COMPILED_PROMPT_REASK_WITHOUT_INSTRUCTIONS = reader(
+    "compiled_prompt_reask_without_instructions.txt"
+)
+COMPILED_PROMPT_FULL_REASK = reader("compiled_prompt_full_reask.txt")
 COMPILED_INSTRUCTIONS = reader("compiled_instructions.txt")
 COMPILED_INSTRUCTIONS_REASK = reader("compiled_instructions_reask.txt")
 COMPILED_PROMPT_SKELETON_REASK_1 = reader("compiled_prompt_skeleton_reask_1.txt")
 COMPILED_PROMPT_SKELETON_REASK_2 = reader("compiled_prompt_skeleton_reask_2.txt")
 COMPILED_MSG_HISTORY = [
     {"role": "system", "content": COMPILED_INSTRUCTIONS},
-    {"role": "user", "content": COMPILED_PROMPT},
+    {"role": "user", "content": COMPILED_PROMPT_WITHOUT_INSTRUCTIONS},
 ]
 
 # LLM outputs
@@ -79,8 +82,9 @@ PYDANTIC_INSTRUCTIONS_CHAT_MODEL = INSTRUCTIONS_CHAT_MODEL
 
 __all__ = [
     "COMPILED_PROMPT",
-    "COMPILED_PROMPT_REASK",
     "COMPILED_PROMPT_WITHOUT_INSTRUCTIONS",
+    "COMPILED_PROMPT_REASK",
+    "COMPILED_PROMPT_REASK_WITHOUT_INSTRUCTIONS",
     "COMPILED_INSTRUCTIONS",
     "COMPILED_INSTRUCTIONS_REASK",
     "COMPILED_MSG_HISTORY",

--- a/tests/integration_tests/test_assets/entity_extraction/compiled_prompt.txt
+++ b/tests/integration_tests/test_assets/entity_extraction/compiled_prompt.txt
@@ -130,3 +130,7 @@ Given below is XML that describes the information to extract from this document 
 
 
 ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise.
+
+
+Json Output:
+

--- a/tests/integration_tests/test_assets/entity_extraction/compiled_prompt_full_reask.txt
+++ b/tests/integration_tests/test_assets/entity_extraction/compiled_prompt_full_reask.txt
@@ -111,3 +111,7 @@ Given below is XML that describes the information to extract from this document 
 
 
 ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `null`.
+
+
+Json Output:
+

--- a/tests/integration_tests/test_assets/entity_extraction/compiled_prompt_reask_without_instructions.txt
+++ b/tests/integration_tests/test_assets/entity_extraction/compiled_prompt_reask_without_instructions.txt
@@ -36,7 +36,3 @@ Given below is XML that describes the information to extract from this document 
 
 
 ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `null`.
-
-
-Json Output:
-

--- a/tests/integration_tests/test_assets/entity_extraction/compiled_prompt_skeleton_reask_1.txt
+++ b/tests/integration_tests/test_assets/entity_extraction/compiled_prompt_skeleton_reask_1.txt
@@ -130,3 +130,7 @@ Given below is XML that describes the information to extract from this document 
 
 
 ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise.
+
+
+Json Output:
+

--- a/tests/integration_tests/test_assets/entity_extraction/compiled_prompt_skeleton_reask_2.txt
+++ b/tests/integration_tests/test_assets/entity_extraction/compiled_prompt_skeleton_reask_2.txt
@@ -84,3 +84,7 @@ Given below is XML that describes the information to extract from this document 
 
 
 ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `null`.
+
+
+Json Output:
+

--- a/tests/integration_tests/test_assets/entity_extraction/optional_prompts.py
+++ b/tests/integration_tests/test_assets/entity_extraction/optional_prompts.py
@@ -37,6 +37,6 @@ OPTIONAL_MSG_HISTORY = [
     },
     {
         "role": "user",
-        "content": "\nGiven the following document, answer the following questions. If the answer doesn't exist in the document, enter 'None'.\n\n${document}\n\n${gr.xml_prefix_prompt}\n\n${output_schema}\n\n${gr.json_suffix_prompt_v2_wo_none}",
+        "content": "\nGiven the following document, answer the following questions. If the answer doesn't exist in the document, enter `null`.\n\n${document}\n\nExtract information from this document and return a JSON that follows the correct schema.\n\n${gr.xml_prefix_prompt}\n\n${output_schema}\n",
     },
 ]

--- a/tests/integration_tests/test_assets/pydantic/compiled_prompt.txt
+++ b/tests/integration_tests/test_assets/pydantic/compiled_prompt.txt
@@ -35,3 +35,7 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<string name='foo' format='two-words lower-case' />` => `{'foo': 'example one'}`
 - `<list name='bar'><string format='upper-case' /></list>` => `{"bar": ['STRING ONE', 'STRING TWO', etc.]}`
 - `<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>` => `{'baz': {'foo': 'Some String', 'index': 1}}`
+
+
+Json Output:
+

--- a/tests/integration_tests/test_assets/pydantic/compiled_prompt_reask_1.txt
+++ b/tests/integration_tests/test_assets/pydantic/compiled_prompt_reask_1.txt
@@ -28,3 +28,7 @@ Given below is XML that describes the information to extract from this document 
 
 
 ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `null`.
+
+
+Json Output:
+

--- a/tests/integration_tests/test_assets/pydantic/compiled_prompt_reask_2.txt
+++ b/tests/integration_tests/test_assets/pydantic/compiled_prompt_reask_2.txt
@@ -29,3 +29,7 @@ Given below is XML that describes the information to extract from this document 
 
 
 ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `null`.
+
+
+Json Output:
+

--- a/tests/integration_tests/test_assets/python_rail/validator_parallelism_prompt_1.txt
+++ b/tests/integration_tests/test_assets/python_rail/validator_parallelism_prompt_1.txt
@@ -14,3 +14,7 @@ Your generated response should satisfy the following properties:
 
 Don't talk; just go.
 
+
+
+String Output:
+

--- a/tests/integration_tests/test_assets/python_rail/validator_parallelism_prompt_2.txt
+++ b/tests/integration_tests/test_assets/python_rail/validator_parallelism_prompt_2.txt
@@ -21,3 +21,7 @@ Your generated response should satisfy the following properties:
 - length: min=1 max=10
 
 Don't talk; just go.
+
+
+String Output:
+

--- a/tests/integration_tests/test_assets/python_rail/validator_parallelism_prompt_3.txt
+++ b/tests/integration_tests/test_assets/python_rail/validator_parallelism_prompt_3.txt
@@ -18,3 +18,7 @@ Your generated response should satisfy the following properties:
 - length: min=1 max=10
 
 Don't talk; just go.
+
+
+String Output:
+

--- a/tests/integration_tests/test_assets/string/compiled_prompt.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt.txt
@@ -2,3 +2,7 @@
 Given the following ingredients, what would you call this pizza?
 
 tomato, cheese, sour cream
+
+
+String Output:
+

--- a/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
+++ b/tests/integration_tests/test_assets/string/compiled_prompt_reask.txt
@@ -13,3 +13,7 @@ Your generated response should satisfy the following properties:
 - two-words
 
 Don't talk; just go.
+
+
+String Output:
+

--- a/tests/integration_tests/test_async.py
+++ b/tests/integration_tests/test_async.py
@@ -3,7 +3,7 @@ import pytest
 
 import guardrails as gd
 
-from .mock_llm_outputs import async_openai_completion_create, entity_extraction
+from .mock_llm_outputs import MockAsyncOpenAICallable, entity_extraction
 from .test_guard import *  # noqa: F403, F401
 
 
@@ -12,8 +12,8 @@ from .test_guard import *  # noqa: F403, F401
 async def test_entity_extraction_with_reask(mocker, multiprocessing_validators: bool):
     """Test that the entity extraction works with re-asking."""
     mocker.patch(
-        "guardrails.llm_providers.async_openai_wrapper",
-        new=async_openai_completion_create,
+        "guardrails.llm_providers.AsyncOpenAICallable",
+        new=MockAsyncOpenAICallable,
     )
     mocker.patch(
         "guardrails.validators.Validator.run_in_separate_process",
@@ -38,9 +38,9 @@ async def test_entity_extraction_with_reask(mocker, multiprocessing_validators: 
 
     # For orginal prompt and output
     assert guard_history[0].prompt == gd.Prompt(entity_extraction.COMPILED_PROMPT)
-    assert guard_history[0].prompt_token_count == 123
-    assert guard_history[0].response_token_count == 1234
-    assert guard_history[0].output == entity_extraction.LLM_OUTPUT
+    assert guard_history[0].llm_response.prompt_token_count == 123
+    assert guard_history[0].llm_response.response_token_count == 1234
+    assert guard_history[0].llm_response.output == entity_extraction.LLM_OUTPUT
     assert (
         guard_history[0].validated_output == entity_extraction.VALIDATED_OUTPUT_REASK_1
     )

--- a/tests/integration_tests/test_async.py
+++ b/tests/integration_tests/test_async.py
@@ -38,6 +38,8 @@ async def test_entity_extraction_with_reask(mocker, multiprocessing_validators: 
 
     # For orginal prompt and output
     assert guard_history[0].prompt == gd.Prompt(entity_extraction.COMPILED_PROMPT)
+    assert guard_history[0].prompt_token_count == 123
+    assert guard_history[0].response_token_count == 1234
     assert guard_history[0].output == entity_extraction.LLM_OUTPUT
     assert (
         guard_history[0].validated_output == entity_extraction.VALIDATED_OUTPUT_REASK_1

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -11,9 +11,9 @@ from guardrails.utils.reask_utils import FieldReAsk
 from guardrails.validators import FailResult
 
 from .mock_llm_outputs import (
+    MockOpenAICallable,
+    MockOpenAIChatCallable,
     entity_extraction,
-    openai_chat_completion_create,
-    openai_completion_create,
 )
 from .test_assets import pydantic, string
 
@@ -126,9 +126,7 @@ def test_entity_extraction_with_reask(
     mocker, rail, prompt, test_full_schema_reask, multiprocessing_validators
 ):
     """Test that the entity extraction works with re-asking."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
     mocker.patch(
         "guardrails.validators.Validator.run_in_separate_process",
         new=multiprocessing_validators,
@@ -155,9 +153,9 @@ def test_entity_extraction_with_reask(
 
     # For orginal prompt and output
     assert guard_history[0].prompt == gd.Prompt(entity_extraction.COMPILED_PROMPT)
-    assert guard_history[0].prompt_token_count == 123
-    assert guard_history[0].response_token_count == 1234
-    assert guard_history[0].output == entity_extraction.LLM_OUTPUT
+    assert guard_history[0].llm_response.prompt_token_count == 123
+    assert guard_history[0].llm_response.response_token_count == 1234
+    assert guard_history[0].llm_response.output == entity_extraction.LLM_OUTPUT
     assert (
         guard_history[0].validated_output == entity_extraction.VALIDATED_OUTPUT_REASK_1
     )
@@ -189,10 +187,15 @@ def test_entity_extraction_with_reask(
             guard_history[1].prompt.source
             == entity_extraction.COMPILED_PROMPT_FULL_REASK
         )
-        assert guard_history[1].output == entity_extraction.LLM_OUTPUT_FULL_REASK
+        assert (
+            guard_history[1].llm_response.output
+            == entity_extraction.LLM_OUTPUT_FULL_REASK
+        )
     else:
         assert guard_history[1].prompt.source == entity_extraction.COMPILED_PROMPT_REASK
-        assert guard_history[1].output == entity_extraction.LLM_OUTPUT_REASK
+        assert (
+            guard_history[1].llm_response.output == entity_extraction.LLM_OUTPUT_REASK
+        )
     assert (
         guard_history[1].validated_output == entity_extraction.VALIDATED_OUTPUT_REASK_2
     )
@@ -207,9 +210,7 @@ def test_entity_extraction_with_reask(
 )
 def test_entity_extraction_with_noop(mocker, rail, prompt):
     """Test that the entity extraction works with re-asking."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     content = gd.docs_utils.read_pdf("docs/examples/data/chase_card_agreement.pdf")
     guard = guard_initializer(rail, prompt)
@@ -245,9 +246,7 @@ def test_entity_extraction_with_noop(mocker, rail, prompt):
 )
 def test_entity_extraction_with_filter(mocker, rail, prompt):
     """Test that the entity extraction works with re-asking."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     content = gd.docs_utils.read_pdf("docs/examples/data/chase_card_agreement.pdf")
     guard = guard_initializer(rail, prompt)
@@ -282,9 +281,7 @@ def test_entity_extraction_with_filter(mocker, rail, prompt):
 )
 def test_entity_extraction_with_fix(mocker, rail, prompt):
     """Test that the entity extraction works with re-asking."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     content = gd.docs_utils.read_pdf("docs/examples/data/chase_card_agreement.pdf")
     guard = guard_initializer(rail, prompt)
@@ -320,9 +317,7 @@ def test_entity_extraction_with_fix(mocker, rail, prompt):
 )
 def test_entity_extraction_with_refrain(mocker, rail, prompt):
     """Test that the entity extraction works with re-asking."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     content = gd.docs_utils.read_pdf("docs/examples/data/chase_card_agreement.pdf")
     guard = guard_initializer(rail, prompt)
@@ -363,8 +358,8 @@ def test_entity_extraction_with_fix_chat_models(mocker, rail, prompt, instructio
     """Test that the entity extraction works with fix for chat models."""
 
     mocker.patch(
-        "guardrails.llm_providers.openai_chat_wrapper",
-        new=openai_chat_completion_create,
+        "guardrails.llm_providers.OpenAIChatCallable",
+        new=MockOpenAIChatCallable,
     )
 
     content = gd.docs_utils.read_pdf("docs/examples/data/chase_card_agreement.pdf")
@@ -396,9 +391,7 @@ def test_entity_extraction_with_fix_chat_models(mocker, rail, prompt, instructio
 
 def test_string_output(mocker):
     """Test single string (non-JSON) generation."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     guard = gd.Guard.from_rail_string(string.RAIL_SPEC_FOR_STRING)
     _, final_output = guard(
@@ -421,9 +414,7 @@ def test_string_output(mocker):
 
 def test_string_reask(mocker):
     """Test single string (non-JSON) generation with re-asking."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     guard = gd.Guard.from_rail_string(string.RAIL_SPEC_FOR_STRING_REASK)
     _, final_output = guard(
@@ -455,9 +446,7 @@ def test_string_reask(mocker):
 
 
 def test_skeleton_reask(mocker):
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     content = gd.docs_utils.read_pdf("docs/examples/data/chase_card_agreement.pdf")
     guard = gd.Guard.from_rail_string(entity_extraction.RAIL_SPEC_WITH_SKELETON_REASK)
@@ -520,7 +509,7 @@ def test_skeleton_reask(mocker):
             openai.ChatCompletion.create,
             entity_extraction.COMPILED_PROMPT_WITHOUT_INSTRUCTIONS,
             entity_extraction.COMPILED_INSTRUCTIONS,
-            entity_extraction.COMPILED_PROMPT_REASK,
+            entity_extraction.COMPILED_PROMPT_REASK_WITHOUT_INSTRUCTIONS,
             entity_extraction.COMPILED_INSTRUCTIONS_REASK,
         ),
         (
@@ -530,8 +519,10 @@ def test_skeleton_reask(mocker):
             entity_extraction.OPTIONAL_MSG_HISTORY,
             openai.ChatCompletion.create,
             None,
-            None,
-            entity_extraction.COMPILED_PROMPT_REASK,
+            "You are a helpful assistant, "
+            "able to express yourself purely through JSON, "
+            "strictly and precisely adhering to the provided XML schemas.",
+            entity_extraction.COMPILED_PROMPT_REASK_WITHOUT_INSTRUCTIONS,
             entity_extraction.COMPILED_INSTRUCTIONS_REASK,
         ),
     ],
@@ -550,13 +541,11 @@ def test_entity_extraction_with_reask_with_optional_prompts(
 ):
     """Test that the entity extraction works with re-asking."""
     if llm_api == openai.Completion.create:
-        mocker.patch(
-            "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-        )
+        mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
     else:
         mocker.patch(
-            "guardrails.llm_providers.openai_chat_wrapper",
-            new=openai_chat_completion_create,
+            "guardrails.llm_providers.OpenAIChatCallable",
+            new=MockOpenAIChatCallable,
         )
 
     content = gd.docs_utils.read_pdf("docs/examples/data/chase_card_agreement.pdf")
@@ -632,8 +621,8 @@ def test_string_with_message_history_reask(mocker):
     """Test single string (non-JSON) generation with message history and
     reask."""
     mocker.patch(
-        "guardrails.llm_providers.openai_chat_wrapper",
-        new=openai_chat_completion_create,
+        "guardrails.llm_providers.OpenAIChatCallable",
+        new=MockOpenAIChatCallable,
     )
 
     guard = gd.Guard.from_rail_string(string.RAIL_SPEC_FOR_MSG_HISTORY)
@@ -651,7 +640,10 @@ def test_string_with_message_history_reask(mocker):
     # Check that the guard state object has the correct number of re-asks.
     assert len(guard_history) == 2
 
-    assert guard_history[0].instructions is None
+    assert (
+        guard_history[0].instructions.source == "You are a helpful assistant, "
+        "expressing yourself through a string."
+    )
     assert guard_history[0].prompt is None
     assert guard_history[0].output == string.MSG_LLM_OUTPUT_INCORRECT
     assert guard_history[0].validated_output == string.MSG_VALIDATED_OUTPUT_REASK
@@ -668,8 +660,8 @@ def test_string_with_message_history_reask(mocker):
 def test_pydantic_with_message_history_reask(mocker):
     """Test JSON generation with message history re-asking."""
     mocker.patch(
-        "guardrails.llm_providers.openai_chat_wrapper",
-        new=openai_chat_completion_create,
+        "guardrails.llm_providers.OpenAIChatCallable",
+        new=MockOpenAIChatCallable,
     )
 
     guard = gd.Guard.from_pydantic(output_class=pydantic.WITH_MSG_HISTORY)
@@ -688,7 +680,11 @@ def test_pydantic_with_message_history_reask(mocker):
     # Check that the guard state object has the correct number of re-asks.
     assert len(guard_history) == 2
 
-    assert guard_history[0].instructions is None
+    assert (
+        guard_history[0].instructions.source == "You are a helpful assistant, "
+        "able to express yourself purely through JSON, "
+        "strictly and precisely adhering to the provided XML schemas."
+    )
     assert guard_history[0].prompt is None
     assert guard_history[0].output == pydantic.MSG_HISTORY_LLM_OUTPUT_INCORRECT
     assert guard_history[0].validated_output == pydantic.MSG_VALIDATED_OUTPUT_REASK

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -155,6 +155,8 @@ def test_entity_extraction_with_reask(
 
     # For orginal prompt and output
     assert guard_history[0].prompt == gd.Prompt(entity_extraction.COMPILED_PROMPT)
+    assert guard_history[0].prompt_token_count == 123
+    assert guard_history[0].response_token_count == 1234
     assert guard_history[0].output == entity_extraction.LLM_OUTPUT
     assert (
         guard_history[0].validated_output == entity_extraction.VALIDATED_OUTPUT_REASK_1

--- a/tests/integration_tests/test_multi_reask.py
+++ b/tests/integration_tests/test_multi_reask.py
@@ -2,15 +2,13 @@ import openai
 
 import guardrails as gd
 
-from .mock_llm_outputs import openai_completion_create
+from .mock_llm_outputs import MockOpenAICallable
 from .test_assets import python_rail
 
 
 def test_multi_reask(mocker):
     """Test that parallel reasking works."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     guard = gd.Guard.from_rail_string(python_rail.RAIL_SPEC_WITH_VALIDATOR_PARALLELISM)
 

--- a/tests/integration_tests/test_pydantic.py
+++ b/tests/integration_tests/test_pydantic.py
@@ -2,15 +2,13 @@ import openai
 
 import guardrails as gd
 
-from .mock_llm_outputs import openai_completion_create, pydantic
+from .mock_llm_outputs import MockOpenAICallable, pydantic
 from .test_assets.pydantic import VALIDATED_RESPONSE_REASK_PROMPT, ListOfPeople
 
 
 def test_pydantic_with_reask(mocker):
     """Test that the entity extraction works with re-asking."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     guard = gd.Guard.from_pydantic(ListOfPeople, prompt=VALIDATED_RESPONSE_REASK_PROMPT)
     _, final_output = guard(

--- a/tests/integration_tests/test_python_rail.py
+++ b/tests/integration_tests/test_python_rail.py
@@ -18,7 +18,7 @@ from guardrails.validators import (
     register_validator,
 )
 
-from .mock_llm_outputs import openai_chat_completion_create, openai_completion_create
+from .mock_llm_outputs import MockOpenAICallable, MockOpenAIChatCallable
 from .test_assets import python_rail, string
 
 
@@ -42,8 +42,8 @@ class IsValidDirector(Validator):
 
 def test_python_rail(mocker):
     mocker.patch(
-        "guardrails.llm_providers.openai_chat_wrapper",
-        new=openai_chat_completion_create,
+        "guardrails.llm_providers.OpenAIChatCallable",
+        new=MockOpenAIChatCallable,
     )
 
     class BoxOfficeRevenue(BaseModel):
@@ -155,8 +155,8 @@ def test_python_rail(mocker):
 
 def test_python_rail_add_validator(mocker):
     mocker.patch(
-        "guardrails.llm_providers.openai_chat_wrapper",
-        new=openai_chat_completion_create,
+        "guardrails.llm_providers.OpenAIChatCallable",
+        new=MockOpenAIChatCallable,
     )
 
     class BoxOfficeRevenue(BaseModel):
@@ -276,9 +276,7 @@ def test_python_rail_add_validator(mocker):
 
 def test_python_string(mocker):
     """Test single string (non-JSON) generation via pydantic with re-asking."""
-    mocker.patch(
-        "guardrails.llm_providers.openai_wrapper", new=openai_completion_create
-    )
+    mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
 
     validators = [TwoWords(on_fail="reask")]
     description = "Name for the pizza"


### PR DESCRIPTION
Based on https://github.com/ShreyaR/guardrails/pull/286, merge that first.

This PR refactors the LLM callable wrappers to subclasses instead of function wrappers, and defines an `LLMResponse` object that allows returning tracking for the number of tokens used (implemented in openai).

Still requires testing and refactoring all the test mocks to the new structure.