### PR TITLE
Validator Hub Telemetry

### DIFF
--- a/guardrails/cli_dir/hub/credentials.py
+++ b/guardrails/cli_dir/hub/credentials.py
@@ -1,17 +1,18 @@
 import os
-import sys
 from dataclasses import dataclass
 from os.path import expanduser
+from typing import Optional
 
+from guardrails.cli_dir.logger import logger
 from guardrails.cli_dir.server.serializeable import Serializeable
 
 
 @dataclass
 class Credentials(Serializeable):
-    id: str
-    client_id: str
-    client_secret: str
-    no_metrics: bool = False
+    id: Optional[str] = None
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    no_metrics: Optional[bool] = False
 
     @staticmethod
     def from_rc_file() -> "Credentials":
@@ -27,8 +28,11 @@ class Credentials(Serializeable):
                 rc_file.close()
                 return Credentials.from_dict(creds)
 
-        except FileNotFoundError:
-            print(
-                "Guardrails Hub credentials not found!\nSign up to use the Hub here: {insert url}"  # noqa: E501
+        except FileNotFoundError as e:
+            logger.error(e)
+            logger.error(
+                "Guardrails Hub credentials not found!"
+                "You will need to sign up to use any authenticated Validators here:"
+                "{insert url}"
             )
-            sys.exit(1)
+            return Credentials()

--- a/guardrails/cli_dir/hub/credentials.py
+++ b/guardrails/cli_dir/hub/credentials.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from dataclasses import dataclass
+from os.path import expanduser
+
+from guardrails.cli_dir.server.serializeable import Serializeable
+
+
+@dataclass
+class Credentials(Serializeable):
+    id: str
+    client_id: str
+    client_secret: str
+    no_metrics: bool = False
+
+    @staticmethod
+    def from_rc_file() -> "Credentials":
+        try:
+            home = expanduser("~")
+            guardrails_rc = os.path.join(home, ".guardrailsrc")
+            with open(guardrails_rc) as rc_file:
+                lines = rc_file.readlines()
+                creds = {}
+                for line in lines:
+                    key, value = line.split("=", 1)
+                    creds[key.strip()] = value.strip()
+                rc_file.close()
+                return Credentials.from_dict(creds)
+
+        except FileNotFoundError as e:
+            print(
+                "Guardrails Hub credentials not found!\nSign up to use the Hub here: {insert url}"
+            )
+            sys.exit(1)

--- a/guardrails/cli_dir/hub/credentials.py
+++ b/guardrails/cli_dir/hub/credentials.py
@@ -27,8 +27,8 @@ class Credentials(Serializeable):
                 rc_file.close()
                 return Credentials.from_dict(creds)
 
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             print(
-                "Guardrails Hub credentials not found!\nSign up to use the Hub here: {insert url}"
+                "Guardrails Hub credentials not found!\nSign up to use the Hub here: {insert url}"  # noqa: E501
             )
             sys.exit(1)

--- a/guardrails/cli_dir/logger.py
+++ b/guardrails/cli_dir/logger.py
@@ -1,0 +1,20 @@
+import logging
+import os
+
+import coloredlogs
+
+os.environ[
+    "COLOREDLOGS_LEVEL_STYLES"
+] = "spam=white,faint;success=green,bold;debug=magenta;verbose=blue;notice=cyan,bold;warning=yellow;error=red;critical=background=red"  # noqa
+LEVELS = {
+    "SPAM": 5,
+    "VERBOSE": 15,
+    "NOTICE": 25,
+    "SUCCESS": 35,
+}
+for key in LEVELS:
+    logging.addLevelName(LEVELS.get(key), key)  # type: ignore
+
+
+logger = logging.getLogger("guardrails-cli")
+coloredlogs.install(level="DEBUG", logger=logger)

--- a/guardrails/cli_dir/server/serializeable.py
+++ b/guardrails/cli_dir/server/serializeable.py
@@ -1,0 +1,33 @@
+import inspect
+import json
+from dataclasses import InitVar, asdict, dataclass, field, is_dataclass
+from json import JSONEncoder
+from typing import Any, Dict
+
+
+class SerializeableJSONEncoder(JSONEncoder):
+    def default(self, o):
+        if is_dataclass(o):
+            return asdict(o)
+        return super().default(o)
+
+
+@dataclass
+class Serializeable:
+    encoder: InitVar[JSONEncoder] = field(
+        kw_only=True, default=SerializeableJSONEncoder  # type: ignore
+    )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]):
+        annotations = inspect.get_annotations(cls)
+        attributes = dict.keys(annotations)
+        kwargs = {k: data.get(k) for k in data if k in attributes}
+        return cls(**kwargs)  # type: ignore
+
+    @property
+    def __dict__(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self):
+        return json.dumps(self, cls=self.encoder)  # type: ignore

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -87,6 +87,10 @@ class Guard(Generic[OT]):
 
         # Get metrics opt-out from credentials
         self._disable_tracer = Credentials.from_rc_file().no_metrics
+        if self._disable_tracer.strip().lower() == "true":
+            self._disable_tracer = True
+        elif self._disable_tracer.strip().lower() == "false":
+            self._disable_tracer = False
 
         # Get id of guard object (that is unique)
         self._guard_id = id(self)  # id of guard object; not the class
@@ -166,9 +170,7 @@ class Guard(Generic[OT]):
         self.num_reasks = (
             num_reasks
             if num_reasks is not None
-            else self.num_reasks
-            if self.num_reasks is not None
-            else 1
+            else self.num_reasks if self.num_reasks is not None else 1
         )
 
     def _set_tracer(self, tracer: Tracer = None) -> None:
@@ -303,8 +305,7 @@ class Guard(Generic[OT]):
         stream: Optional[bool] = False,
         *args,
         **kwargs,
-    ) -> Union[ValidationOutcome[OT], Iterable[str]]:
-        ...
+    ) -> Union[ValidationOutcome[OT], Iterable[str]]: ...
 
     @overload
     def __call__(
@@ -319,8 +320,7 @@ class Guard(Generic[OT]):
         full_schema_reask: Optional[bool] = None,
         *args,
         **kwargs,
-    ) -> Awaitable[ValidationOutcome[OT]]:
-        ...
+    ) -> Awaitable[ValidationOutcome[OT]]: ...
 
     def __call__(
         self,
@@ -614,8 +614,7 @@ class Guard(Generic[OT]):
         full_schema_reask: Optional[bool] = None,
         *args,
         **kwargs,
-    ) -> ValidationOutcome[OT]:
-        ...
+    ) -> ValidationOutcome[OT]: ...
 
     @overload
     def parse(
@@ -628,8 +627,7 @@ class Guard(Generic[OT]):
         full_schema_reask: Optional[bool] = None,
         *args,
         **kwargs,
-    ) -> Awaitable[ValidationOutcome[OT]]:
-        ...
+    ) -> Awaitable[ValidationOutcome[OT]]: ...
 
     @overload
     def parse(
@@ -642,8 +640,7 @@ class Guard(Generic[OT]):
         full_schema_reask: Optional[bool] = None,
         *args,
         **kwargs,
-    ) -> ValidationOutcome[OT]:
-        ...
+    ) -> ValidationOutcome[OT]: ...
 
     def parse(
         self,

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -170,7 +170,9 @@ class Guard(Generic[OT]):
         self.num_reasks = (
             num_reasks
             if num_reasks is not None
-            else self.num_reasks if self.num_reasks is not None else 1
+            else self.num_reasks
+            if self.num_reasks is not None
+            else 1
         )
 
     def _set_tracer(self, tracer: Tracer = None) -> None:
@@ -305,7 +307,8 @@ class Guard(Generic[OT]):
         stream: Optional[bool] = False,
         *args,
         **kwargs,
-    ) -> Union[ValidationOutcome[OT], Iterable[str]]: ...
+    ) -> Union[ValidationOutcome[OT], Iterable[str]]:
+        ...
 
     @overload
     def __call__(
@@ -320,7 +323,8 @@ class Guard(Generic[OT]):
         full_schema_reask: Optional[bool] = None,
         *args,
         **kwargs,
-    ) -> Awaitable[ValidationOutcome[OT]]: ...
+    ) -> Awaitable[ValidationOutcome[OT]]:
+        ...
 
     def __call__(
         self,
@@ -614,7 +618,8 @@ class Guard(Generic[OT]):
         full_schema_reask: Optional[bool] = None,
         *args,
         **kwargs,
-    ) -> ValidationOutcome[OT]: ...
+    ) -> ValidationOutcome[OT]:
+        ...
 
     @overload
     def parse(
@@ -627,7 +632,8 @@ class Guard(Generic[OT]):
         full_schema_reask: Optional[bool] = None,
         *args,
         **kwargs,
-    ) -> Awaitable[ValidationOutcome[OT]]: ...
+    ) -> Awaitable[ValidationOutcome[OT]]:
+        ...
 
     @overload
     def parse(
@@ -640,7 +646,8 @@ class Guard(Generic[OT]):
         full_schema_reask: Optional[bool] = None,
         *args,
         **kwargs,
-    ) -> ValidationOutcome[OT]: ...
+    ) -> ValidationOutcome[OT]:
+        ...
 
     def parse(
         self,

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -24,6 +24,7 @@ from guardrails.classes import OT, ValidationOutcome
 from guardrails.classes.generic import Stack
 from guardrails.classes.history import Call
 from guardrails.classes.history.call_inputs import CallInputs
+from guardrails.cli_dir.hub.credentials import Credentials
 from guardrails.llm_providers import get_async_llm_ask, get_llm_ask
 from guardrails.logger import logger, set_scope
 from guardrails.prompt import Instructions, Prompt
@@ -37,9 +38,8 @@ from guardrails.stores.context import (
     set_tracer,
     set_tracer_context,
 )
-from guardrails.validators import Validator
 from guardrails.utils.hub_telemetry_utils import HubTelemetry
-from guardrails.cli_dir.hub.credentials import Credentials
+from guardrails.validators import Validator
 
 add_destinations(logger.debug)
 

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -384,6 +384,11 @@ class Guard(Generic[OT]):
 
                 span.set_attribute("guard_id", self._guard_id)
                 span.set_attribute("user_id", self._user_id)
+                span.set_attribute("llm_api", llm_api.__name__ if llm_api else "None")
+                span.set_attribute("custom_reask_prompt", self.reask_prompt is not None)
+                span.set_attribute(
+                    "custom_reask_instructions", self.reask_instructions is not None
+                )
 
             set_call_kwargs(kwargs)
             set_tracer(self._tracer)
@@ -685,6 +690,11 @@ class Guard(Generic[OT]):
 
                 span.set_attribute("guard_id", self._guard_id)
                 span.set_attribute("user_id", self._user_id)
+                span.set_attribute("llm_api", llm_api.__name__ if llm_api else "None")
+                span.set_attribute("custom_reask_prompt", self.reask_prompt is not None)
+                span.set_attribute(
+                    "custom_reask_instructions", self.reask_instructions is not None
+                )
 
             self.configure(final_num_reasks)
             if self.num_reasks is None:

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -17,6 +17,7 @@ from guardrails.logger import logger, set_scope
 from guardrails.prompt import Instructions, Prompt
 from guardrails.schema import Schema, StringSchema
 from guardrails.utils.exception_utils import UserFacingException
+from guardrails.utils.hub_telemetry_utils import HubTelemetry
 from guardrails.utils.llm_response import LLMResponse
 from guardrails.utils.openai_utils import OPENAI_VERSION
 from guardrails.utils.reask_utils import (
@@ -26,7 +27,6 @@ from guardrails.utils.reask_utils import (
     reasks_to_dict,
 )
 from guardrails.utils.telemetry_utils import async_trace, trace
-from guardrails.utils.hub_telemetry_utils import HubTelemetry
 from guardrails.validator_base import ValidatorError
 
 add_destinations(logger.debug)

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -107,6 +107,11 @@ class Runner:
 
         # Get metrics opt-out from credentials
         self._disable_tracer = Credentials.from_rc_file().no_metrics
+        if self._disable_tracer.strip().lower() == "true":
+            self._disable_tracer = True
+        elif self._disable_tracer.strip().lower() == "false":
+            self._disable_tracer = False
+
         if not self._disable_tracer:
             # Get the HubTelemetry singleton
             self._hub_telemetry = HubTelemetry()

--- a/guardrails/utils/hub_telemetry_utils.py
+++ b/guardrails/utils/hub_telemetry_utils.py
@@ -1,0 +1,89 @@
+# Imports
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+class HubTelemetry:
+    """Singleton class for initializing a tracer for Guardrails Hub"""
+
+    _instance = None
+    _service_name = None
+    _endpoint = None
+    _tracer_name = None
+    _resource = None
+    _tracer_provider = None
+    _processor = None
+    _tracer = None
+    _prop = None
+    _carrier = {}
+
+    def __new__(
+        cls,
+        service_name: str = "guardrails-hub",
+        endpoint: str = "localhost:4317",
+        tracer_name: str = "gr_hub",
+        export_locally: bool = True,
+    ):
+        if cls._instance is None:
+            print("Creating HubTelemetry instance...")
+            cls._instance = super(HubTelemetry, cls).__new__(cls)
+            print("Initializing HubTelemetry instance...")
+            cls._instance.initialize_tracer(
+                service_name, endpoint, tracer_name, export_locally
+            )
+        return cls._instance
+
+    def initialize_tracer(
+        self,
+        service_name: str,
+        endpoint: str,
+        tracer_name: str,
+        export_locally: bool,
+    ):
+        """Initializes a tracer for Guardrails Hub"""
+
+        self._service_name = service_name
+        self._endpoint = endpoint
+        self._tracer_name = tracer_name
+
+        # Create a resource
+        # Service name is required for most backends
+        self._resource = Resource(attributes={SERVICE_NAME: self._service_name})
+
+        # Create a tracer provider and a processor
+        self._tracer_provider = TracerProvider(resource=self._resource)
+
+        if export_locally:
+            self._processor = BatchSpanProcessor(ConsoleSpanExporter())
+        else:
+            self._processor = BatchSpanProcessor(
+                OTLPSpanExporter(endpoint=self._endpoint, insecure=True)
+            )
+
+        # Add the processor to the provider
+        self._tracer_provider.add_span_processor(self._processor)
+
+        # Set the tracer provider and return a tracer
+        trace.set_tracer_provider(self._tracer_provider)
+        self._tracer = trace.get_tracer(self._tracer_name)
+
+        self._prop = TraceContextTextMapPropagator()
+
+    def get_tracer(self):
+        """Returns the tracer"""
+
+        return self._tracer
+
+    def inject_current_context(self) -> None:
+        """Injects the current context into the carrier"""
+        self._prop.inject(carrier=self._carrier)
+
+    def extract_current_context(self):
+        """Extracts the current context from the carrier"""
+
+        context = self._prop.extract(carrier=self._carrier)
+        return context

--- a/guardrails/utils/hub_telemetry_utils.py
+++ b/guardrails/utils/hub_telemetry_utils.py
@@ -1,19 +1,11 @@
 # Imports
 from opentelemetry import trace
-
-# 2 exporters available: HTTP and GRPC, only use one at a time
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter,
-)  # HTTP
-
-# from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-#     OTLPSpanExporter,
-# )  # GRPC
-
+)  # HTTP Exporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
-    BatchSpanProcessor,
     ConsoleSpanExporter,
     SimpleSpanProcessor,
 )
@@ -37,7 +29,6 @@ class HubTelemetry:
     def __new__(
         cls,
         service_name: str = "guardrails-hub",
-        endpoint: str = "http://localhost:4318/v1/traces",  # HTTP: 4318, GRPC: 4317
         tracer_name: str = "gr_hub",
         export_locally: bool = False,
     ):
@@ -45,22 +36,20 @@ class HubTelemetry:
             print("Creating HubTelemetry instance...")
             cls._instance = super(HubTelemetry, cls).__new__(cls)
             print("Initializing HubTelemetry instance...")
-            cls._instance.initialize_tracer(
-                service_name, endpoint, tracer_name, export_locally
-            )
+            cls._instance.initialize_tracer(service_name, tracer_name, export_locally)
         return cls._instance
 
     def initialize_tracer(
         self,
         service_name: str,
-        endpoint: str,
         tracer_name: str,
         export_locally: bool,
     ):
         """Initializes a tracer for Guardrails Hub"""
 
         self._service_name = service_name
-        self._endpoint = endpoint
+        # self._endpoint = "http://localhost:4318/v1/traces"  # Local Otel Collector (Docker)
+        self._endpoint = "https://hty0gc1ok3.execute-api.us-east-1.amazonaws.com/v1/traces"  # AWS ECS
         self._tracer_name = tracer_name
 
         # Create a resource

--- a/guardrails/utils/hub_telemetry_utils.py
+++ b/guardrails/utils/hub_telemetry_utils.py
@@ -1,9 +1,22 @@
 # Imports
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+# 2 exporters available: HTTP and GRPC, only use one at a time
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter,
+)  # HTTP
+
+# from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+#     OTLPSpanExporter,
+# )  # GRPC
+
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ConsoleSpanExporter,
+    SimpleSpanProcessor,
+)
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 
@@ -24,9 +37,9 @@ class HubTelemetry:
     def __new__(
         cls,
         service_name: str = "guardrails-hub",
-        endpoint: str = "localhost:4317",
+        endpoint: str = "http://localhost:4318/v1/traces",  # HTTP: 4318, GRPC: 4317
         tracer_name: str = "gr_hub",
-        export_locally: bool = True,
+        export_locally: bool = False,
     ):
         if cls._instance is None:
             print("Creating HubTelemetry instance...")
@@ -58,10 +71,10 @@ class HubTelemetry:
         self._tracer_provider = TracerProvider(resource=self._resource)
 
         if export_locally:
-            self._processor = BatchSpanProcessor(ConsoleSpanExporter())
+            self._processor = SimpleSpanProcessor(ConsoleSpanExporter())
         else:
-            self._processor = BatchSpanProcessor(
-                OTLPSpanExporter(endpoint=self._endpoint, insecure=True)
+            self._processor = SimpleSpanProcessor(
+                OTLPSpanExporter(endpoint=self._endpoint)
             )
 
         # Add the processor to the provider

--- a/guardrails/utils/hub_telemetry_utils.py
+++ b/guardrails/utils/hub_telemetry_utils.py
@@ -1,19 +1,16 @@
 # Imports
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # HTTP Exporter
     OTLPSpanExporter,
-)  # HTTP Exporter
+)
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import (
-    ConsoleSpanExporter,
-    SimpleSpanProcessor,
-)
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 
 class HubTelemetry:
-    """Singleton class for initializing a tracer for Guardrails Hub"""
+    """Singleton class for initializing a tracer for Guardrails Hub."""
 
     _instance = None
     _service_name = None
@@ -45,11 +42,13 @@ class HubTelemetry:
         tracer_name: str,
         export_locally: bool,
     ):
-        """Initializes a tracer for Guardrails Hub"""
+        """Initializes a tracer for Guardrails Hub."""
 
         self._service_name = service_name
-        # self._endpoint = "http://localhost:4318/v1/traces"  # Local Otel Collector (Docker)
-        self._endpoint = "https://hty0gc1ok3.execute-api.us-east-1.amazonaws.com/v1/traces"  # AWS ECS
+        # self._endpoint = "http://localhost:4318/v1/traces"
+        self._endpoint = (
+            "https://hty0gc1ok3.execute-api.us-east-1.amazonaws.com/v1/traces"
+        )
         self._tracer_name = tracer_name
 
         # Create a resource
@@ -76,16 +75,16 @@ class HubTelemetry:
         self._prop = TraceContextTextMapPropagator()
 
     def get_tracer(self):
-        """Returns the tracer"""
+        """Returns the tracer."""
 
         return self._tracer
 
     def inject_current_context(self) -> None:
-        """Injects the current context into the carrier"""
+        """Injects the current context into the carrier."""
         self._prop.inject(carrier=self._carrier)
 
     def extract_current_context(self):
-        """Extracts the current context from the carrier"""
+        """Extracts the current context from the carrier."""
 
         context = self._prop.extract(carrier=self._carrier)
         return context

--- a/guardrails/utils/hub_telemetry_utils.py
+++ b/guardrails/utils/hub_telemetry_utils.py
@@ -95,11 +95,13 @@ class HubTelemetry:
         is_parent: bool,  # Inject current context if IS a parent span
         has_parent: bool,  # Extract current context if HAS a parent span
     ):
-        """Creates a new span within the tracer with the given name and attributes.
+        """Creates a new span within the tracer with the given name and
+        attributes.
 
         If it's a parent span, the current context is injected into the carrier.
         If it has a parent span, the current context is extracted from the carrier.
-        Both the conditions can co-exist e.g. if it's a parent span and also has a parent span.
+        Both the conditions can co-exist e.g. a span can be a parent span which
+        also has a parent span.
 
         Args:
             span_name (str): The name of the span.

--- a/guardrails/utils/hub_telemetry_utils.py
+++ b/guardrails/utils/hub_telemetry_utils.py
@@ -1,4 +1,6 @@
 # Imports
+import logging
+
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # HTTP Exporter
     OTLPSpanExporter,
@@ -30,12 +32,12 @@ class HubTelemetry:
         export_locally: bool = False,
     ):
         if cls._instance is None:
-            print("Creating HubTelemetry instance...")
+            logging.debug("Creating HubTelemetry instance...")
             cls._instance = super(HubTelemetry, cls).__new__(cls)
-            print("Initializing HubTelemetry instance...")
+            logging.debug("Initializing HubTelemetry instance...")
             cls._instance.initialize_tracer(service_name, tracer_name, export_locally)
         else:
-            print("Returning existing HubTelemetry instance...")
+            logging.debug("Returning existing HubTelemetry instance...")
         return cls._instance
 
     def initialize_tracer(

--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -122,17 +122,19 @@ class ValidatorServiceBase:
         #   this will have to change.
         validator_logs.instance_id = to_string(id(validator))
 
-        # Get HubTelemetry singleton and tracer
-        hub_telemetry = HubTelemetry()
-        hub_tracer = hub_telemetry.get_tracer()
-        print(f"Getting tracer from location: {id(hub_tracer)}")
-
-        with hub_tracer.start_as_current_span(
-            "/validator_usage", context=hub_telemetry.extract_current_context()
-        ) as span:
-            span.set_attribute("validator_name", validator.rail_alias)
-            span.set_attribute("validator_on_fail", validator.on_fail_descriptor)
-            span.set_attribute("validator_result", result.outcome)
+        # Get HubTelemetry singleton and create a new span to
+        # log the validator usage
+        _hub_telemetry = HubTelemetry()
+        _hub_telemetry.create_new_span(
+            span_name="/validator_usage",
+            attributes=[
+                ("validator_name", validator.rail_alias),
+                ("validator_on_fail", validator.on_fail_descriptor),
+                ("validator_result", result.outcome),
+            ],
+            is_parent=False,  # This span will have no children
+            has_parent=True,  # This span has a parent
+        )
 
         return validator_logs
 

--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -125,6 +125,11 @@ class ValidatorServiceBase:
 
         # Get metrics opt-out from credentials
         disable_tracer = Credentials.from_rc_file().no_metrics
+        if disable_tracer.strip().lower() == "true":
+            disable_tracer = True
+        elif disable_tracer.strip().lower() == "false":
+            disable_tracer = False
+
         if not disable_tracer:
             # Get HubTelemetry singleton and create a new span to
             # log the validator usage

--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -130,10 +130,9 @@ class ValidatorServiceBase:
         with hub_tracer.start_as_current_span(
             "/validator_usage", context=hub_telemetry.extract_current_context()
         ) as span:
-            # Inject the current context
-            hub_telemetry.inject_current_context()
-
-            span.set_attribute("validator_name", validator_class_name)
+            span.set_attribute("validator_name", validator.rail_alias)
+            span.set_attribute("validator_on_fail", validator.on_fail_descriptor)
+            span.set_attribute("validator_result", result.outcome)
 
         return validator_logs
 

--- a/guardrails/validator_service.py
+++ b/guardrails/validator_service.py
@@ -9,6 +9,7 @@ from guardrails.classes.history import Iteration
 from guardrails.datatypes import FieldValidation
 from guardrails.logger import logger
 from guardrails.utils.casting_utils import to_string
+from guardrails.utils.hub_telemetry_utils import HubTelemetry
 from guardrails.utils.logs_utils import ValidatorLogs
 from guardrails.utils.reask_utils import FieldReAsk, ReAsk
 from guardrails.utils.safe_get import safe_get
@@ -22,7 +23,6 @@ from guardrails.validator_base import (
     Validator,
     ValidatorError,
 )
-from guardrails.utils.hub_telemetry_utils import HubTelemetry
 
 
 class ValidatorServiceBase:


### PR DESCRIPTION
## What is this about?
Adds manual instrumentation using the `OpenTelemetry` Python SDK to capture anonymous information and usage metadata and send it to a private OpenSearch sink for analysis. 

Following is all what we capture:
- User ID
- The unique ID of the Guard object
- The LLM provider API name
- Boolean values that reflect whether custom reask prompts and instructions were used (not the actual content of the prompts and instructions)
- The names of the validators utilized - including both in-house and custom-made (Just the name of the validator)
- The `on_fail` actions used on each of the validator e.g. fix, reask, refrain, noop, etc.
- The result of each validator: pass/fail (Again, just the outcome, not the content)
- The number of times `reask` was performed in each guard call

Following are some of the insights we get from the raw traces data:
- Number of uses per validator, guard and user, LLM Provider, outcome and on_fail action
- Number of times a custom reask prompt or instruction was provided
- Most popular validator, `on_fail` action and LLM Provider

## Why do we need this?
- Observability is crucial for understanding and maintaining complex distributed systems. As modern applications evolve to use microservices and other distributed architectures, it becomes challenging to trace the flow of requests and identify issues that may arise across various services. Observability tools like OpenTelemetry provide a unified way to collect and analyze data, allowing teams to monitor performance, troubleshoot problems, and optimize system behavior. This helps in maintaining a high level of reliability and performance in dynamic and distributed environments.
- This manual instrumentation helps to observe the metadata, gain valuable insights and find any bugs, and improve iteratively.