### PR TITLE
Fix validator initialization bugs

### DIFF
--- a/guardrails/validators/bug_free_sql.py
+++ b/guardrails/validators/bug_free_sql.py
@@ -33,7 +33,7 @@ class BugFreeSQL(Validator):
         schema_file: Optional[str] = None,
         on_fail: Optional[Callable] = None,
     ):
-        super().__init__(on_fail=on_fail)
+        super().__init__(on_fail, conn=conn, schema_file=schema_file)
         self._driver: SQLDriver = create_sql_driver(schema_file=schema_file, conn=conn)
 
     def validate(self, value: Any, metadata: Dict) -> ValidationResult:

--- a/guardrails/validators/extracted_summary_sentences_match.py
+++ b/guardrails/validators/extracted_summary_sentences_match.py
@@ -44,7 +44,7 @@ class ExtractedSummarySentencesMatch(Validator):
         on_fail: Optional[Callable] = None,
         **kwargs: Optional[Dict[str, Any]],
     ):
-        super().__init__(on_fail, **kwargs)
+        super().__init__(on_fail, threshold=threshold, **kwargs)
         # TODO(shreya): Pass embedding_model, vector_db, document_store from spec
 
         self._threshold = float(threshold)

--- a/guardrails/validators/extractive_summary.py
+++ b/guardrails/validators/extractive_summary.py
@@ -47,7 +47,7 @@ class ExtractiveSummary(Validator):
         on_fail: Optional[Callable] = None,
         **kwargs,
     ):
-        super().__init__(on_fail, **kwargs)
+        super().__init__(on_fail, threshold=threshold, **kwargs)
 
         self._threshold = threshold
 

--- a/guardrails/validators/pydantic_field_validator.py
+++ b/guardrails/validators/pydantic_field_validator.py
@@ -38,8 +38,9 @@ class PydanticFieldValidator(Validator):
     ):
         warn(
             """
-            PydanticFieldValidator is deprecated (v0.3.3); will be removed (v0.4.0).
-            Instead, use the `add_validator` function with a Guardrails validator class.
+            `PydanticFieldValidator` is deprecated (v0.3.3); will be removed (v0.4.0). 
+            Instead, use the `add_validator` function, or create a custom Guardrails validator as shown here:
+            https://www.guardrailsai.com/docs/concepts/validators#custom-validators
             """,
             DeprecationWarning,
             stacklevel=2,

--- a/guardrails/validators/pydantic_field_validator.py
+++ b/guardrails/validators/pydantic_field_validator.py
@@ -35,8 +35,8 @@ class PydanticFieldValidator(Validator):
         on_fail: Optional[Callable[..., Any]] = None,
         **kwargs,
     ):
+        super().__init__(on_fail, field_validator=field_validator, **kwargs)
         self.field_validator = field_validator
-        super().__init__(on_fail, **kwargs)
 
     def validate(self, value: Any, metadata: Dict) -> ValidationResult:
         try:
@@ -51,4 +51,4 @@ class PydanticFieldValidator(Validator):
         )
 
     def to_prompt(self, with_keywords: bool = True) -> str:
-        return self.field_validator.__func__.__name__
+        return self.field_validator.__name__

--- a/guardrails/validators/pydantic_field_validator.py
+++ b/guardrails/validators/pydantic_field_validator.py
@@ -39,7 +39,7 @@ class PydanticFieldValidator(Validator):
         warn(
             """
             `PydanticFieldValidator` is deprecated (v0.3.3); will be removed (v0.4.0). 
-            Instead, use the `add_validator` function, or create a custom Guardrails validator as shown here:
+            Instead, define and use a custom Guardrails validator as shown here:
             https://www.guardrailsai.com/docs/concepts/validators#custom-validators
             """,
             DeprecationWarning,

--- a/guardrails/validators/pydantic_field_validator.py
+++ b/guardrails/validators/pydantic_field_validator.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, Dict, Optional
+from warnings import warn
 
 from guardrails.validator_base import (
     FailResult,
@@ -35,6 +36,14 @@ class PydanticFieldValidator(Validator):
         on_fail: Optional[Callable[..., Any]] = None,
         **kwargs,
     ):
+        warn(
+            """
+            PydanticFieldValidator is deprecated (v0.3.3); will be removed (v0.4.0).
+            Instead, use the `add_validator` function with a Guardrails validator class.
+            """,
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(on_fail, field_validator=field_validator, **kwargs)
         self.field_validator = field_validator
 

--- a/guardrails/validators/pydantic_field_validator.py
+++ b/guardrails/validators/pydantic_field_validator.py
@@ -38,8 +38,8 @@ class PydanticFieldValidator(Validator):
     ):
         warn(
             """
-            `PydanticFieldValidator` is deprecated (v0.3.3); will be removed (v0.4.0). 
-            Instead, define and use a custom Guardrails validator as shown here:
+            PydanticFieldValidator is deprecated (v0.3.3); will be removed (v0.4.0).
+            Instead, use a custom Guardrails validator as shown here:
             https://www.guardrailsai.com/docs/concepts/validators#custom-validators
             """,
             DeprecationWarning,

--- a/guardrails/validators/qa_relevance_llm_eval.py
+++ b/guardrails/validators/qa_relevance_llm_eval.py
@@ -36,7 +36,7 @@ class QARelevanceLLMEval(Validator):
         on_fail: Optional[Callable] = None,
         **kwargs,
     ):
-        super().__init__(on_fail, **kwargs)
+        super().__init__(on_fail, llm_callable=llm_callable, **kwargs)
 
         if llm_callable is not None and inspect.iscoroutinefunction(llm_callable):
             raise ValueError(

--- a/guardrails/validators/remove_redundant_sentences.py
+++ b/guardrails/validators/remove_redundant_sentences.py
@@ -34,7 +34,7 @@ class RemoveRedundantSentences(Validator):
     def __init__(
         self, threshold: int = 70, on_fail: Optional[Callable] = None, **kwargs
     ):
-        super().__init__(on_fail, **kwargs)
+        super().__init__(on_fail, threshold=threshold, **kwargs)
         self._threshold = threshold
 
     def validate(self, value: Any, metadata: Dict) -> ValidationResult:

--- a/guardrails/validators/saliency_check.py
+++ b/guardrails/validators/saliency_check.py
@@ -47,7 +47,13 @@ class SaliencyCheck(Validator):
             threshold: Threshold for overlap between topics in document and summary.
         """
 
-        super().__init__(on_fail, **kwargs)
+        super().__init__(
+            on_fail,
+            docs_dir=docs_dir,
+            llm_callable=llm_callable,
+            threshold=threshold,
+            **kwargs,
+        )
 
         if llm_callable is not None and inspect.iscoroutinefunction(llm_callable):
             raise ValueError(

--- a/tests/unit_tests/validators/test_parameters.py
+++ b/tests/unit_tests/validators/test_parameters.py
@@ -298,16 +298,23 @@ ${ingredients}
     }
 }
 
+
 validator_test_xml = {
     "ValidLength": {
         "expected_xml": "length: 4 17",
         "instance_variables": {"min": 4, "max": 17},
     },
     "BugFreeSQL": {
-        "expected_xml": "bug-free-sql",
+        "expected_xml": "bug-free-sql: None None",
     },
     "ExtractedSummarySentencesMatch": {
-        "expected_xml": "extracted-summary-sentences-match",
+        "expected_xml": "extracted-summary-sentences-match: 0.7",
+    },
+    "ExtractiveSummary": {
+        "expected_xml": "extractive-summary: 85",
+    },
+    "QARelevanceLLMEval": {
+        "expected_xml": "qa-relevance-llm-eval: None",
     },
     "LowerCase": {
         "expected_xml": "lower-case",
@@ -355,7 +362,7 @@ validator_test_xml = {
         "instance_variables": {"predicates": ["EXISTS", "IN"]},
     },
     "IsProfanityFree": {"expected_xml": "is-profanity-free"},
-    "RemoveRedundantSentences": {"expected_xml": "remove-redundant-sentences"},
+    "RemoveRedundantSentences": {"expected_xml": "remove-redundant-sentences: 70"},
     "RegexMatch": {
         "expected_xml": "regex_match: \\w+\\d\\w+ fullmatch",
         "instance_variables": {"regex": "\\w+\\d\\w+", "match_type": "fullmatch"},
@@ -366,13 +373,18 @@ validator_test_xml = {
     },
 }
 
+
+def test_field_validator():
+    pass
+
+
 validator_test_prompt = {
     "ValidLength": {
         "expected_prompt": "length: min=4 max=17",
         "instance_variables": {"min": 4, "max": 17},
     },
     "BugFreeSQL": {
-        "expected_prompt": "bug-free-sql",
+        "expected_prompt": "bug-free-sql: conn=None schema_file=None",
     },
     "LowerCase": {
         "expected_prompt": "lower-case",
@@ -420,9 +432,15 @@ validator_test_prompt = {
         "instance_variables": {"predicates": ["EXISTS", "IN"]},
     },
     "IsProfanityFree": {"expected_prompt": "is-profanity-free"},
-    "RemoveRedundantSentences": {"expected_prompt": "remove-redundant-sentences"},
+    "RemoveRedundantSentences": {
+        "expected_prompt": "remove-redundant-sentences: threshold=70"
+    },
     "RegexMatch": {
         "expected_prompt": "results should match \\w+\\d\\w+",
         "instance_variables": {"regex": "\\w+\\d\\w+", "match_type": "fullmatch"},
+    },
+    "PydanticFieldValidator": {
+        "expected_prompt": "test_field_validator",
+        "instance_variables": {"field_validator": test_field_validator},
     },
 }


### PR DESCRIPTION
**Bug Description**
As found in: https://github.com/guardrails-ai/guardrails/issues/550, error was thrown when using `PydanticFieldValidator` due to a missing keyword argument in the `super.__init__` call within the validator initialization method. This is a bug and all keyword argument(s) that a validator expects should be passed explicitly to the super call as passing in `**kwargs` doesn't automatically include the remaining keyword arguments.

Turns out, this is a pattern that has been erroneously implemented across the following 6 other validators alongwith the `PydanticFieldValidator`:
- `BugFreeSQL`
- `ExtractedSummarySentencesMatch`
- `ExtractiveSummary`
- `QARelevanceLLMEval`
- `RemoveRedundantSentences`
- `SaliencyCheck`

**Fix**
All other validators pass in the keyword arguments explicitly in either of the following two ways:
1. `super.__init__(on_fail, kwarg_1=kwarg_1, kwarg_2=kwarg_2,... **kwargs)`
2. `super.__init__(kwarg_1=kwarg_1, kwarg_2=kwarg_2,... on_fail=on_fail,  **kwargs)`

The `super.__init__` method's definition is as follows:
https://github.com/guardrails-ai/guardrails/blob/8833c0507d58825b2712d7660b14efff7dc69855/guardrails/validator_base.py#L196

Hence, both of the ways are fine and the arguments get passed in correctly. This PR corrects these 7 validators by using the first way (either is fine)
A relevant similar PR was previously opened for `ProvenanceV0`: https://github.com/guardrails-ai/guardrails/pull/288