### PR TITLE
write `use`-ed validators to output_schema root node

### DIFF
--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -1026,7 +1026,6 @@ class Guard(Runnable, Generic[OT]):
             self._validators.append(hydrated_validator)
             self.rail.output_schema.root_datatype.validators.append(hydrated_validator)
 
-
         return self
 
     def validate(self, llm_output: str, *args, **kwargs) -> ValidationOutcome[str]:

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -987,6 +987,17 @@ class Guard(Runnable, Generic[OT]):
     def use(
         self, validator: Union[Validator, Type[Validator]], *args, **kwargs
     ) -> "Guard":
+        """
+        Use a validator to validate results of an LLM request.
+        
+        *Note*: `use` is only available for string output types.
+        """
+
+        if (self.rail.output_type != "str"):
+            raise RuntimeError(
+                "The `use` method is only available for string output types."
+            )
+
         if validator:
             hydrated_validator = get_validator(validator, *args, **kwargs)
             self._validators.append(hydrated_validator)
@@ -1021,6 +1032,17 @@ class Guard(Runnable, Generic[OT]):
             ],
         ],
     ) -> "Guard":
+        """
+        Use a validator to validate results of an LLM request.
+        
+        *Note*: `use_many` is only available for string output types.
+        """
+
+        if self.rail.output_type != "str":
+            raise RuntimeError(
+                "The `use_many` method is only available for string output types."
+            )
+
         for v in validators:
             hydrated_validator = get_validator(v)
             self._validators.append(hydrated_validator)

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -987,13 +987,12 @@ class Guard(Runnable, Generic[OT]):
     def use(
         self, validator: Union[Validator, Type[Validator]], *args, **kwargs
     ) -> "Guard":
-        """
-        Use a validator to validate results of an LLM request.
-        
+        """Use a validator to validate results of an LLM request.
+
         *Note*: `use` is only available for string output types.
         """
 
-        if (self.rail.output_type != "str"):
+        if self.rail.output_type != "str":
             raise RuntimeError(
                 "The `use` method is only available for string output types."
             )
@@ -1032,9 +1031,8 @@ class Guard(Runnable, Generic[OT]):
             ],
         ],
     ) -> "Guard":
-        """
-        Use a validator to validate results of an LLM request.
-        
+        """Use a validator to validate results of an LLM request.
+
         *Note*: `use_many` is only available for string output types.
         """
 

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -988,7 +988,10 @@ class Guard(Runnable, Generic[OT]):
         self, validator: Union[Validator, Type[Validator]], *args, **kwargs
     ) -> "Guard":
         if validator:
-            self._validators.append(get_validator(validator, *args, **kwargs))
+            hydrated_validator = get_validator(validator, *args, **kwargs)
+            self._validators.append(hydrated_validator)
+
+            self.rail.output_schema.root_datatype.validators.append(hydrated_validator)
 
         return self
 
@@ -1019,7 +1022,10 @@ class Guard(Runnable, Generic[OT]):
         ],
     ) -> "Guard":
         for v in validators:
-            self._validators.append(get_validator(v))
+            hydrated_validator = get_validator(v)
+            self._validators.append(hydrated_validator)
+            self.rail.output_schema.root_datatype.validators.append(hydrated_validator)
+
 
         return self
 

--- a/tests/unit_tests/test_guard.py
+++ b/tests/unit_tests/test_guard.py
@@ -216,8 +216,10 @@ def test_use():
 
     # Raises error when trying to `use` a validator on a non-string
     with pytest.raises(RuntimeError):
+
         class TestClass(BaseModel):
             another_field: str
+
         py_guard = Guard.from_pydantic(output_class=TestClass)
         py_guard.use(EndsWith("a"), OneLine(), LowerCase(), TwoWords(on_fail="reask"))
 
@@ -246,10 +248,14 @@ def test_use_many_instances():
 
     # Raises error when trying to `use_many` a validator on a non-string
     with pytest.raises(RuntimeError):
+
         class TestClass(BaseModel):
             another_field: str
+
         py_guard = Guard.from_pydantic(output_class=TestClass)
-        py_guard.use_many([EndsWith("a"), OneLine(), LowerCase(), TwoWords(on_fail="reask")])
+        py_guard.use_many(
+            [EndsWith("a"), OneLine(), LowerCase(), TwoWords(on_fail="reask")]
+        )
 
 
 def test_use_many_tuple():

--- a/tests/unit_tests/test_guard.py
+++ b/tests/unit_tests/test_guard.py
@@ -214,6 +214,13 @@ def test_use():
     assert guard._validators[4]._kwargs["max"] == 12
     assert guard._validators[4].on_fail_descriptor == "refrain"  # bc we set it
 
+    # Raises error when trying to `use` a validator on a non-string
+    with pytest.raises(RuntimeError):
+        class TestClass(BaseModel):
+            another_field: str
+        py_guard = Guard.from_pydantic(output_class=TestClass)
+        py_guard.use(EndsWith("a"), OneLine(), LowerCase(), TwoWords(on_fail="reask"))
+
 
 def test_use_many_instances():
     guard: Guard = Guard().use_many(
@@ -236,6 +243,13 @@ def test_use_many_instances():
 
     assert isinstance(guard._validators[3], TwoWords)
     assert guard._validators[3].on_fail_descriptor == "reask"  # bc we set it
+
+    # Raises error when trying to `use_many` a validator on a non-string
+    with pytest.raises(RuntimeError):
+        class TestClass(BaseModel):
+            another_field: str
+        py_guard = Guard.from_pydantic(output_class=TestClass)
+        py_guard.use_many([EndsWith("a"), OneLine(), LowerCase(), TwoWords(on_fail="reask")])
 
 
 def test_use_many_tuple():

--- a/tests/unit_tests/test_guard.py
+++ b/tests/unit_tests/test_guard.py
@@ -278,14 +278,13 @@ def test_use_many_tuple():
 def test_validate():
     guard: Guard = (
         Guard()
-        .use(EndsWith("a"))
         .use(OneLine)
         .use(LowerCase(on_fail="fix"))
         .use(TwoWords)
         .use(ValidLength, 0, 12, on_fail="refrain")
     )
 
-    llm_output = "Oh Canada"  # bc it meets our criteria
+    llm_output: str = "Oh Canada"  # bc it meets our criteria
 
     response = guard.validate(llm_output)
 


### PR DESCRIPTION
This makes it possible to use the `.use` syntax with guard.call()