### PR TITLE
Fix custom onfail handler

### DIFF
--- a/guardrails/formatattr.py
+++ b/guardrails/formatattr.py
@@ -32,7 +32,7 @@ class FormatAttr(pydantic.BaseModel):
     format: Optional[str]
 
     # The on-fail handlers.
-    on_fail_handlers: Dict[str, str]
+    on_fail_handlers: Mapping[str, Union[str, Callable]]
 
     # The validator arguments.
     validator_args: Mapping[str, Union[Dict[str, Any], List[Any]]]
@@ -65,7 +65,10 @@ class FormatAttr(pydantic.BaseModel):
                 validator_args = val.get_args()
                 validators_with_args[validator_name] = validator_args
                 # Set the on-fail attribute based on the on_fail value
-                on_fail = val.on_fail_descriptor
+                if val.on_fail_descriptor == "custom":
+                    on_fail = val.on_fail_method
+                else:
+                    on_fail = val.on_fail_descriptor
                 on_fails[val.rail_alias] = on_fail
             elif isinstance(val, tuple) and len(val) == 2:
                 validator, on_fail = val

--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -47,7 +47,7 @@ class ValidatorServiceBase:
         if on_fail_descriptor == "custom":
             if validator.on_fail_method is None:
                 raise ValueError("on_fail is 'custom' but on_fail_method is None")
-            return validator.on_fail_method(value, results[0])
+            return validator.on_fail_method(value, results)
         if on_fail_descriptor == "reask":
             return FieldReAsk(
                 incorrect_value=value,


### PR DESCRIPTION
Based on #413, merge that first

This PR fixes the use of custom `on_fail` handlers, and requires the removal of XML as an interim step in pydantic guards.

Here's an example of how to use a custom `on_fail` handler:

```python
from typing import Any, List

from pydantic import BaseModel, Field

from guardrails.utils.reask_utils import FieldReAsk
from guardrails.validator_base import FailResult, ValidatorError, Filter, Refrain
from guardrails.validators import TwoWords
from guardrails import Guard


def custom_on_fail_handler(value: Any, fail_results: List[FailResult]):
    print("Value:", value)
    print("Fail results:", fail_results)

    # Custom fail handling logic...
    ...

    # Return a fixed value:
    return value + " " + value

    # Trigger a reask:
    # return FieldReAsk(
    #     incorrect_value=value,
    #     fail_results=fail_results
    # )

    # Raise an exception:
    # raise ValidatorError("Something went wrong!")

    # Filter the value:
    # return Filter()

    # Refrain from responding:
    # return Refrain()


class Pet(BaseModel):
    pet_type: str = Field(
        description="Species of pet",
        validators=[TwoWords(on_fail=custom_on_fail_handler)]
    )
    name: str = Field(description="a unique pet name")


prompt = """
    What kind of pet should I get and what should I name it?

    ${gr.complete_json_suffix_v2}
"""

output = """
{
   "pet_type": "dog",
   "name": "Fido"
}
"""

guard = Guard.from_pydantic(output_class=Pet, prompt=prompt)

validated_output = guard.parse(output)

print(validated_output)

```