### PR TITLE
Bugfix for empty string validation

### DIFF
--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -1380,13 +1380,15 @@ class StreamRunner(Runner):
                 output, stream=True, verified=verified
             )
 
-            # Error can be either of (True/False/None/string representing error)
+            # Error can be either of
+            # (True/False/None/ValueError/string representing error)
             if error:
                 # If parsing error is a string,
                 # it is an error from output_schema.parse_fragment()
                 if isinstance(error, str):
                     raise ValueError("Unable to parse output: " + error)
-            # Else if either of (None/True/False), return parsed_output and error
+            # Else if either of
+            # (None/True/False/ValueError), return parsed_output and error
 
             action.log(
                 message_type="info",

--- a/guardrails/schema/string_schema.py
+++ b/guardrails/schema/string_schema.py
@@ -122,8 +122,9 @@ class StringSchema(Schema):
 
         return self, prompt, instructions
 
-    def parse(self, output: str, **kwargs) -> Tuple[Any, Optional[Exception]]:
-        return output, None
+    def parse(self, output: str, **kwargs) -> Tuple[Any, bool]:
+        error = not output  # True if empty/None, else False
+        return output, error
 
     def validate(
         self,

--- a/guardrails/schema/string_schema.py
+++ b/guardrails/schema/string_schema.py
@@ -122,8 +122,9 @@ class StringSchema(Schema):
 
         return self, prompt, instructions
 
-    def parse(self, output: str, **kwargs) -> Tuple[Any, bool]:
-        error = not output  # True if empty/None, else False
+    def parse(self, output: str, **kwargs) -> Tuple[Any, Optional[Exception]]:
+        # Return a ValueError if the output is empty, else None
+        error = ValueError("Empty response received.") if not output else None
         return output, error
 
     def validate(


### PR DESCRIPTION
- Fixes this https://github.com/guardrails-ai/guardrails/issues/619
- Was previously always returning `None` as error for `StringSchema`'s `parse()` method. This allowed even empty strings/None to fail validators which expect only non-empty strings.
- Solution: Return `True` as error if empty string, else `False` -> This will enable `move_to_next` [here](https://github.com/guardrails-ai/guardrails/blob/ac7e2081765b74ca61cd34a77f1e4c8dbd55f4c3/guardrails/run.py#L1282): and will continue until a non-empty string is found.