### PR TITLE
Fix OpenAI Chat Callable

### DIFF
--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -200,8 +200,8 @@ class OpenAIChatCallable(PromptCallableBase):
 
         return LLMResponse(
             output=output,
-            prompt_token_count=openai_response["choices"][0]["tokens"],
-            response_token_count=openai_response["choices"][0]["tokens"],
+            prompt_token_count=openai_response["usage"]["prompt_tokens"],
+            response_token_count=openai_response["usage"]["completion_tokens"],
         )
 
 
@@ -446,8 +446,8 @@ class AsyncOpenAIChatCallable(AsyncPromptCallableBase):
 
         return LLMResponse(
             output=output,
-            prompt_token_count=openai_response["choices"][0]["tokens"],
-            response_token_count=openai_response["choices"][0]["tokens"],
+            prompt_token_count=openai_response["usage"]["prompt_tokens"],
+            response_token_count=openai_response["usage"]["completion_tokens"],
         )
 
 

--- a/tests/unit_tests/test_llm_providers.py
+++ b/tests/unit_tests/test_llm_providers.py
@@ -107,16 +107,13 @@ def openai_chat_mock():
     return {
         "choices": [
             {
-                "message": {
-                    "content": "Mocked LLM output"
-                },
+                "message": {"content": "Mocked LLM output"},
             }
         ],
-        "usage":
-            {
-                "prompt_tokens": 10,
-                "completion_tokens": 20,
-            }
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+        },
     }
 
 
@@ -128,21 +125,18 @@ def openai_mock():
                 "text": "Mocked LLM output",
             }
         ],
-        "usage":
-            {
-                "prompt_tokens": 10,
-                "completion_tokens": 20,
-            }
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+        },
     }
 
 
 def test_openai_callable(mocker, openai_mock):
-    mocker.patch(
-        "openai.Completion.create",
-        return_value=openai_mock
-    )
+    mocker.patch("openai.Completion.create", return_value=openai_mock)
 
     from guardrails.llm_providers import OpenAICallable
+
     openai_callable = OpenAICallable()
     response = openai_callable(text="Hello")
 
@@ -154,12 +148,10 @@ def test_openai_callable(mocker, openai_mock):
 
 @pytest.mark.asyncio
 async def test_async_openai_callable(mocker, openai_mock):
-    mocker.patch(
-        "openai.Completion.acreate",
-        return_value=openai_mock
-    )
+    mocker.patch("openai.Completion.acreate", return_value=openai_mock)
 
     from guardrails.llm_providers import AsyncOpenAICallable
+
     openai_callable = AsyncOpenAICallable()
     response = await openai_callable(text="Hello")
 
@@ -170,12 +162,10 @@ async def test_async_openai_callable(mocker, openai_mock):
 
 
 def test_openai_chat_callable(mocker, openai_chat_mock):
-    mocker.patch(
-        "openai.ChatCompletion.create",
-        return_value=openai_chat_mock
-    )
+    mocker.patch("openai.ChatCompletion.create", return_value=openai_chat_mock)
 
     from guardrails.llm_providers import OpenAIChatCallable
+
     openai_chat_callable = OpenAIChatCallable()
     response = openai_chat_callable(text="Hello")
 
@@ -187,12 +177,10 @@ def test_openai_chat_callable(mocker, openai_chat_mock):
 
 @pytest.mark.asyncio
 async def test_async_openai_chat_callable(mocker, openai_chat_mock):
-    mocker.patch(
-        "openai.ChatCompletion.acreate",
-        return_value=openai_chat_mock
-    )
+    mocker.patch("openai.ChatCompletion.acreate", return_value=openai_chat_mock)
 
     from guardrails.llm_providers import AsyncOpenAIChatCallable
+
     openai_chat_callable = AsyncOpenAIChatCallable()
     response = await openai_chat_callable(text="Hello")
 

--- a/tests/unit_tests/test_llm_providers.py
+++ b/tests/unit_tests/test_llm_providers.py
@@ -100,3 +100,103 @@ async def test_async_arbitrary_callable_does_not_retry_on_success(mocker):
     assert response.output == "Hello world!"
     assert response.prompt_token_count is None
     assert response.response_token_count is None
+
+
+@pytest.fixture(scope="module")
+def openai_chat_mock():
+    return {
+        "choices": [
+            {
+                "message": {
+                    "content": "Mocked LLM output"
+                },
+            }
+        ],
+        "usage":
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+            }
+    }
+
+
+@pytest.fixture(scope="module")
+def openai_mock():
+    return {
+        "choices": [
+            {
+                "text": "Mocked LLM output",
+            }
+        ],
+        "usage":
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+            }
+    }
+
+
+def test_openai_callable(mocker, openai_mock):
+    mocker.patch(
+        "openai.Completion.create",
+        return_value=openai_mock
+    )
+
+    from guardrails.llm_providers import OpenAICallable
+    openai_callable = OpenAICallable()
+    response = openai_callable(text="Hello")
+
+    assert isinstance(response, LLMResponse) is True
+    assert response.output == "Mocked LLM output"
+    assert response.prompt_token_count == 10
+    assert response.response_token_count == 20
+
+
+@pytest.mark.asyncio
+async def test_async_openai_callable(mocker, openai_mock):
+    mocker.patch(
+        "openai.Completion.acreate",
+        return_value=openai_mock
+    )
+
+    from guardrails.llm_providers import AsyncOpenAICallable
+    openai_callable = AsyncOpenAICallable()
+    response = await openai_callable(text="Hello")
+
+    assert isinstance(response, LLMResponse) is True
+    assert response.output == "Mocked LLM output"
+    assert response.prompt_token_count == 10
+    assert response.response_token_count == 20
+
+
+def test_openai_chat_callable(mocker, openai_chat_mock):
+    mocker.patch(
+        "openai.ChatCompletion.create",
+        return_value=openai_chat_mock
+    )
+
+    from guardrails.llm_providers import OpenAIChatCallable
+    openai_chat_callable = OpenAIChatCallable()
+    response = openai_chat_callable(text="Hello")
+
+    assert isinstance(response, LLMResponse) is True
+    assert response.output == "Mocked LLM output"
+    assert response.prompt_token_count == 10
+    assert response.response_token_count == 20
+
+
+@pytest.mark.asyncio
+async def test_async_openai_chat_callable(mocker, openai_chat_mock):
+    mocker.patch(
+        "openai.ChatCompletion.acreate",
+        return_value=openai_chat_mock
+    )
+
+    from guardrails.llm_providers import AsyncOpenAIChatCallable
+    openai_chat_callable = AsyncOpenAIChatCallable()
+    response = await openai_chat_callable(text="Hello")
+
+    assert isinstance(response, LLMResponse) is True
+    assert response.output == "Mocked LLM output"
+    assert response.prompt_token_count == 10
+    assert response.response_token_count == 20


### PR DESCRIPTION
Fix #324 

It was erroring on OpenAI Chat models due to an incorrect path to the token counts being specified.

Also added unit tests for OpenAI callables to prevent this in the future.