### PR TITLE
Update ends_with validator to support lists and strings with test

### DIFF
--- a/guardrails/validators/ends_with.py
+++ b/guardrails/validators/ends_with.py
@@ -10,7 +10,7 @@ from guardrails.validator_base import (
 )
 
 
-@register_validator(name="ends-with", data_type="list")
+@register_validator(name="ends-with", data_type=["string", "list"])
 class EndsWith(Validator):
     """Validates that a list ends with a given value.
 
@@ -19,8 +19,8 @@ class EndsWith(Validator):
     | Property                      | Description                       |
     | ----------------------------- | --------------------------------- |
     | Name for `format` attribute   | `ends-with`                       |
-    | Supported data types          | `list`                            |
-    | Programmatic fix              | Append the given value to the list. |
+    | Supported data types          | `list`, `string                   |
+    | Programmatic fix              | Append the given value to the list or string |
 
     Args:
         end: The required last element.
@@ -33,10 +33,15 @@ class EndsWith(Validator):
     def validate(self, value: Any, metadata: Dict) -> ValidationResult:
         logger.debug(f"Validating {value} ends with {self._end}...")
 
-        if not value[-1] == self._end:
+        end = self._end
+        if isinstance(value, list) and not isinstance(self._end, list):
+            end = [self._end]
+
+        ending_idxs = len(end)
+        if not value[-ending_idxs:] == end:
             return FailResult(
-                error_message=f"{value} must end with {self._end}",
-                fix_value=value + [self._end],
+                error_message=f"{value} must end with {end}",
+                fix_value=value + end,
             )
 
         return PassResult()

--- a/guardrails/validators/ends_with.py
+++ b/guardrails/validators/ends_with.py
@@ -39,7 +39,6 @@ class EndsWith(Validator):
 
         ending_idxs = len(end)
         if not value[-ending_idxs:] == end:
-
             if isinstance(value, list) and isinstance(end, list):
                 fix_value = value + end
             elif isinstance(value, str) and isinstance(end, str):

--- a/guardrails/validators/ends_with.py
+++ b/guardrails/validators/ends_with.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 
 from guardrails.logger import logger
 from guardrails.validator_base import (
@@ -26,7 +26,7 @@ class EndsWith(Validator):
         end: The required last element.
     """
 
-    def __init__(self, end: str, on_fail: str = "fix"):
+    def __init__(self, end: Union[List[Any], Any, str], on_fail: str = "fix"):
         super().__init__(on_fail=on_fail, end=end)
         self._end = end
 
@@ -39,9 +39,19 @@ class EndsWith(Validator):
 
         ending_idxs = len(end)
         if not value[-ending_idxs:] == end:
+
+            if isinstance(value, list) and isinstance(end, list):
+                fix_value = value + end
+            elif isinstance(value, str) and isinstance(end, str):
+                fix_value = value + end
+            else:
+                raise TypeError(
+                    "Cannot concatenate `end` and `value` of different types"
+                )
+
             return FailResult(
                 error_message=f"{value} must end with {end}",
-                fix_value=value + end,
+                fix_value=fix_value,
             )
 
         return PassResult()

--- a/tests/unit_tests/validators/test_ends_with.py
+++ b/tests/unit_tests/validators/test_ends_with.py
@@ -1,6 +1,6 @@
 import pytest
 
-from guardrails.validators import FailResult, PassResult, EndsWith
+from guardrails.validators import EndsWith, FailResult, PassResult
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/validators/test_ends_with.py
+++ b/tests/unit_tests/validators/test_ends_with.py
@@ -1,0 +1,29 @@
+import pytest
+
+from guardrails.validators import FailResult, PassResult, EndsWith
+
+
+@pytest.mark.parametrize(
+    "input, end, outcome, fix_value",
+    [
+        ("Test string", "g", "pass", None),
+        ("Test string", "string", "pass", None),
+        (["Item 1", "Item 2"], ["Item 2"], "pass", None),
+        (["Item 1", "Item 2", "Item 3"], ["Item 2", "Item 3"], "pass", None),
+        ("Test string", "Test", "fail", "Test stringTest"),
+        (["Item 1", "Item 2"], ["Item 1"], "fail", ["Item 1", "Item 2", "Item 1"]),
+        (["Item 1", "Item 2"], "Item 2", "pass", None),
+        (["Item 1", "Item 2"], "Item 3", "fail", ["Item 1", "Item 2", "Item 3"]),
+    ],
+)
+def test_ends_with_validator(input, end, outcome, fix_value):
+    """Test that the validator returns the expected outcome and fix_value."""
+    validator = EndsWith(end=end, on_fail="fix")
+    result: PassResult = validator.validate(input, {})
+
+    # Check that the result matches the expected outcome and fix_value
+    if outcome == "fail":
+        assert isinstance(result, FailResult)
+        assert result.fix_value == fix_value
+    else:
+        assert isinstance(result, PassResult)


### PR DESCRIPTION
- Existing `ends_with` validator only support lists, and comparing with the element at the last place of the list.
- This PR adds support for strings and lists, and comparing and expected end to be of any length
- Also adds a test