### PR TITLE
Regex validator

### DIFF
--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -10,14 +10,15 @@ import itertools
 import logging
 import os
 import re
+import string
 import warnings
 from collections import defaultdict
 from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
-import rstr
-import string
+
 import openai
 import pydantic
+import rstr
 from pydantic import Field
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
@@ -571,9 +572,10 @@ class ValidLength(Validator):
 
         return PassResult()
 
+
 @register_validator(name="regex_match", data_type="string")
 class RegexMatch(Validator):
-    """Validates that a value matches a regualr expression
+    """Validates that a value matches a regualr expression.
 
     **Key Properties**
 
@@ -582,29 +584,31 @@ class RegexMatch(Validator):
     | Name for `format` attribute   | `regex_match`                       |
     | Supported data types          | `string`                          |
     | Programmatic fix              | Generate a string that matches the regular expression        |
+
+    Parameters: Arguments
+        regex: Str regex pattern
+        match_type: Str in {"search", "fullmatch"} for a regex search or full-match option
     """
-    def __init__(
-        self,
-        regex: str,
-        match_type: str,
-        on_fail: Optional[Callable] = None
-    ):
+
+    def __init__(self, regex: str, match_type: str, on_fail: Optional[Callable] = None):
         super().__init__(on_fail=on_fail, match_type=match_type, regex=regex)
         match_types = ["fullmatch", "search"]
         assert match_type in match_types, f"match_type must be in {match_types}"
         self._regex = regex
         self._p = re.compile(regex)
         self._match_f = getattr(self._p, match_type)
-        #Pad matchign string on either side for fix example if we are performing a regex search
-        str_padding = "" if match_type == "fullmatch" else rstr.rstr(string.ascii_lowercase)
+        # Pad matchign string on either side for fix example if we are performing a regex search
+        str_padding = (
+            "" if match_type == "fullmatch" else rstr.rstr(string.ascii_lowercase)
+        )
         self._fix_str = str_padding + rstr.xeger(regex) + str_padding
 
     def validate(self, value: Any, metadata: Dict) -> ValidationResult:
         """Validates that value matches the provided regular expression."""
         if not self._match_f(value):
             return FailResult(
-                error_message=f"Result must exactly match {self._regex}",
-                fix_value=self._fix_str
+                error_message=f"Result must match {self._regex}",
+                fix_value=self._fix_str,
             )
         return PassResult()
 

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -583,7 +583,7 @@ class RegexMatch(Validator):
         self._p = re.compile(regex)
 
     def validate(self, value: Any, metadata: Dict) -> ValidationResult:
-        """Validates that the length of value is within the expected range."""
+        """Validates that value matches the provided regular expression."""
         if not self._p.match(value):
             return FailResult(
                 error_message=f"Result must match {self._regex}",

--- a/guardrails/validators.py
+++ b/guardrails/validators.py
@@ -14,7 +14,7 @@ import warnings
 from collections import defaultdict
 from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
-
+import rstr
 import openai
 import pydantic
 from pydantic import Field
@@ -568,6 +568,27 @@ class ValidLength(Validator):
                 fix_value=value[: self._max],
             )
 
+        return PassResult()
+
+@register_validator(name="regex_match", data_type="string")
+class RegexMatch(Validator):
+    """
+    """  # noqa
+
+    def __init__(
+        self, regex: str, on_fail: Optional[Callable] = None
+    ):
+        super().__init__(on_fail=on_fail, regex=regex)
+        self._regex = regex
+        self._p = re.compile(regex)
+
+    def validate(self, value: Any, metadata: Dict) -> ValidationResult:
+        """Validates that the length of value is within the expected range."""
+        if not self._p.match(value):
+            return FailResult(
+                error_message=f"Result must match {self._regex}",
+                fix_value=rstr.xeger(self._regex)
+            )
         return PassResult()
 
 

--- a/tests/unit_tests/validators/test_regex_match.py
+++ b/tests/unit_tests/validators/test_regex_match.py
@@ -1,0 +1,31 @@
+import pytest
+import re
+from guardrails.validators import RegexMatch, FailResult, PassResult
+
+class TestRegexMatchLValidator:
+    regex = """\w+\d\w+"""
+    p = re.compile(regex)
+    fullmatch_val = RegexMatch(regex=regex, match_type="fullmatch", on_fail="reask")
+    search_val = RegexMatch(regex=regex, match_type="search", on_fail="reask")
+
+    def test_fullmatch_fail(self):
+        bad_str = "abcdef"
+        result = self.fullmatch_val.validate(bad_str, {})
+        assert isinstance(result, FailResult)
+        assert result.error_message != ""
+
+    def test_fullmatch_pass(self):
+        good_str = "ab1cd"
+        result = self.fullmatch_val.validate(good_str, {})
+        assert isinstance(result, PassResult)
+
+    def test_search_fail(self):
+        bad_str = "abcdef"
+        result = self.search_val.validate(bad_str, {})
+        assert isinstance(result, FailResult)
+        assert result.error_message != ""
+
+    def test_search_pass(self):
+        good_str = "1234ab1cd5678"
+        result = self.search_val.validate(good_str, {})
+        assert isinstance(result, PassResult)


### PR DESCRIPTION
`RegexMatch` Validator class to validate that an LLM output matches a regex

Supports:
- regex search
- regex full-match
- re-ask attempts using a string generated with provided regex

Tests in `tests/unit_tests/validators/test_regex_match.py`

I wasn't quite clear on the requirements for the prompt suffix! Pls provide more detail if possible.

Will be out on leave from the 21st until the 28th, let me know what feedback you have and I will happily incorporate when I'm back! 