### PR TITLE
Fix JSON Schema Validation when LLM returns JSON Array

### DIFF
--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -843,6 +843,8 @@ class Guard(Runnable, Generic[OT]):
             The validated response.
         """
         with start_action(action_type="guard_parse"):
+            if llm_output.startswith("["):
+                return ValidationOutcome(validation_passed=False, data=None, errors=["LLM output is a JSON array, expeccted an object."])
             runner = Runner(
                 instructions=kwargs.pop("instructions", None),
                 prompt=kwargs.pop("prompt", None),

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -48,6 +48,8 @@ from guardrails.stores.context import (
 from guardrails.utils.hub_telemetry_utils import HubTelemetry
 from guardrails.utils.validator_utils import get_validator
 from guardrails.validator_base import Validator
+from guardrails.utils.reask_utils import ReAsk
+
 
 add_destinations(logger.debug)
 
@@ -844,7 +846,7 @@ class Guard(Runnable, Generic[OT]):
         """
         with start_action(action_type="guard_parse"):
             if llm_output.startswith("["):
-                return ValidationOutcome(validation_passed=False, data=None, errors=["LLM output is a JSON array, expeccted an object."])
+                return ValidationOutcome(validation_passed=False, data=None, reask = ReAsk(), errors=["LLM output is a JSON array, expeccted an object."])
             runner = Runner(
                 instructions=kwargs.pop("instructions", None),
                 prompt=kwargs.pop("prompt", None),

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -50,7 +50,6 @@ from guardrails.utils.validator_utils import get_validator
 from guardrails.validator_base import Validator
 from guardrails.utils.reask_utils import ReAsk
 
-
 add_destinations(logger.debug)
 
 


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/guardrails-ai/guardrails/issues/594) and returns a `ValidationOutcome` when the LLM generates a JSON array instead of an object. 