### PR TITLE
Safe Get

### DIFF
--- a/guardrails/utils/safe_get.py
+++ b/guardrails/utils/safe_get.py
@@ -16,9 +16,7 @@ def safe_get_with_brackets(
 def safe_get(
     container: Union[List[Any], Dict[Any, Any]], key: Any, default: Optional[Any] = None
 ) -> Any:
-    if isinstance(container, list):
-        return safe_get_with_brackets(container, key, default)
-    elif isinstance(container, dict):
+    if isinstance(container, dict):
         return container.get(key, default)
     else:
         return safe_get_with_brackets(container, key, default)

--- a/guardrails/utils/safe_get.py
+++ b/guardrails/utils/safe_get.py
@@ -1,0 +1,24 @@
+from typing import Any, Dict, List, Optional, Union
+
+
+def safe_get_with_brackets(
+    container: Union[List[Any], Any], key: Any, default: Optional[Any] = None
+) -> Any:
+    try:
+        value = container[key]
+        if not value:
+            return default
+        return value
+    except Exception:
+        return default
+
+
+def safe_get(
+    container: Union[List[Any], Dict[Any, Any]], key: Any, default: Optional[Any] = None
+) -> Any:
+    if isinstance(container, list):
+        return safe_get_with_brackets(container, key, default)
+    elif isinstance(container, dict):
+        return container.get(key, default)
+    else:
+        return safe_get_with_brackets(container, key, default)

--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Tuple
 from guardrails.datatypes import FieldValidation
 from guardrails.utils.logs_utils import FieldValidationLogs, ValidatorLogs
 from guardrails.utils.reask_utils import FieldReAsk, ReAsk
+from guardrails.utils.safe_get import safe_get
 from guardrails.validators import (
     FailResult,
     Filter,
@@ -125,7 +126,7 @@ class SequentialValidatorService(ValidatorServiceBase):
 
     def validate_dependents(self, value, metadata, validator_setup, validation_logs):
         for child_setup in validator_setup.children:
-            child_schema = value[child_setup.key]
+            child_schema = safe_get(value, child_setup.key)
             child_validation_logs = FieldValidationLogs()
             validation_logs.children[child_setup.key] = child_validation_logs
             child_schema, metadata = self.validate(

--- a/tests/unit_tests/utils/test_safe_get.py
+++ b/tests/unit_tests/utils/test_safe_get.py
@@ -1,0 +1,24 @@
+import pytest
+
+from guardrails.utils.safe_get import safe_get
+
+
+@pytest.mark.parametrize(
+    "container,key,default,expected_value",
+    [
+        ([1, 2, 3], 1, None, 2),
+        ([1, 2, 3], 4, None, None),
+        ([1, 2, 3], 4, 42, 42),
+        ([1, 2, None], 2, 42, 42),
+        ({"a": 1, "b": 2, "c": 3}, "b", None, 2),
+        ({"a": 1, "b": 2, "c": 3}, "d", None, None),
+        ({"a": 1, "b": 2, "c": 3}, "d", 42, 42),
+        ("123", 1, None, "2"),
+        ("123", 4, None, None),
+        ("123", 4, 42, 42),
+    ],
+)
+def test_safe_get(container, key, default, expected_value):
+    actual = safe_get(container, key, default)
+
+    assert actual == expected_value


### PR DESCRIPTION
During validation, if a property is optional and therefore was not included in the response from the LLM, `validate_dependents` would throw a KeyError because it tries to access the property by bracketes (i.e. `value[child_setup.key]`).  We cannot simply switch to `get` because sometimes the value is a list or other iterable.  Instead we can use a `safe_get` implementation that accounts for these.