### PR TITLE
Num reask default

### DIFF
--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -385,7 +385,6 @@ class Guard:
         Returns:
             The validated response.
         """
-        # #TODO: num_reasks = num_reasks or self.num_reasks or 0
         num_reasks = (
             num_reasks if num_reasks is not None else 0 if llm_api is None else None
         )

--- a/tests/unit_tests/test_assets/empty.rail
+++ b/tests/unit_tests/test_assets/empty.rail
@@ -1,0 +1,6 @@
+<rail version="0.1">
+<output
+    type="string"
+    description="empty railspec"
+/>
+</rail>


### PR DESCRIPTION
This PR:
* Standardizes the defaulting of `num_reasks` and pushes most of that logic to `Guard.configure`.  This way, regardless of how a Guard is instantiated, the `num_reasks` property will be set consistently.
* Allows users to override/re-set `num_reasks` when calling `__call__` or `parse`
* Defaults `num_reasks` to zero when parse is called without an `llm_api`

Addresses https://github.com/ShreyaR/guardrails/issues/282
Makes https://github.com/ShreyaR/guardrails/pull/260 obsolete