### PR TITLE
Fix async validators multithreading

### DIFF
--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -337,10 +337,6 @@ def validate(
     elif loop is not None and not loop.is_running():
         validator_service = AsyncValidatorService()
     else:
-        logger.warning(
-            "Async event loop found, but guard was invoked synchronously."
-            "For validator parallelization, please call `validate_async` instead."
-        )
         validator_service = SequentialValidatorService()
     return validator_service.validate(
         value,

--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -319,7 +319,12 @@ def validate(
     validation_logs: FieldValidationLogs,
 ):
     process_count = int(os.environ.get("GUARDRAILS_PROCESS_COUNT", 10))
-    loop = asyncio.get_event_loop()
+
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = None
+
     if process_count == 1:
         logger.warning(
             "Process count was set to 1 via the GUARDRAILS_PROCESS_COUNT"
@@ -329,14 +334,14 @@ def validate(
             "greater than 1 or unset this environment variable."
         )
         validator_service = SequentialValidatorService()
-    elif loop.is_running():
+    elif loop is not None and not loop.is_running():
+        validator_service = AsyncValidatorService()
+    else:
         logger.warning(
             "Async event loop found, but guard was invoked synchronously."
             "For validator parallelization, please call `validate_async` instead."
         )
         validator_service = SequentialValidatorService()
-    else:
-        validator_service = AsyncValidatorService()
     return validator_service.validate(
         value,
         metadata,

--- a/tests/unit_tests/test_validator_service.py
+++ b/tests/unit_tests/test_validator_service.py
@@ -41,8 +41,6 @@ def test_validate_with_running_loop(mocker):
     )
     mocker.patch("asyncio.get_event_loop", return_value=mockLoop)
 
-    warn_spy = mocker.spy(vs.logger, "warning")
-
     validated_value, validated_metadata = vs.validate(
         value=True,
         metadata={},
@@ -50,10 +48,6 @@ def test_validate_with_running_loop(mocker):
         validation_logs=empty_field_validation_logs,
     )
 
-    assert warn_spy.call_count == 1
-    warn_spy.assert_called_with(
-        "Async event loop found, but guard was invoked synchronously.For validator parallelization, please call `validate_async` instead."  # noqa
-    )
     assert validated_value == "MockSequentialValidatorService.validate"
     assert validated_metadata == {"sync": True}
 

--- a/tests/unit_tests/test_validator_service.py
+++ b/tests/unit_tests/test_validator_service.py
@@ -72,3 +72,26 @@ def test_validate_without_running_loop(mocker):
 
     assert validated_value == "MockAsyncValidatorService.validate"
     assert validated_metadata == {"sync": True}
+
+
+def test_validate_loop_runtime_error(mocker):
+    mocker.patch(
+        "guardrails.validator_service.AsyncValidatorService",
+        new=MockAsyncValidatorService,
+    )
+    mocker.patch(
+        "guardrails.validator_service.SequentialValidatorService",
+        new=MockSequentialValidatorService,
+    )
+    # raise RuntimeError in `get_event_loop`
+    mocker.patch("asyncio.get_event_loop", side_effect=RuntimeError)
+
+    validated_value, validated_metadata = vs.validate(
+        value=True,
+        metadata={},
+        validator_setup=empty_field_validation,
+        validation_logs=empty_field_validation_logs,
+    )
+
+    assert validated_value == "MockSequentialValidatorService.validate"
+    assert validated_metadata == {"sync": True}


### PR DESCRIPTION
Fix #332, resolve #294

When invoking guardrails from within a thread, `get_event_loop` throws a `RuntimeError`. Instead of instantiating an async event loop and parallelizing guards, in this case, let's just run them sequentially.

Also drops the warning for when guards are invoked synchronously in an async context (such as jupyter notebook).