### PR TITLE
fix status for string guards

### DIFF
--- a/guardrails/utils/safe_get.py
+++ b/guardrails/utils/safe_get.py
@@ -30,6 +30,9 @@ def get_value_from_path(
     if object is None:
         return None
 
+    if isinstance(object, str) and property_path == "$.string":
+        return object
+
     path_elems = property_path.split(".")
     path_elems.pop(0)
 

--- a/tests/integration_tests/test_multi_reask.py
+++ b/tests/integration_tests/test_multi_reask.py
@@ -43,5 +43,5 @@ def test_multi_reask(mocker):
     # The output here fails some validators but passes others.
     # Since those that it fails in the end are noop fixes, validation fails.
     assert call.validation_output == python_rail.VALIDATOR_PARALLELISM_RESPONSE_3
-    assert call.validated_output == None
+    assert call.validated_output is None
     assert call.status == "fail"

--- a/tests/integration_tests/test_multi_reask.py
+++ b/tests/integration_tests/test_multi_reask.py
@@ -40,4 +40,8 @@ def test_multi_reask(mocker):
 
     assert call.reask_prompts.last == python_rail.VALIDATOR_PARALLELISM_PROMPT_3
     assert call.raw_outputs.last == python_rail.VALIDATOR_PARALLELISM_RESPONSE_3
-    assert call.validated_output == python_rail.VALIDATOR_PARALLELISM_RESPONSE_3
+    # The output here fails some validators but passes others.
+    # Since those that it fails in the end are noop fixes, validation fails.
+    assert call.validation_output == python_rail.VALIDATOR_PARALLELISM_RESPONSE_3
+    assert call.validated_output == None
+    assert call.status == "fail"


### PR DESCRIPTION
One last status fix PR.

There was a bug with how we were fetching the value if the output was unstructured because we use a fake key in validation service.

The test update here also shows important details on how status is handled when multiple validators are applied to the same property.  Right now it is most restrictive, meaning if any fail with out fixes, then it all fails.