### PR TITLE
fix empty check on setup key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,20 +156,20 @@ jobs:
         - name: Checkout repository
           uses: actions/checkout@v2    
         - name: Set up Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with: 
             python-version: 3.11.x
-        - name: Poetry cache
-          uses: actions/cache@v3
-          with:
-            path: ~/.cache/pypoetry
-            key: poetry-cache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ env.POETRY_VERSION }}
         - name: Install Poetry
           uses: snok/install-poetry@v1
           with:
             virtualenvs-create: true
             virtualenvs-in-project: true
             installer-parallel: true
+        - name: Load cached venv
+          uses: actions/cache@v3
+          with:
+            path: .venv
+            key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
         - name: Install dependencies
           run: |
             make full;

--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -20,6 +20,10 @@ from guardrails.validator_base import (
 )
 
 
+def key_not_empty(key: str) -> bool:
+    return key is not None and len(str(key)) > 0
+
+
 class ValidatorServiceBase:
     """Base class for validator services."""
 
@@ -153,7 +157,7 @@ class SequentialValidatorService(ValidatorServiceBase):
         iteration: Iteration,
         path: str = "$",
     ) -> Tuple[Any, dict]:
-        property_path = f"{path}.{validator_setup.key}"
+        property_path = f"{path}.{validator_setup.key}" if key_not_empty(validator_setup.key) else path
         # Validate children first
         if validator_setup.children:
             self.validate_dependents(
@@ -296,7 +300,7 @@ class AsyncValidatorService(ValidatorServiceBase, MultiprocMixin):
         iteration: Iteration,
         path: str = "$",
     ) -> Tuple[Any, dict]:
-        property_path = f"{path}.{validator_setup.key}" if validator_setup.key else path
+        property_path = f"{path}.{validator_setup.key}" if key_not_empty(validator_setup.key) else path
         # Validate children first
         if validator_setup.children:
             await self.validate_dependents(

--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -157,7 +157,11 @@ class SequentialValidatorService(ValidatorServiceBase):
         iteration: Iteration,
         path: str = "$",
     ) -> Tuple[Any, dict]:
-        property_path = f"{path}.{validator_setup.key}" if key_not_empty(validator_setup.key) else path
+        property_path = (
+            f"{path}.{validator_setup.key}"
+            if key_not_empty(validator_setup.key)
+            else path
+        )
         # Validate children first
         if validator_setup.children:
             self.validate_dependents(
@@ -300,7 +304,11 @@ class AsyncValidatorService(ValidatorServiceBase, MultiprocMixin):
         iteration: Iteration,
         path: str = "$",
     ) -> Tuple[Any, dict]:
-        property_path = f"{path}.{validator_setup.key}" if key_not_empty(validator_setup.key) else path
+        property_path = (
+            f"{path}.{validator_setup.key}"
+            if key_not_empty(validator_setup.key)
+            else path
+        )
         # Validate children first
         if validator_setup.children:
             await self.validate_dependents(

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -713,7 +713,7 @@ def test_sequential_validator_log_is_not_duplicated(mocker):
             entity_extraction.PYDANTIC_RAIL_WITH_NOOP, entity_extraction.PYDANTIC_PROMPT
         )
 
-        _, final_output, *rest = guard(
+        guard(
             llm_api=get_static_openai_create_func(),
             prompt_params={"document": content[:6000]},
             num_reasks=1,
@@ -727,7 +727,9 @@ def test_sequential_validator_log_is_not_duplicated(mocker):
             for x in guard.history.first.iterations.first.validator_logs
             if x.validator_name == "OneLine"
         )
-        assert len(one_line_logs) == len(final_output.get("fees"))
+        assert len(one_line_logs) == len(
+            guard.history.first.validation_output.get("fees")
+        )
 
     finally:
         if proc_count_bak is None:


### PR DESCRIPTION
This PR fixes creating the property path during validation for the ValidatorLogs.  Previously it wouldn't append the array index for the first element in a list because python considers `0` falsey.