### PR TITLE
Top Level List Support

### DIFF
--- a/docs/how_to_guides/structured_data_with_guardrails.mdx
+++ b/docs/how_to_guides/structured_data_with_guardrails.mdx
@@ -1,0 +1,219 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Generate structured data with Guardrails AI
+
+Guardrails AI is effective for generating structured data across from a variety of LLMs. This guide contains 
+the following:
+1. General instructions on generating structured data from Guardrails using `Pydantic` or Markup (i.e. `RAIL`), and
+2. Examples to generate structured data using `Pydantic` or Markup.
+
+## Syntax for generating structured data
+
+There are two ways to generate structured data with Guardrails AI: using `Pydantic` or Markup (i.e. `RAIL`).
+
+1. **Pydantic**: In order to generate structured data with Pydantic models, create a Pydantic model with the desired fields and types, then create a `Guard` object that uses the Pydantic model to generate structured data, and finally call the LLM of your choice with the `guard` object to generate structured data.
+2. **RAIL**: In order to generate structured data with RAIL specs, create a RAIL spec with the desired fields and types, then create a `Guard` object that uses the RAIL spec to generate structured data, and finally call the LLM of your choice with the `guard` object to generate structured data.
+
+Below is the syntax for generating structured data with Guardrails AI using `Pydantic` or Markup (i.e. `RAIL`).
+
+<Tabs>
+  <TabItem value="pydantic" label="Pydantic" default>
+    In order to generate structured data, first create a Pydantic model with the desired fields and types.
+    ```python
+    from pydantic import BaseModel
+
+    class Person(BaseModel):
+        name: str
+        age: int
+        is_employed: bool
+    ```
+
+    Then, create a `Guard` object that uses the Pydantic model to generate structured data.
+    ```python
+    from guardrails import Guard
+
+    guard = Guard.from_pydantic(Person)
+    ```
+
+    Finally, call the LLM of your choice with the `guard` object to generate structured data.
+    ```python
+    import openai
+
+    res = guard(
+        openai.chat.completion.create,
+        model="gpt-3.5-turbo",
+    )
+    ```
+  </TabItem>
+  <TabItem value="rail" label="RAIL">
+    In order to generate structured data, first create a RAIL spec with the desired fields and types.
+    ```xml
+    <rail version="0.1">
+      <output>
+        <string name="name" />
+        <integer name="age" />
+        <boolean name="is_employed" />
+      </output>
+    ```
+
+    Then, create a `Guard` object that uses the RAIL spec to generate structured data.
+    ```python
+    from guardrails import Guard
+
+    guard = Guard.from_s("""
+      <rail version="0.1">
+        <output>
+          <string name="name" />
+          <integer name="age" />
+          <boolean name="is_employed" />
+        </output>
+      </rail>
+    """)
+    ```
+
+    Finally, call the LLM of your choice with the `guard` object to generate structured data.
+    ```python
+    import openai
+
+    res = guard(
+        openai.chat.completion.create,
+        model="gpt-3.5-turbo",
+    )
+    ```
+  </TabItem>
+</Tabs>
+
+## Generate a JSON object with simple types
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+    ```json
+    {
+      "name": "John Doe",
+      "age": 30,
+      "is_employed": true
+    }
+    ```
+  </TabItem>
+  <TabItem value="pydantic" label="Pydantic">
+    ```python
+    from pydantic import BaseModel
+
+    class Person(BaseModel):
+        name: str
+        age: int
+        is_employed: bool
+    ```
+  </TabItem>
+  <TabItem value="rail" label="Markup">
+    ```xml
+    <rail version="0.1">
+      <output>
+        <string name="name" />
+        <integer name="age" />
+        <boolean name="is_employed" />
+      </output>
+    </rail>
+    ```
+  </TabItem>
+</Tabs>
+
+
+## Generate a dictionary of nested types
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+    ```json
+    {
+      "name": "John Doe",
+      "age": 30,
+      "is_employed": true,
+      "address": {
+        "street": "123 Main St",
+        "city": "Anytown",
+        "zip": "12345"
+      }
+    }
+    ```
+  </TabItem>
+  <TabItem value="pydantic" label="Pydantic">
+    ```python
+    from pydantic import BaseModel
+
+    class Address(BaseModel):
+        street: str
+        city: str
+        zip: str
+
+    class Person(BaseModel):
+        name: str
+        age: int
+        is_employed: bool
+        address: Address
+    ```
+  </TabItem>
+  <TabItem value="rail" label="Markup">
+    ```xml
+    <rail version="0.1">
+      <output>
+        <string name="name" />
+        <integer name="age" />
+        <boolean name="is_employed" />
+        <object name="address">
+          <string name="street" />
+          <string name="city" />
+          <string name="zip" />
+        </object>
+      </output>
+    </rail>
+    ```
+  </TabItem>
+</Tabs>
+
+
+## Generate a list of types
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+    ```json
+    [
+      {
+        "name": "John Doe",
+        "age": 30,
+        "is_employed": true
+      },
+      {
+        "name": "Jane Smith",
+        "age": 25,
+        "is_employed": false
+      }
+    ]
+    ```
+  </TabItem>
+  <TabItem value="pydantic" label="Pydantic">
+    ```python
+    from pydantic import BaseModel
+
+    class Person(BaseModel):
+        name: str
+        age: int
+        is_employed: bool
+
+    people = list[Person]
+    ```
+  </TabItem>
+  <TabItem value="rail" label="Markup">
+    ```xml
+    <rail version="0.1">
+      <output type="list">
+        <object>
+          <string name="name" />
+          <integer name="age" />
+          <boolean name="is_employed" />
+        </object>
+      </output>
+    </rail>
+    ```
+  </TabItem>
+</Tabs>

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -44,7 +44,7 @@ const sidebars = {
       type: "category",
       label: "How-to Guides",
       collapsed: true,
-      items: ["how_to_guides/logs", "how_to_guides/streaming", "how_to_guides/llm_api_wrappers", "how_to_guides/rail", "how_to_guides/envvars" ],
+      items: ["how_to_guides/logs", "how_to_guides/streaming", "how_to_guides/llm_api_wrappers", "how_to_guides/rail", "how_to_guides/envvars", "how_to_guides/structured_data_with_guardrails" ],
     },
     "the_guard",
     {

--- a/guardrails/classes/history/call.py
+++ b/guardrails/classes/history/call.py
@@ -366,3 +366,6 @@ class Call(ArbitraryModel):
             )
 
         return tree
+
+    def __str__(self) -> str:
+        return pretty_repr(self)

--- a/guardrails/classes/history/iteration.py
+++ b/guardrails/classes/history/iteration.py
@@ -189,3 +189,6 @@ class Iteration(ArbitraryModel):
                     style="on #F0FFF0",
                 ),
             )
+
+    def __str__(self) -> str:
+        return pretty_repr(self)

--- a/guardrails/classes/output_type.py
+++ b/guardrails/classes/output_type.py
@@ -1,3 +1,3 @@
-from typing import Dict, TypeVar
+from typing import Dict, List, TypeVar
 
-OT = TypeVar("OT", str, Dict)
+OT = TypeVar("OT", str, Dict, List)

--- a/guardrails/classes/output_type.py
+++ b/guardrails/classes/output_type.py
@@ -1,3 +1,3 @@
 from typing import Dict, List, TypeVar
 
-OT = TypeVar("OT", str, Dict, List)
+OT = TypeVar("OT", str, List, Dict)

--- a/guardrails/classes/validation_outcome.py
+++ b/guardrails/classes/validation_outcome.py
@@ -9,7 +9,7 @@ from guardrails.utils.logs_utils import ArbitraryModel
 from guardrails.utils.reask_utils import ReAsk
 
 
-class ValidationOutcome(Generic[OT], ArbitraryModel):
+class ValidationOutcome(ArbitraryModel, Generic[OT]):
     raw_llm_output: Optional[str] = Field(
         description="The raw, unchanged output from the LLM call.", default=None
     )

--- a/guardrails/classes/validation_outcome.py
+++ b/guardrails/classes/validation_outcome.py
@@ -1,6 +1,7 @@
 from typing import Generic, Iterator, Optional, Tuple, Union, cast
 
 from pydantic import Field
+from rich.pretty import pretty_repr
 
 from guardrails.classes.history import Call, Iteration
 from guardrails.classes.output_type import OT
@@ -83,3 +84,6 @@ class ValidationOutcome(ArbitraryModel, Generic[OT]):
     def __getitem__(self, keys):
         """Get a subset of the ValidationOutcome's fields."""
         return iter(getattr(self, k) for k in keys)
+
+    def __str__(self) -> str:
+        return pretty_repr(self)

--- a/guardrails/cli/validate.py
+++ b/guardrails/cli/validate.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 import typer
 
@@ -7,7 +7,7 @@ from guardrails import Guard
 from guardrails.cli.guardrails import guardrails
 
 
-def validate_llm_output(rail: str, llm_output: str) -> Union[str, Dict, None]:
+def validate_llm_output(rail: str, llm_output: str) -> Union[str, Dict, List, None]:
     """Validate guardrails.yml file."""
     guard = Guard.from_rail(rail)
     result = guard.parse(llm_output)

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -80,7 +80,9 @@ class Guard(Runnable, Generic[OT]):
         self,
         rail: Optional[Rail] = None,
         num_reasks: Optional[int] = None,
-        base_model: Optional[Type[BaseModel]] = None,
+        base_model: Optional[
+            Union[Type[BaseModel], Type[List[Type[BaseModel]]]]
+        ] = None,
         tracer: Optional[Tracer] = None,
     ):
         """Initialize the Guard with optional Rail instance, num_reasks, and
@@ -260,7 +262,7 @@ class Guard(Runnable, Generic[OT]):
     @classmethod
     def from_pydantic(
         cls,
-        output_class: Type[BaseModel],
+        output_class: Union[Type[BaseModel], Type[List[Type[BaseModel]]]],
         prompt: Optional[str] = None,
         instructions: Optional[str] = None,
         num_reasks: Optional[int] = None,
@@ -280,7 +282,10 @@ class Guard(Runnable, Generic[OT]):
             reask_prompt=reask_prompt,
             reask_instructions=reask_instructions,
         )
-        # TODO: Add List[BaseModel] support
+        if rail.output_type == "list":
+            return cast(
+                Guard[List], cls(rail, num_reasks=num_reasks, base_model=output_class)
+            )
         return cast(
             Guard[Dict],
             cls(rail, num_reasks=num_reasks, base_model=output_class, tracer=tracer),

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -220,6 +220,10 @@ class Guard(Runnable, Generic[OT]):
             return cast(
                 Guard[str], cls(rail=rail, num_reasks=num_reasks, tracer=tracer)
             )
+        elif rail.output_type == "list":
+            return cast(
+                Guard[List], cls(rail=rail, num_reasks=num_reasks, tracer=tracer)
+            )
         return cast(Guard[Dict], cls(rail=rail, num_reasks=num_reasks, tracer=tracer))
 
     @classmethod
@@ -247,6 +251,10 @@ class Guard(Runnable, Generic[OT]):
             return cast(
                 Guard[str], cls(rail=rail, num_reasks=num_reasks, tracer=tracer)
             )
+        elif rail.output_type == "list":
+            return cast(
+                Guard[List], cls(rail=rail, num_reasks=num_reasks, tracer=tracer)
+            )
         return cast(Guard[Dict], cls(rail=rail, num_reasks=num_reasks, tracer=tracer))
 
     @classmethod
@@ -272,6 +280,7 @@ class Guard(Runnable, Generic[OT]):
             reask_prompt=reask_prompt,
             reask_instructions=reask_instructions,
         )
+        # TODO: Add List[BaseModel] support
         return cast(
             Guard[Dict],
             cls(rail, num_reasks=num_reasks, base_model=output_class, tracer=tracer),

--- a/guardrails/rail.py
+++ b/guardrails/rail.py
@@ -1,12 +1,12 @@
 """Rail class."""
 import warnings
 from dataclasses import dataclass
-from typing import Optional, Sequence, Type
+from typing import List, Optional, Sequence, Type, Union
 
 from lxml import etree as ET
 from pydantic import BaseModel
 
-from guardrails.datatypes import List
+from guardrails.datatypes import List as ListDataType
 from guardrails.prompt import Instructions, Prompt
 from guardrails.schema import JsonSchema, Schema, StringSchema
 from guardrails.utils.xml_utils import cast_xml_to_string
@@ -67,7 +67,7 @@ class Rail:
         if isinstance(self.output_schema, StringSchema):
             return "str"
         elif isinstance(self.output_schema, JsonSchema) and isinstance(
-            self.output_schema.root_datatype, List
+            self.output_schema.root_datatype, ListDataType
         ):
             return "list"
         return "dict"
@@ -75,7 +75,7 @@ class Rail:
     @classmethod
     def from_pydantic(
         cls,
-        output_class: Type[BaseModel],
+        output_class: Union[Type[BaseModel], Type[List[Type[BaseModel]]]],
         prompt: Optional[str] = None,
         instructions: Optional[str] = None,
         reask_prompt: Optional[str] = None,
@@ -267,7 +267,7 @@ class Rail:
 
     @staticmethod
     def load_json_schema_from_pydantic(
-        output_class: Type[BaseModel],
+        output_class: Union[Type[BaseModel], Type[List[Type[BaseModel]]]],
         reask_prompt_template: Optional[str] = None,
         reask_instructions_template: Optional[str] = None,
     ):

--- a/guardrails/rail.py
+++ b/guardrails/rail.py
@@ -6,6 +6,7 @@ from typing import Optional, Sequence, Type
 from lxml import etree as ET
 from pydantic import BaseModel
 
+from guardrails.datatypes import List
 from guardrails.prompt import Instructions, Prompt
 from guardrails.schema import JsonSchema, Schema, StringSchema
 from guardrails.utils.xml_utils import cast_xml_to_string
@@ -65,8 +66,11 @@ class Rail:
 
         if isinstance(self.output_schema, StringSchema):
             return "str"
-        else:
-            return "dict"
+        elif isinstance(self.output_schema, JsonSchema) and isinstance(
+            self.output_schema.root_datatype, List
+        ):
+            return "list"
+        return "dict"
 
     @classmethod
     def from_pydantic(
@@ -226,18 +230,25 @@ class Rail:
         Returns:
             A Schema object.
         """
+        schema_type = root.attrib["type"] if "type" in root.attrib else "object"
         # If root contains a `type="string"` attribute, then it's a StringSchema
-        if "type" in root.attrib and root.attrib["type"] == "string":
+        if schema_type == "string":
             return StringSchema.from_xml(
                 root,
                 reask_prompt_template=reask_prompt,
                 reask_instructions_template=reask_instructions,
             )
-        return JsonSchema.from_xml(
-            root,
-            reask_prompt_template=reask_prompt,
-            reask_instructions_template=reask_instructions,
-        )
+        elif schema_type in ["object", "list"]:
+            return JsonSchema.from_xml(
+                root,
+                reask_prompt_template=reask_prompt,
+                reask_instructions_template=reask_instructions,
+            )
+        else:
+            raise ValueError(
+                "The type attribute of the <output /> tag must be one of:"
+                ' "string", "object", or "list"'
+            )
 
     @staticmethod
     def load_string_schema_from_string(

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -64,7 +64,9 @@ class Runner:
         msg_history_schema: Optional[StringSchema] = None,
         metadata: Optional[Dict[str, Any]] = None,
         output: Optional[str] = None,
-        base_model: Optional[Type[BaseModel]] = None,
+        base_model: Optional[
+            Union[Type[BaseModel], Type[List[Type[BaseModel]]]]
+        ] = None,
         full_schema_reask: bool = False,
     ):
         if prompt:
@@ -676,7 +678,9 @@ class AsyncRunner(Runner):
         msg_history_schema: Optional[StringSchema] = None,
         metadata: Optional[Dict[str, Any]] = None,
         output: Optional[str] = None,
-        base_model: Optional[Type[BaseModel]] = None,
+        base_model: Optional[
+            Union[Type[BaseModel], Type[List[Type[BaseModel]]]]
+        ] = None,
         full_schema_reask: bool = False,
     ):
         super().__init__(

--- a/guardrails/schema/json_schema.py
+++ b/guardrails/schema/json_schema.py
@@ -453,7 +453,7 @@ class JsonSchema(Schema):
 
         return validated_response
 
-    def introspect(self, data: Any) -> Tuple[List[ReAsk], Optional[Dict]]:
+    def introspect(self, data: Any) -> Tuple[List[ReAsk], Union[Dict, List, None]]:
         if isinstance(data, SkeletonReAsk):
             return [data], None
         elif isinstance(data, NonParseableReAsk):

--- a/guardrails/schema/string_schema.py
+++ b/guardrails/schema/string_schema.py
@@ -19,7 +19,11 @@ from guardrails.schema.schema import Schema
 from guardrails.utils.constants import constants
 from guardrails.utils.reask_utils import FieldReAsk, ReAsk
 from guardrails.utils.telemetry_utils import trace_validation_result
-from guardrails.validator_base import ValidatorSpec, check_refrain_in_dict, filter_in_dict
+from guardrails.validator_base import (
+    ValidatorSpec,
+    check_refrain_in_dict,
+    filter_in_dict,
+)
 
 
 class StringSchema(Schema):

--- a/guardrails/schema/string_schema.py
+++ b/guardrails/schema/string_schema.py
@@ -19,11 +19,7 @@ from guardrails.schema.schema import Schema
 from guardrails.utils.constants import constants
 from guardrails.utils.reask_utils import FieldReAsk, ReAsk
 from guardrails.utils.telemetry_utils import trace_validation_result
-from guardrails.validator_base import (
-    ValidatorSpec,
-    check_refrain_in_dict,
-    filter_in_dict,
-)
+from guardrails.validator_base import ValidatorSpec, check_refrain_in_dict, filter_in_dict
 
 
 class StringSchema(Schema):

--- a/guardrails/utils/json_utils.py
+++ b/guardrails/utils/json_utils.py
@@ -267,7 +267,9 @@ class ChoicePlaceholder(Placeholder):
         )
 
 
-def generate_type_skeleton_from_schema(schema: Object) -> Placeholder:
+def generate_type_skeleton_from_schema(
+    schema: Union[Object, ListDataType]
+) -> Placeholder:
     """Generate a JSON skeleton from an XML schema."""
 
     def _recurse_schema(schema: DataType):
@@ -327,7 +329,7 @@ be dropped in version 0.3.0 and beyond.""",
 
 
 def verify_schema_against_json(
-    schema: Object,
+    schema: Union[Object, ListDataType],
     generated_json: Dict[str, Any],
     prune_extra_keys: bool = False,
     coerce_types: bool = False,

--- a/guardrails/utils/pydantic_utils/v2.py
+++ b/guardrails/utils/pydantic_utils/v2.py
@@ -63,12 +63,15 @@ def add_validator(
 
 def is_pydantic_base_model(type_annotation: Any) -> Union[Type[BaseModel], None]:
     """Check if a type_annotation is a Pydantic BaseModel."""
-    if (
-        type_annotation is not None
-        and isinstance(type_annotation, type)
-        and issubclass(type_annotation, BaseModel)
-    ):
-        return type_annotation
+    try:
+        if (
+            type_annotation is not None
+            and isinstance(type_annotation, type)
+            and issubclass(type_annotation, BaseModel)
+        ):
+            return type_annotation
+    except TypeError:
+        pass
     return None
 
 

--- a/guardrails/utils/reask_utils.py
+++ b/guardrails/utils/reask_utils.py
@@ -86,9 +86,9 @@ def gather_reasks(
 
 
 def get_pruned_tree(
-    root: ObjectType,
+    root: Union[ObjectType, ListType],
     reasks: Optional[List[FieldReAsk]] = None,
-) -> ObjectType:
+) -> Union[ObjectType, ListType]:
     """Prune tree of any elements that are not in `reasks`.
 
     Return the tree with only the elements that are keys of `reasks` and

--- a/guardrails/utils/reask_utils.py
+++ b/guardrails/utils/reask_utils.py
@@ -26,8 +26,8 @@ class NonParseableReAsk(ReAsk):
 
 
 def gather_reasks(
-    validated_output: Optional[Union[str, Dict, ReAsk]]
-) -> Tuple[List[ReAsk], Optional[Dict]]:
+    validated_output: Optional[Union[str, Dict, List, ReAsk]]
+) -> Tuple[List[ReAsk], Union[Dict, List, None]]:
     """Traverse output and gather all ReAsk objects.
 
     Args:

--- a/guardrails/utils/reask_utils.py
+++ b/guardrails/utils/reask_utils.py
@@ -82,6 +82,10 @@ def gather_reasks(
         valid_output = deepcopy(validated_output)
         _gather_reasks_in_dict(validated_output, valid_output)
         return reasks, valid_output
+    elif isinstance(validated_output, List):
+        valid_output = deepcopy(validated_output)
+        _gather_reasks_in_list(validated_output, valid_output)
+        return reasks, valid_output
     return reasks, None
 
 

--- a/guardrails/validator_base.py
+++ b/guardrails/validator_base.py
@@ -76,6 +76,12 @@ def check_refrain_in_dict(schema: Dict) -> bool:
     return False
 
 
+def check_refrain(schema: Union[List, Dict]) -> bool:
+    if isinstance(schema, List):
+        return check_refrain_in_list(schema)
+    return check_refrain_in_dict(schema)
+
+
 def filter_in_list(schema: List) -> List:
     """Remove out all Filter objects from a list.
 
@@ -128,6 +134,12 @@ def filter_in_dict(schema: Dict) -> Dict:
             filtered_dict[key] = value
 
     return filtered_dict
+
+
+def filter_in_schema(schema: Union[Dict, List]) -> Union[Dict, List]:
+    if isinstance(schema, List):
+        return filter_in_list(schema)
+    return filter_in_dict(schema)
 
 
 validators_registry = {}

--- a/tests/integration_tests/mock_llm_outputs.py
+++ b/tests/integration_tests/mock_llm_outputs.py
@@ -7,7 +7,7 @@ from guardrails.llm_providers import (
 )
 from guardrails.utils.llm_response import LLMResponse
 
-from .test_assets import entity_extraction, pydantic, python_rail, string
+from .test_assets import entity_extraction, pydantic, python_rail, string, lists_object
 
 
 class MockOpenAICallable(OpenAICallable):
@@ -36,6 +36,7 @@ class MockOpenAICallable(OpenAICallable):
             python_rail.VALIDATOR_PARALLELISM_PROMPT_1: python_rail.VALIDATOR_PARALLELISM_RESPONSE_1,  # noqa: E501
             python_rail.VALIDATOR_PARALLELISM_PROMPT_2: python_rail.VALIDATOR_PARALLELISM_RESPONSE_2,  # noqa: E501
             python_rail.VALIDATOR_PARALLELISM_PROMPT_3: python_rail.VALIDATOR_PARALLELISM_RESPONSE_3,  # noqa: E501
+            lists_object.LIST_PROMPT: lists_object.LIST_OUTPUT,
         }
 
         try:

--- a/tests/integration_tests/mock_llm_outputs.py
+++ b/tests/integration_tests/mock_llm_outputs.py
@@ -7,7 +7,7 @@ from guardrails.llm_providers import (
 )
 from guardrails.utils.llm_response import LLMResponse
 
-from .test_assets import entity_extraction, pydantic, python_rail, string, lists_object
+from .test_assets import entity_extraction, lists_object, pydantic, python_rail, string
 
 
 class MockOpenAICallable(OpenAICallable):

--- a/tests/integration_tests/test_assets/lists_object.py
+++ b/tests/integration_tests/test_assets/lists_object.py
@@ -1,0 +1,33 @@
+from typing import List
+from pydantic import BaseModel
+
+
+LIST_PROMPT = """Create a list of items that may be found in a grocery store.
+
+Json Output:
+
+"""
+
+
+LIST_OUTPUT = """[{"name": "apple", "price": 1.0}, {"name": "banana", "price": 0.5}, {"name": "orange", "price": 1.5}]"""  # noqa: E501
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+
+
+PYDANTIC_RAIL_WITH_LIST = List[Item]
+
+
+RAIL_SPEC_WITH_LIST = """
+<rail version="0.1">
+  <output type="list">
+    <object>
+        <string name="name" />
+        <float name="price" />
+    </object>
+  </output>
+  <prompt>Create a list of items that may be found in a grocery store.</prompt>
+</rail>
+"""

--- a/tests/integration_tests/test_assets/lists_object.py
+++ b/tests/integration_tests/test_assets/lists_object.py
@@ -1,6 +1,6 @@
 from typing import List
-from pydantic import BaseModel
 
+from pydantic import BaseModel
 
 LIST_PROMPT = """Create a list of items that may be found in a grocery store.
 

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -1,7 +1,7 @@
 import enum
 import json
 import os
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import pytest
 from pydantic import BaseModel

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -134,8 +134,9 @@ def test_entity_extraction_with_reask(
 ):
     """Test that the entity extraction works with re-asking.
 
-    This test creates a Guard for the entity extraction use case. It performs
-    a single call to the LLM and then re-asks the LLM for a second time.
+    This test creates a Guard for the entity extraction use case. It
+    performs a single call to the LLM and then re-asks the LLM for a
+    second time.
     """
     mocker.patch("guardrails.llm_providers.OpenAICallable", new=MockOpenAICallable)
     mocker.patch(
@@ -864,9 +865,9 @@ def test_guard_as_runnable(output: str, throws: bool):
     [
         (
             lists_object.PYDANTIC_RAIL_WITH_LIST,
-            "Create a list of items that may be found in a grocery store."
+            "Create a list of items that may be found in a grocery store.",
         ),
-        (lists_object.RAIL_SPEC_WITH_LIST, None)
+        (lists_object.RAIL_SPEC_WITH_LIST, None),
     ],
 )
 def test_guard_with_top_level_list_return_type(mocker, rail, prompt):

--- a/tests/unit_tests/test_json_schema.py
+++ b/tests/unit_tests/test_json_schema.py
@@ -1,8 +1,9 @@
 import sys
 from typing import List
-from pydantic import BaseModel
+
 import pytest
 from lxml import etree as ET
+from pydantic import BaseModel
 
 from guardrails.schema.json_schema import JsonSchema
 
@@ -28,7 +29,7 @@ def test_json_schema_from_xml_outermost_list():
 def test_json_schema_from_pydantic_outermost_list_typing():
     class Foo(BaseModel):
         field: str
-    
+
     # Test 1: typing.List with BaseModel
     try:
         JsonSchema.from_pydantic(model=List[Foo])
@@ -37,13 +38,13 @@ def test_json_schema_from_pydantic_outermost_list_typing():
 
 
 @pytest.mark.skipif(
-        sys.version_info.major <= 3 and sys.version_info.minor <= 8,
-        reason="requires Python > 3.8"
+    sys.version_info.major <= 3 and sys.version_info.minor <= 8,
+    reason="requires Python > 3.8",
 )
 def test_json_schema_from_pydantic_outermost_list():
     class Foo(BaseModel):
         field: str
-    
+
     # Test 1: typing.List with BaseModel
     try:
         JsonSchema.from_pydantic(model=list[Foo])

--- a/tests/unit_tests/test_json_schema.py
+++ b/tests/unit_tests/test_json_schema.py
@@ -1,0 +1,51 @@
+import sys
+from typing import List
+from pydantic import BaseModel
+import pytest
+from lxml import etree as ET
+
+from guardrails.schema.json_schema import JsonSchema
+
+# Set up XML parser
+XMLPARSER = ET.XMLParser(encoding="utf-8")
+
+
+def test_json_schema_from_xml_outermost_list():
+    rail_spec = """
+<output>
+    <list name="temp_name">
+        <string name="string_name" />
+    </list>
+</output>
+"""
+    try:
+        xml = ET.fromstring(rail_spec, parser=XMLPARSER)
+        JsonSchema.from_xml(xml)
+    except Exception as e:
+        pytest.fail(f"JsonSchema.from_xml() raised an exception: {e}")
+
+
+def test_json_schema_from_pydantic_outermost_list_typing():
+    class Foo(BaseModel):
+        field: str
+    
+    # Test 1: typing.List with BaseModel
+    try:
+        JsonSchema.from_pydantic(model=List[Foo])
+    except Exception as e:
+        pytest.fail(f"JsonSchema.from_pydantic() raised an exception: {e}")
+
+
+@pytest.mark.skipif(
+        sys.version_info.major <= 3 and sys.version_info.minor <= 8,
+        reason="requires Python > 3.8"
+)
+def test_json_schema_from_pydantic_outermost_list():
+    class Foo(BaseModel):
+        field: str
+    
+    # Test 1: typing.List with BaseModel
+    try:
+        JsonSchema.from_pydantic(model=list[Foo])
+    except Exception as e:
+        pytest.fail(f"JsonSchema.from_pydantic() raised an exception: {e}")

--- a/tests/unit_tests/test_rail.py
+++ b/tests/unit_tests/test_rail.py
@@ -151,6 +151,25 @@ Hello world
     Rail.from_string(rail_spec)
 
 
+def test_rail_outermost_list():
+    rail_spec = """
+<rail version="0.1">
+
+<output type="list">
+    <object>
+        <string name="string_name" description="Any random string value" />
+    </object>
+</output>
+
+<prompt>
+Hello world
+</prompt>
+
+</rail>
+"""
+    Rail.from_string(rail_spec)
+
+
 def test_format_deprecated():
     rail_spec = """
     <rail version="0.1">

--- a/tests/unit_tests/test_validator_base.py
+++ b/tests/unit_tests/test_validator_base.py
@@ -1,7 +1,7 @@
 # Write tests for check_refrain and filter_in_schema in guardrails/validator_base.py
 import pytest
 
-from guardrails.validator_base import check_refrain, filter_in_schema, Refrain, Filter
+from guardrails.validator_base import Filter, Refrain, check_refrain, filter_in_schema
 
 
 @pytest.mark.parametrize(
@@ -19,7 +19,7 @@ from guardrails.validator_base import check_refrain, filter_in_schema, Refrain, 
         ({"a": "b", "c": {"d": "e"}}, False),
         ({"a": "b", "c": ["d", Refrain()]}, True),
         ({"a": "b", "c": ["d", "e"]}, False),
-    ]
+    ],
 )
 def test_check_refrain(schema, expected):
     assert check_refrain(schema) == expected
@@ -37,7 +37,7 @@ def test_check_refrain(schema, expected):
         ({"a": "b", "c": {"d": Filter()}}, {"a": "b", "c": {}}),
         ({"a": "b", "c": {"d": "e"}}, {"a": "b", "c": {"d": "e"}}),
         ({"a": "b", "c": ["d", Filter()]}, {"a": "b", "c": ["d"]}),
-    ]
+    ],
 )
 def test_filter_in_schema(schema, expected):
     assert filter_in_schema(schema) == expected

--- a/tests/unit_tests/test_validator_base.py
+++ b/tests/unit_tests/test_validator_base.py
@@ -1,0 +1,43 @@
+# Write tests for check_refrain and filter_in_schema in guardrails/validator_base.py
+import pytest
+
+from guardrails.validator_base import check_refrain, filter_in_schema, Refrain, Filter
+
+
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        (["a", Refrain(), "b"], True),
+        (["a", "b"], False),
+        (["a", ["b", Refrain(), "c"], "d"], True),
+        (["a", ["b", "c", "d"], "e"], False),
+        (["a", {"b": Refrain(), "c": "d"}, "e"], True),
+        (["a", {"b": "c", "d": "e"}, "f"], False),
+        ({"a": "b"}, False),
+        ({"a": Refrain()}, True),
+        ({"a": "b", "c": {"d": Refrain()}}, True),
+        ({"a": "b", "c": {"d": "e"}}, False),
+        ({"a": "b", "c": ["d", Refrain()]}, True),
+        ({"a": "b", "c": ["d", "e"]}, False),
+    ]
+)
+def test_check_refrain(schema, expected):
+    assert check_refrain(schema) == expected
+
+
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        (["a", Filter(), "b"], ["a", "b"]),
+        (["a", ["b", Filter(), "c"], "d"], ["a", ["b", "c"], "d"]),
+        (["a", ["b", "c", "d"], "e"], ["a", ["b", "c", "d"], "e"]),
+        (["a", {"b": Filter(), "c": "d"}, "e"], ["a", {"c": "d"}, "e"]),
+        ({"a": "b"}, {"a": "b"}),
+        ({"a": Filter()}, {}),
+        ({"a": "b", "c": {"d": Filter()}}, {"a": "b", "c": {}}),
+        ({"a": "b", "c": {"d": "e"}}, {"a": "b", "c": {"d": "e"}}),
+        ({"a": "b", "c": ["d", Filter()]}, {"a": "b", "c": ["d"]}),
+    ]
+)
+def test_filter_in_schema(schema, expected):
+    assert filter_in_schema(schema) == expected

--- a/tests/unit_tests/test_validators.py
+++ b/tests/unit_tests/test_validators.py
@@ -69,7 +69,7 @@ from .mocks.mock_comet import BAD_TRANSLATION, GOOD_TRANSLATION, MockModel
         ({"a": 1}, False),
     ],
 )
-def test_check_refrain(input_dict, expected):
+def test_check_refrain_in_dict(input_dict, expected):
     assert check_refrain_in_dict(input_dict) == expected
 
 


### PR DESCRIPTION
## Summary
Adds the ability to generate structured data where the outermost layer is a List/Array.  This can be helpful when using LLM's to generate synthetic data, when mimicking REST APIs, etc.

This PR also removes an exception that what raised during validation when the data was not a dictionary.  We now let the process enter schema validation regardless of its type.  If the type is wrong, this will be caught and result in a `SkeletonReAsk`.  Addresses https://github.com/guardrails-ai/guardrails/issues/594.

## Usage
A list structure can be specified as such:
### The Desired List Structure
```json
[
  { "field": "hello, world!" }
]
```

### Using Pydantic
```python
class Foo(BaseModel):
    field: str
    
guard = Guard.from_pydantic(output_class=List[Foo])
```

### Using RAIL
```xml
<rail version="0.1">
  <output type="list">
    <object>
        <string name="field" description="Any random string value" />
    </object>
  </output>
</rail>
```


## TODO
 - [x] Unit Tests
    - [x] Rail.output_type
    - [x] JsonSchema.from_xml
    - [x] JsonSchema.from_pydantic
    - [x] validator_base.check_refrain
    - [x] validator_base.filter_in_schema
 - [x] Integration Tests
    - [x] from_pydantic with List[BaseModel]
    - [x] from_rail with output.type = "list"
 - [ ] Notebooks?
 - [x] Documentation?