### PR TITLE
use datetime parser to deal with unspecified datetimes

### DIFF
--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -2,13 +2,13 @@ import datetime
 import logging
 import warnings
 from dataclasses import dataclass
-from dateutil.parser import *
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable
 from typing import List
 from typing import List as TypedList
 from typing import Tuple, Type, Union
 
+from dateutil.parser import parse
 from lxml import etree as ET
 from pydantic import BaseModel
 

--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import warnings
 from dataclasses import dataclass
+from dateutil.parser import *
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable
 from typing import List
@@ -244,14 +245,15 @@ class Date(ScalarType):
     def __init__(
         self, children: Dict[str, Any], format_attr: "FormatAttr", element: ET._Element
     ) -> None:
-        self.date_format = "%Y-%m-%d"
+        self.date_format = None
         super().__init__(children, format_attr, element)
 
     def from_str(self, s: str) -> "Date":
         """Create a Date from a string."""
         if s is None:
             return None
-
+        if self.date_format is None:
+            return parse(s).date()
         return datetime.datetime.strptime(s, self.date_format).date()
 
     @classmethod

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -400,14 +400,15 @@ class Guard:
     ) -> Union[str, Dict, Awaitable[str], Awaitable[Dict]]:
         """Alternate flow to using Guard where the llm_output is known.
 
-        Args:
-            llm_api: The LLM API to call
-                     (e.g. openai.Completion.create or openai.Completion.acreate)
-            num_reasks: The max times to re-ask the LLM for invalid output.
+                Args:
+                    llm_api: The LLM API to call
+                             (e.g. openai.Completion.create or
+                             openai.Completion.acreate)
+                    num_reasks: The max times to re-ask the LLM for invalid output.
 
-        Returns:
-            The validated response. This is either a string or a dictionary, \
-determined by the object schema defined in the RAILspec.
+                Returns:
+                    The validated response. This is either a string or a dictionary, \
+        determined by the object schema defined in the RAILspec.
         """
         num_reasks = (
             num_reasks if num_reasks is not None else 0 if llm_api is None else None

--- a/tests/integration_tests/test_datatypes.py
+++ b/tests/integration_tests/test_datatypes.py
@@ -1,0 +1,62 @@
+from guardrails.guard import Guard
+
+
+def test_passed_date_format():
+    rail_spec = """
+<rail version="0.1">
+
+<output>
+    <string name="name"/>
+    <date name="dob" date-format="%Y-%m-%d"/>
+</output>
+
+
+<prompt>
+Dummy prompt.
+</prompt>
+
+</rail>
+"""
+
+    guard = Guard.from_rail_string(rail_spec)
+    guard.parse(llm_output='{"name": "John Doe", "dob": "2021-01-01"}', num_reasks=0)
+
+def test_defaulted_date_parser():
+    rail_spec = """
+<rail version="0.1">
+
+<output>
+    <string name="name"/>
+    <date name="dob"/>
+</output>
+
+
+<prompt>
+Dummy prompt.
+</prompt>
+
+</rail>
+"""
+
+    guard = Guard.from_rail_string(rail_spec)
+    guard.parse(llm_output='{"name": "John Doe", "dob": "2021-01-01"}', num_reasks=0)
+
+def test_defaulted_date_parser_cohere_style_datestring():
+    rail_spec = """
+<rail version="0.1">
+
+<output>
+    <string name="name"/>
+    <date name="dob"/>
+</output>
+
+
+<prompt>
+Dummy prompt.
+</prompt>
+
+</rail>
+"""
+
+    guard = Guard.from_rail_string(rail_spec)
+    guard.parse(llm_output='{"name": "John Doe", "dob": "2021-01-01T11:10:00+01:00"}', num_reasks=0)

--- a/tests/integration_tests/test_datatypes.py
+++ b/tests/integration_tests/test_datatypes.py
@@ -21,6 +21,7 @@ Dummy prompt.
     guard = Guard.from_rail_string(rail_spec)
     guard.parse(llm_output='{"name": "John Doe", "dob": "2021-01-01"}', num_reasks=0)
 
+
 def test_defaulted_date_parser():
     rail_spec = """
 <rail version="0.1">
@@ -41,6 +42,7 @@ Dummy prompt.
     guard = Guard.from_rail_string(rail_spec)
     guard.parse(llm_output='{"name": "John Doe", "dob": "2021-01-01"}', num_reasks=0)
 
+
 def test_defaulted_date_parser_cohere_style_datestring():
     rail_spec = """
 <rail version="0.1">
@@ -59,4 +61,7 @@ Dummy prompt.
 """
 
     guard = Guard.from_rail_string(rail_spec)
-    guard.parse(llm_output='{"name": "John Doe", "dob": "2021-01-01T11:10:00+01:00"}', num_reasks=0)
+    guard.parse(
+        llm_output='{"name": "John Doe", "dob": "2021-01-01T11:10:00+01:00"}',
+        num_reasks=0,
+    )

--- a/tests/integration_tests/test_datatypes.py
+++ b/tests/integration_tests/test_datatypes.py
@@ -1,3 +1,5 @@
+import pytest
+
 from guardrails.guard import Guard
 
 
@@ -22,7 +24,15 @@ Dummy prompt.
     guard.parse(llm_output='{"name": "John Doe", "dob": "2021-01-01"}', num_reasks=0)
 
 
-def test_defaulted_date_parser():
+@pytest.mark.parametrize(
+    "date_string",
+    [
+        ("2021-01-01"),  # standard date
+        ("2021-01-01T11:10:00+01:00"),  # Cohere-style
+        ("2023-10-03T14:18:38.476Z"),  # ISO
+    ],
+)
+def test_defaulted_date_parser(date_string: str):
     rail_spec = """
 <rail version="0.1">
 
@@ -40,28 +50,39 @@ Dummy prompt.
 """
 
     guard = Guard.from_rail_string(rail_spec)
-    guard.parse(llm_output='{"name": "John Doe", "dob": "2021-01-01"}', num_reasks=0)
-
-
-def test_defaulted_date_parser_cohere_style_datestring():
-    rail_spec = """
-<rail version="0.1">
-
-<output>
-    <string name="name"/>
-    <date name="dob"/>
-</output>
-
-
-<prompt>
-Dummy prompt.
-</prompt>
-
-</rail>
-"""
-
-    guard = Guard.from_rail_string(rail_spec)
+    # This should not raise an exception
     guard.parse(
-        llm_output='{"name": "John Doe", "dob": "2021-01-01T11:10:00+01:00"}',
-        num_reasks=0,
+        llm_output='{"name": "John Doe", "dob": "' + date_string + '"}', num_reasks=0
     )
+
+
+@pytest.mark.parametrize(
+    "date_string",
+    [
+        ("1696343743"),  # Unix timestamp/seconds
+        ("1697579939213"),  # Unix timestamp/milliseconds
+    ],
+)
+def test_defaulted_date_parser_unsupported_values(date_string: str):
+    rail_spec = """
+<rail version="0.1">
+
+<output>
+    <string name="name"/>
+    <date name="dob"/>
+</output>
+
+
+<prompt>
+Dummy prompt.
+</prompt>
+
+</rail>
+"""
+    guard = Guard.from_rail_string(rail_spec)
+    # this should always raise either a ValueError or an OverflowError
+    with pytest.raises((ValueError, OverflowError)):
+        guard.parse(
+            llm_output='{"name": "John Doe", "dob": "' + date_string + '"}',
+            num_reasks=0,
+        )


### PR DESCRIPTION
The default behavior here was sometimes difficult to use because we had to specify datestring formats, and we would use a standard Y-M-D format if it wasn't specified. This was quite brittle. The new behavior uses a [generic library](https://labix.org/python-dateutil) to infer the datestring's format and convert it to a date. This behavior can still be overridden by providing the `date-format` property to the railspec, which will have the validator continue to use the provided datestring format.