### PR TITLE
Remove default expand in nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,6 @@ theme:
   features:
     - navigation.instant
     - navigation.tracking
-    - navigation.expand
     # - navigation.sections
     - content.code.annotate
     - toc.follow


### PR DESCRIPTION
To address https://github.com/ShreyaR/guardrails/issues/372

The problem was that mkdocs offers the `navigation.expand` feature to expand all categories in the side-nav by default. That also has the side effect of apparently expanding all items when a single item is clicked. 

Before:
<img width="1440" alt="image" src="https://github.com/ShreyaR/guardrails/assets/6458766/02cab64e-fc4c-4bd9-ba99-bab7b14dc37d">


After:
<img width="1440" alt="image" src="https://github.com/ShreyaR/guardrails/assets/6458766/30a2873c-8da6-4040-9077-c9b9b1b6c117">
