### PR TITLE
Add make target for local typing runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,25 +74,9 @@ jobs:
           poetry run pip install pydantic==${{ matrix.pydantic-version }}
           poetry run pip install openai==${{ matrix.openai-version }}
 
-      - if: matrix.pydantic-version == '2.4.2' && matrix.openai-version == '0.28.1'
-        name: Static analysis with pyright (ignoring pydantic v1 and openai v1)
+      - name: Static analysis with pyright
         run: |
-          make type-pydantic-v2-openai-v0
-
-      - if: matrix.pydantic-version == '1.10.9' && matrix.openai-version == '0.28.1'
-        name: Static analysis with mypy (ignoring pydantic v2 and openai v1)
-        run: |
-          make type-pydantic-v1-openai-v0
-
-      - if: matrix.pydantic-version == '2.4.2' && matrix.openai-version == '1.2.4'
-        name: Static analysis with pyright (ignoring pydantic v1 and openai v0)
-        run: |
-          make type-pydantic-v2-openai-v1
-
-      - if: matrix.pydantic-version == '1.10.9' && matrix.openai-version == '1.2.4'
-        name: Static analysis with mypy (ignoring pydantic v2 and openai v0)
-        run: |
-          make type-pydantic-v1-openai-v1
+          make type-local
 
   Pytests:
     runs-on: LargeBois

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Static analysis with pyright
         run: |
-          make type-local
+          make type
 
   Pytests:
     runs-on: LargeBois

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ Follow these steps before committing your changes:
 
 1. Ensure tests pass: `make test`
 2. Format your code: `make autoformat`
-3. Update documentation if needed. Docs are located in the `docs` directory. You can serve docs using `mkdocs serve`.
+3. Run static analysis: `make type-local`
+4. Update documentation if needed. Docs are located in the `docs` directory. You can serve docs using `mkdocs serve`.
 
 ### Optional: Pre-Commit Hooks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Follow these steps before committing your changes:
 
 1. Ensure tests pass: `make test`
 2. Format your code: `make autoformat`
-3. Run static analysis: `make type-local`
+3. Run static analysis: `make type`
 4. Update documentation if needed. Docs are located in the `docs` directory. You can serve docs using `mkdocs serve`.
 
 ### Optional: Pre-Commit Hooks

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 MKDOCS_SERVE_ADDR ?= localhost:8000 # Default address for mkdocs serve, format: <host>:<port>, override with `make docs-serve MKDOCS_SERVE_ADDR=<host>:<port>`
 
+# Extract major package versions for OpenAI and Pydantic
+OPENAI_VERSION_MAJOR := $(shell python -c 'import openai; print(openai.__version__.split(".")[0])')
+PYDANTIC_VERSION_MAJOR := $(shell python -c 'import pydantic; print(pydantic.__version__.split(".")[0])')
+
+# Construct the typing command using only major versions
+TYPING_CMD := type-pydantic-v$(PYDANTIC_VERSION_MAJOR)-openai-v$(OPENAI_VERSION_MAJOR)
+
 autoformat:
 	poetry run black guardrails/ tests/
 	poetry run isort --atomic guardrails/ tests/
@@ -7,6 +14,10 @@ autoformat:
 
 type:
 	poetry run pyright guardrails/
+
+.PHONY: typing
+type-local:
+	@make $(TYPING_CMD)
 
 type-pydantic-v1-openai-v0:
 	echo '{"exclude": ["guardrails/utils/pydantic_utils/v2.py", "guardrails/utils/openai_utils/v1.py"]}' > pyrightconfig.json

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 MKDOCS_SERVE_ADDR ?= localhost:8000 # Default address for mkdocs serve, format: <host>:<port>, override with `make docs-serve MKDOCS_SERVE_ADDR=<host>:<port>`
 
 # Extract major package versions for OpenAI and Pydantic
-OPENAI_VERSION_MAJOR := $(shell python -c 'import openai; print(openai.__version__.split(".")[0])')
-PYDANTIC_VERSION_MAJOR := $(shell python -c 'import pydantic; print(pydantic.__version__.split(".")[0])')
+OPENAI_VERSION_MAJOR := $(shell poetry run python -c 'import openai; print(openai.__version__.split(".")[0])')
+PYDANTIC_VERSION_MAJOR := $(shell poetry run python -c 'import pydantic; print(pydantic.__version__.split(".")[0])')
 
 # Construct the typing command using only major versions
 TYPING_CMD := type-pydantic-v$(PYDANTIC_VERSION_MAJOR)-openai-v$(OPENAI_VERSION_MAJOR)

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,8 @@ autoformat:
 	poetry run isort --atomic guardrails/ tests/
 	poetry run docformatter --in-place --recursive guardrails tests
 
+.PHONY: type
 type:
-	poetry run pyright guardrails/
-
-.PHONY: typing
-type-local:
 	@make $(TYPING_CMD)
 
 type-pydantic-v1-openai-v0:


### PR DESCRIPTION
Currently, there are different typing targets in the make file based on the versions of `pydantic` and `openai`.

This PR adds a new `make` target called `type-local` that runs the appropriate typing target based on the correct versions of `pydantic` and `openai`.