### PR TITLE
Miscellaneous typo, type annotation and docs fixes

### DIFF
--- a/docs/concepts/instructions.md
+++ b/docs/concepts/instructions.md
@@ -2,9 +2,9 @@
 
 The `<instructions></instructions>` element contains the high level instructions sent to the LLM (e.g. the system message for chat models).
 
-## 📚 Components of a Prompt
+## 📚 Components of an Instructions Element
 
-In addition to the high level task description, the prompt also contains the following:
+In addition to the high level task description, the instructions element also contains the following:
 
 | Component         | Syntax                   | Description                                                                                                                                                                                                                                                                                                                             |
 |-------------------|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -14,17 +14,17 @@ In addition to the high level task description, the prompt also contains the fol
 
 ```xml
 <rail version="0.1">
-<prompt>
+<instructions>
 <!-- (1)! -->
 You are a helpful assistant only capable of communicating with valid JSON, and no other text.
 
 ${gr.json_suffix_prompt_examples}  <!-- (2)! -->
-</prompt>
+</instructions>
 </rail>
 ```
 
 
-1. The prompt contains high level task information.
+1. The instructions element contains high level task information.
 2. `${gr.json_suffix_prompt_examples}` is a prompt primitive provided by guardrails. It is equivalent to typing the following lines in the prompt: `Given below is XML that describes the information to extract from this document and the tags to extract it into.`
 
 ```

--- a/docs/concepts/prompt.md
+++ b/docs/concepts/prompt.md
@@ -1,8 +1,8 @@
 # `Prompt` Element
 
-The `<prompt></prompt>` element contains the high level instructions sent to the LLM, that describe the high level task.
+The `<prompt></prompt>` element contains the query that describes the high level task.
 
-## 📚 Components of a Prompt
+## 📚 Components of a Prompt Element
 
 In addition to the high level task description, the prompt also contains the following:
 

--- a/docs/examples/regex_validation.ipynb
+++ b/docs/examples/regex_validation.ipynb
@@ -66,9 +66,9 @@
      "text": [
       "/home/zayd/workspace/shreya/guardrails/.venv/lib/python3.11/site-packages/guardrails/rail.py:115: UserWarning: Prompt must be provided during __call__.\n",
       "  warnings.warn(\"Prompt must be provided during __call__.\")\n",
-      "/home/zayd/workspace/shreya/guardrails/.venv/lib/python3.11/site-packages/guardrails/prompt/prompt.py:23: UserWarning: Prompt does not have any variables, if you are migrating follow the new variable convention documented here: https://docs.getguardrails.ai/0-2-migration/\n",
+      "/home/zayd/workspace/shreya/guardrails/.venv/lib/python3.11/site-packages/guardrails/prompt/prompt.py:23: UserWarning: Prompt does not have any variables, if you are migrating follow the new variable convention documented here: https://docs.guardrailsai.com/0-2-migration/\n",
       "  warnings.warn(\n",
-      "/home/zayd/workspace/shreya/guardrails/.venv/lib/python3.11/site-packages/guardrails/prompt/instructions.py:32: UserWarning: Instructions do not have any variables, if you are migrating follow the new variable convention documented here: https://docs.getguardrails.ai/0-2-migration/\n",
+      "/home/zayd/workspace/shreya/guardrails/.venv/lib/python3.11/site-packages/guardrails/prompt/instructions.py:32: UserWarning: Instructions do not have any variables, if you are migrating follow the new variable convention documented here: https://docs.guardrailsai.com/0-2-migration/\n",
       "  warn(\n"
      ]
     },

--- a/docs/integrations/azure_openai.ipynb
+++ b/docs/integrations/azure_openai.ipynb
@@ -112,7 +112,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/rafael/guardrails/guardrails/prompt/prompt.py:23: UserWarning: Prompt does not have any variables, if you are migrating follow the new variable convention documented here: https://docs.getguardrails.ai/0-2-migration/\n",
+      "/Users/rafael/guardrails/guardrails/prompt/prompt.py:23: UserWarning: Prompt does not have any variables, if you are migrating follow the new variable convention documented here: https://docs.guardrailsai.com/0-2-migration/\n",
       "  warnings.warn(\n"
      ]
     }

--- a/guardrails/document_store.py
+++ b/guardrails/document_store.py
@@ -53,7 +53,7 @@ class DocumentStoreBase(ABC):
     """
 
     @abstractmethod
-    def add_document(self, document: Document):
+    def add_document(self, document: Document) -> None:
         """Adds a document to the store.
 
         Args:

--- a/guardrails/prompt/base_prompt.py
+++ b/guardrails/prompt/base_prompt.py
@@ -51,7 +51,7 @@ class BasePrompt:
             warnings.warn(
                 "It appears that you are using an old schema for gaurdrails variables, "
                 "follow the new namespaced convention "
-                "documented here: https://docs.getguardrails.ai/0-2-migration/"
+                "documented here: https://docs.guardrailsai.com/0-2-migration/"
             )
 
         matches = re.findall(r"\${gr\.(\w+)}", text)

--- a/guardrails/prompt/instructions.py
+++ b/guardrails/prompt/instructions.py
@@ -32,7 +32,7 @@ class Instructions(BasePrompt):
             warn(
                 "Instructions do not have any variables, "
                 "if you are migrating follow the new variable convention "
-                "documented here: https://docs.getguardrails.ai/0-2-migration/"
+                "documented here: https://docs.guardrailsai.com/0-2-migration/"
             )
 
         # Return another instance of the class with the formatted prompt.

--- a/guardrails/prompt/prompt.py
+++ b/guardrails/prompt/prompt.py
@@ -23,7 +23,7 @@ class Prompt(BasePrompt):
             warnings.warn(
                 "Prompt does not have any variables, "
                 "if you are migrating follow the new variable convention "
-                "documented here: https://docs.getguardrails.ai/0-2-migration/"
+                "documented here: https://docs.guardrailsai.com/0-2-migration/"
             )
 
         # Return another instance of the class with the formatted prompt.

--- a/tests/unit_tests/test_prompt.py
+++ b/tests/unit_tests/test_prompt.py
@@ -248,7 +248,7 @@ def test_uses_old_constant_schema(text, is_old_schema):
             warn_mock.assert_called_once_with(
                 """It appears that you are using an old schema for gaurdrails\
  variables, follow the new namespaced convention documented here:\
- https://docs.getguardrails.ai/0-2-migration/\
+ https://docs.guardrailsai.com/0-2-migration/\
 """
             )
 


### PR DESCRIPTION
- [fix: URL typo to](https://github.com/guardrails-ai/guardrails/pull/396/commits/a450c5c059a8628e319b7e12877e35092bb98105) https://docs.guardrailsai.com/0-2-migration/
- [fix: add return type annotation for completeness sake](https://github.com/guardrails-ai/guardrails/pull/396/commits/2ade6502ea12a4f79c655ef5c73e3c1b72eb5f17)
- [docs: fix the instructions element docs typos](https://github.com/guardrails-ai/guardrails/pull/396/commits/6df02cfea34fc0bce33554ee96e514708a36bd00)
- [docs: improve the Prompts Element docs page](https://github.com/guardrails-ai/guardrails/pull/396/commits/c784c4dec97e220b7edbec60785c454688194ae5)
