### PR TITLE
Fix valid_chess_moves_notebook

### DIFF
--- a/docs/examples/valid_chess_moves.ipynb
+++ b/docs/examples/valid_chess_moves.ipynb
@@ -311,7 +311,7 @@
     }
    ],
    "source": [
-    "board = guard.output_schema.move.validators[0].board\n",
+    "board = guard.output_schema.root_datatype.children.__getattribute__(\"move\").validators[0].board\n",
     "board"
    ]
   },


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/guardrails-ai/guardrails/issues/430) and makes it so that `guard.output_schema` can access properties like `move` in the `valid_chess_moves` notebook.  