### PR TITLE
Remove deprecated code for unsupported datatypes

### DIFF
--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -168,8 +168,7 @@ def register_type(name: str):
 # Decorator for deprecation
 def deprecate_type(cls: type):
     warnings.warn(
-        f"""The '{cls.__name__}' type  is deprecated and will be removed in \
-versions 0.3.0 and beyond. Use the pydantic 'str' primitive instead.""",
+        f"""Use the pydantic 'str' primitive instead.""",
         DeprecationWarning,
     )
     return cls

--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -348,68 +348,6 @@ class Time(ScalarType):
 
         return datatype
 
-
-# @deprecate_type
-# @register_type("email")
-# class Email(ScalarType):
-#     """Element tag: `<email>`"""
-
-#     tag = "email"
-
-#     def __init__(self, *args, **kwargs):
-#         super().__init__(*args, **kwargs)
-#         deprecate_type(type(self))
-
-#     def get_example(self):
-#         return "hello@example.com"
-
-
-# @deprecate_type
-# @register_type("url")
-# class URL(ScalarType):
-#     """Element tag: `<url>`"""
-
-#     tag = "url"
-
-#     def __init__(self, *args, **kwargs):
-#         super().__init__(*args, **kwargs)
-#         deprecate_type(type(self))
-
-#     def get_example(self):
-#         return "https://example.com"
-
-
-# @deprecate_type
-# @register_type("pythoncode")
-# class PythonCode(ScalarType):
-#     """Element tag: `<pythoncode>`"""
-
-#     tag = "pythoncode"
-
-#     def __init__(self, *args, **kwargs):
-#         super().__init__(*args, **kwargs)
-#         deprecate_type(type(self))
-
-#     def get_example(self):
-#         return "print('hello world')"
-
-
-# @deprecate_type
-# @register_type("sql")
-# class SQLCode(ScalarType):
-#     """Element tag: `<sql>`"""
-
-#     tag = "sql"
-#     value: str
-
-#     def __init__(self, *args, **kwargs):
-#         super().__init__(*args, **kwargs)
-#         deprecate_type(type(self))
-
-#     def get_example(self):
-#         return "SELECT * FROM table"
-
-
 @register_type("percentage")
 class Percentage(ScalarType):
     """Element tag: `<percentage>`"""

--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -168,7 +168,8 @@ def register_type(name: str):
 # Decorator for deprecation
 def deprecate_type(cls: type):
     warnings.warn(
-        f"""Use the pydantic 'str' primitive instead.""",
+        f"""The '{cls.__name__}' type  is deprecated and will be removed in \
+versions 0.4.0 and beyond. Use the pydantic 'str' primitive instead.""",
         DeprecationWarning,
     )
     return cls
@@ -347,6 +348,7 @@ class Time(ScalarType):
             datatype.time_format = element.attrib["time-format"]
 
         return datatype
+
 
 @register_type("percentage")
 class Percentage(ScalarType):

--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -15,13 +15,7 @@ from guardrails.utils.xml_utils import cast_xml_to_string
 from guardrails.validator_base import Validator, ValidatorSpec
 from guardrails.validatorsattr import ValidatorsAttr
 
-# TODO - deprecate these altogether
-deprecated_string_types = {"sql", "email", "url", "pythoncode"}
-
-
 def update_deprecated_type_to_string(type):
-    if type in deprecated_string_types:
-        return "string"
     return type
 
 

--- a/guardrails/datatypes.py
+++ b/guardrails/datatypes.py
@@ -350,64 +350,65 @@ class Time(ScalarType):
         return datatype
 
 
-@deprecate_type
-@register_type("email")
-class Email(ScalarType):
-    """Element tag: `<email>`"""
+# @deprecate_type
+# @register_type("email")
+# class Email(ScalarType):
+#     """Element tag: `<email>`"""
 
-    tag = "email"
+#     tag = "email"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        deprecate_type(type(self))
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         deprecate_type(type(self))
 
-    def get_example(self):
-        return "hello@example.com"
-
-
-@deprecate_type
-@register_type("url")
-class URL(ScalarType):
-    """Element tag: `<url>`"""
-
-    tag = "url"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        deprecate_type(type(self))
-
-    def get_example(self):
-        return "https://example.com"
+#     def get_example(self):
+#         return "hello@example.com"
 
 
-@deprecate_type
-@register_type("pythoncode")
-class PythonCode(ScalarType):
-    """Element tag: `<pythoncode>`"""
+# @deprecate_type
+# @register_type("url")
+# class URL(ScalarType):
+#     """Element tag: `<url>`"""
 
-    tag = "pythoncode"
+#     tag = "url"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        deprecate_type(type(self))
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         deprecate_type(type(self))
 
-    def get_example(self):
-        return "print('hello world')"
+#     def get_example(self):
+#         return "https://example.com"
 
 
-@deprecate_type
-@register_type("sql")
-class SQLCode(ScalarType):
-    """Element tag: `<sql>`"""
+# @deprecate_type
+# @register_type("pythoncode")
+# class PythonCode(ScalarType):
+#     """Element tag: `<pythoncode>`"""
 
-    tag = "sql"
+#     tag = "pythoncode"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        deprecate_type(type(self))
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         deprecate_type(type(self))
 
-    def get_example(self):
-        return "SELECT * FROM table"
+#     def get_example(self):
+#         return "print('hello world')"
+
+
+# @deprecate_type
+# @register_type("sql")
+# class SQLCode(ScalarType):
+#     """Element tag: `<sql>`"""
+
+#     tag = "sql"
+#     value: str
+
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         deprecate_type(type(self))
+
+#     def get_example(self):
+#         return "SELECT * FROM table"
 
 
 @register_type("percentage")

--- a/guardrails/utils/json_utils.py
+++ b/guardrails/utils/json_utils.py
@@ -4,13 +4,11 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
 from guardrails.datatypes import (
-    URL,
     Boolean,
     Case,
     Choice,
     DataType,
     Date,
-    Email,
     Enum,
     Float,
     Integer,
@@ -18,7 +16,6 @@ from guardrails.datatypes import (
 from guardrails.datatypes import List as ListDataType
 from guardrails.datatypes import (
     Object,
-    PythonCode,
     String,
     Time,
     deprecated_string_types,
@@ -54,11 +51,11 @@ type_map: Dict[Type[DataType], Type] = {
     Enum: str,
 }
 
-ignore_types = [
-    Email,  # email and url should become string validators
-    URL,
-    PythonCode,
-]
+# ignore_types = [
+#     Email,  # email and url should become string validators
+#     URL,
+#     PythonCode,
+# ]
 
 
 @dataclass

--- a/guardrails/utils/json_utils.py
+++ b/guardrails/utils/json_utils.py
@@ -51,21 +51,12 @@ type_map: Dict[Type[DataType], Type] = {
     Enum: str,
 }
 
-# ignore_types = [
-#     Email,  # email and url should become string validators
-#     URL,
-#     PythonCode,
-# ]
-
-
 @dataclass
 class ValuePlaceholder(Placeholder):
     datatype_type: Type[DataType]
 
     @property
     def type_object(self):
-        if self.datatype_type in ignore_types:
-            return Any
         return type_map[self.datatype_type]
 
     class VerificationFailed:

--- a/guardrails/utils/pydantic_utils/v2.py
+++ b/guardrails/utils/pydantic_utils/v2.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, ge
 from pydantic import BaseModel, ConfigDict, HttpUrl, field_validator
 from pydantic.fields import FieldInfo
 
-from guardrails.datatypes import URL as URLDataType
+#from guardrails.datatypes import URL as URLDataType
 from guardrails.datatypes import Boolean as BooleanDataType
 from guardrails.datatypes import Case as CaseDataType
 from guardrails.datatypes import Choice
@@ -20,7 +20,7 @@ from guardrails.datatypes import Float as FloatDataType
 from guardrails.datatypes import Integer as IntegerDataType
 from guardrails.datatypes import List as ListDataType
 from guardrails.datatypes import Object as ObjectDataType
-from guardrails.datatypes import PythonCode as PythonCodeDataType
+#from guardrails.datatypes import PythonCode as PythonCodeDataType
 from guardrails.datatypes import String as StringDataType
 from guardrails.datatypes import Time as TimeDataType
 from guardrails.validator_base import Validator

--- a/guardrails/utils/pydantic_utils/v2.py
+++ b/guardrails/utils/pydantic_utils/v2.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, ge
 from pydantic import BaseModel, ConfigDict, HttpUrl, field_validator
 from pydantic.fields import FieldInfo
 
-#from guardrails.datatypes import URL as URLDataType
 from guardrails.datatypes import Boolean as BooleanDataType
 from guardrails.datatypes import Case as CaseDataType
 from guardrails.datatypes import Choice
@@ -20,7 +19,6 @@ from guardrails.datatypes import Float as FloatDataType
 from guardrails.datatypes import Integer as IntegerDataType
 from guardrails.datatypes import List as ListDataType
 from guardrails.datatypes import Object as ObjectDataType
-#from guardrails.datatypes import PythonCode as PythonCodeDataType
 from guardrails.datatypes import String as StringDataType
 from guardrails.datatypes import Time as TimeDataType
 from guardrails.validator_base import Validator


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/guardrails-ai/guardrails/issues/565) and 

1) Removes the `Email`, `URL`, `PythonCode`, and `SQLCode` classes as those are deprecated past version 0.3.0 
2) Changes the warning to say version 0.4.0 instead of 0.3.0 