### PR TITLE
Handle Invalid RC Files

### DIFF
--- a/guardrails/classes/credentials.py
+++ b/guardrails/classes/credentials.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from dataclasses import dataclass
 from os.path import expanduser
@@ -14,16 +15,30 @@ class Credentials(Serializeable):
     no_metrics: Optional[bool] = False
 
     @staticmethod
-    def from_rc_file() -> "Credentials":
+    def from_rc_file(logger: Optional[logging.Logger] = None) -> "Credentials":
         try:
+            if not logger:
+                logger = logging.getLogger()
             home = expanduser("~")
             guardrails_rc = os.path.join(home, ".guardrailsrc")
             with open(guardrails_rc) as rc_file:
                 lines = rc_file.readlines()
+                filtered_lines = list(filter(lambda l: l.strip(), lines))
                 creds = {}
-                for line in lines:
-                    key, value = line.split("=", 1)
-                    creds[key.strip()] = value.strip()
+                for line in filtered_lines:
+                    line_content = line.split("=", 1)
+                    if len(line_content) != 2:
+                        logger.warn(
+                            """
+                            Invalid line found in .guardrailsrc file!
+                            All lines in this file should follow the format: key=value
+                            Ignoring line contents...
+                            """
+                        )
+                        logger.debug(f".guardrailsrc file location: {guardrails_rc}")
+                    else:
+                        key, value = line_content
+                        creds[key.strip()] = value.strip()
                 rc_file.close()
                 return Credentials.from_dict(creds)
 

--- a/guardrails/cli/configure.py
+++ b/guardrails/cli/configure.py
@@ -21,7 +21,7 @@ def save_configuration_file(
             f"id={str(uuid.uuid4())}{os.linesep}",
             f"client_id={client_id}{os.linesep}",
             f"client_secret={client_secret}{os.linesep}",
-            f"no_metrics={str(no_metrics).lower()}{os.linesep}",
+            f"no_metrics={str(no_metrics).lower()}",
         ]
         rc_file.writelines(lines)
         rc_file.close()

--- a/guardrails/cli/server/hub_client.py
+++ b/guardrails/cli/server/hub_client.py
@@ -63,7 +63,7 @@ def fetch_module_manifest(
 
 
 def fetch_module(module_name: str) -> ModuleManifest:
-    creds = Credentials.from_rc_file()
+    creds = Credentials.from_rc_file(logger)
     token = get_auth_token(creds)
 
     module_manifest_json = fetch_module_manifest(module_name, token, creds.id)
@@ -89,7 +89,7 @@ def get_validator_manifest(module_name: str):
 # GET /auth
 def get_auth():
     try:
-        creds = Credentials.from_rc_file()
+        creds = Credentials.from_rc_file(logger)
         token = get_auth_token(creds)
         auth_url = f"{validator_hub_service}/auth"
         response = fetch(auth_url, token, creds.id)
@@ -105,7 +105,7 @@ def get_auth():
 
 def post_validator_submit(package_name: str, content: str):
     try:
-        creds = Credentials.from_rc_file()
+        creds = Credentials.from_rc_file(logger)
         token = get_auth_token(creds)
         submission_url = f"{validator_hub_service}/validator/submit"
 

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -126,11 +126,13 @@ class Guard(Runnable, Generic[OT]):
         self.base_model = base_model
         self._set_tracer(tracer)
 
+        credentials = Credentials.from_rc_file(logger)
+
         # Get unique id of user from credentials
-        self._user_id = Credentials.from_rc_file().id or ""
+        self._user_id = credentials.id or ""
 
         # Get metrics opt-out from credentials
-        self._disable_tracer = Credentials.from_rc_file().no_metrics
+        self._disable_tracer = credentials.no_metrics
 
         # Get id of guard object (that is unique)
         self._guard_id = id(self)  # id of guard object; not the class
@@ -683,6 +685,7 @@ class Guard(Runnable, Generic[OT]):
                     metadata=metadata,
                     base_model=self.base_model,
                     full_schema_reask=full_schema_reask,
+                    disable_tracer=self._disable_tracer,
                 )
                 return runner(call_log=call_log, prompt_params=prompt_params)
         else:
@@ -701,6 +704,7 @@ class Guard(Runnable, Generic[OT]):
                     metadata=metadata,
                     base_model=self.base_model,
                     full_schema_reask=full_schema_reask,
+                    disable_tracer=self._disable_tracer,
                 )
                 call = runner(call_log=call_log, prompt_params=prompt_params)
                 return ValidationOutcome[OT].from_guard_history(call)
@@ -760,6 +764,7 @@ class Guard(Runnable, Generic[OT]):
                 metadata=metadata,
                 base_model=self.base_model,
                 full_schema_reask=full_schema_reask,
+                disable_tracer=self._disable_tracer,
             )
             call = await runner.async_run(
                 call_log=call_log, prompt_params=prompt_params
@@ -1020,6 +1025,7 @@ class Guard(Runnable, Generic[OT]):
                 output=llm_output,
                 base_model=self.base_model,
                 full_schema_reask=full_schema_reask,
+                disable_tracer=self._disable_tracer,
             )
             call = runner(call_log=call_log, prompt_params=prompt_params)
 
@@ -1062,6 +1068,7 @@ class Guard(Runnable, Generic[OT]):
                 output=llm_output,
                 base_model=self.base_model,
                 full_schema_reask=full_schema_reask,
+                disable_tracer=self._disable_tracer,
             )
             call = await runner.async_run(
                 call_log=call_log, prompt_params=prompt_params

--- a/guardrails/schema/json_schema.py
+++ b/guardrails/schema/json_schema.py
@@ -326,6 +326,7 @@ class JsonSchema(Schema):
         data: Optional[Dict[str, Any]],
         metadata: Dict,
         attempt_number: int = 0,
+        disable_tracer: Optional[bool] = True,
         **kwargs,
     ) -> Any:
         """Validate a dictionary of data against the schema.
@@ -369,6 +370,7 @@ class JsonSchema(Schema):
             metadata=metadata,
             validator_setup=validation,
             iteration=iteration,
+            disable_tracer=disable_tracer,
         )
 
         if check_refrain(validated_response):

--- a/guardrails/schema/string_schema.py
+++ b/guardrails/schema/string_schema.py
@@ -131,6 +131,7 @@ class StringSchema(Schema):
         data: Any,
         metadata: Dict,
         attempt_number: int = 0,
+        disable_tracer: Optional[bool] = True,
         **kwargs,
     ) -> Any:
         """Validate a dictionary of data against the schema.
@@ -163,6 +164,7 @@ class StringSchema(Schema):
             metadata=metadata,
             validator_setup=validation,
             iteration=iteration,
+            disable_tracer=disable_tracer,
         )
 
         validated_response = {dummy_key: validated_response}

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -128,7 +128,7 @@ def guard_initializer(
         ),
     ],
 )
-@pytest.mark.parametrize("multiprocessing_validators", (True,))  # False))
+@pytest.mark.parametrize("multiprocessing_validators", (True, False))
 def test_entity_extraction_with_reask(
     mocker, rail, prompt, test_full_schema_reask, multiprocessing_validators
 ):
@@ -172,14 +172,17 @@ def test_entity_extraction_with_reask(
     assert first.validation_output == entity_extraction.VALIDATED_OUTPUT_REASK_1
 
     # For reask validator logs
-    # TODO: Update once we add json_path to the ValidatorLog class
-    nested_validator_logs = list(
-        x for x in first.validator_logs if x.value_before_validation == "my chase plan"
+    two_words_validator_logs = list(
+        x
+        for x in first.validator_logs
+        if x.property_path == "$.fees.1.name" and x.registered_name == "two-words"
     )
-    nested_validator_log = nested_validator_logs[1]
 
-    assert nested_validator_log.value_before_validation == "my chase plan"
-    assert nested_validator_log.value_after_validation == FieldReAsk(
+    two_words_validator_log = two_words_validator_logs[0]
+
+    assert two_words_validator_log.value_before_validation == "my chase plan"
+
+    expected_value_after_validation = FieldReAsk(
         incorrect_value="my chase plan",
         fail_results=[
             FailResult(
@@ -188,6 +191,10 @@ def test_entity_extraction_with_reask(
             )
         ],
         path=["fees", 1, "name"],
+    )
+    assert (
+        two_words_validator_log.value_after_validation
+        == expected_value_after_validation
     )
 
     # For re-asked prompt and output

--- a/tests/unit_tests/cli/test_configure.py
+++ b/tests/unit_tests/cli/test_configure.py
@@ -98,7 +98,7 @@ def test_save_configuration_file(mocker):
             f"id=f49354e0-80c7-4591-81db-cc2f945e5f1e{os.linesep}",
             f"client_id=id{os.linesep}",
             f"client_secret=secret{os.linesep}",
-            f"no_metrics=true{os.linesep}",
+            "no_metrics=true",
         ]
     )
     assert close_spy.call_count == 1

--- a/tests/unit_tests/mocks/mock_async_validator_service.py
+++ b/tests/unit_tests/mocks/mock_async_validator_service.py
@@ -2,6 +2,11 @@ import asyncio
 
 
 class MockAsyncValidatorService:
+    initialized: bool
+
+    def __init__(self, *args, **kwargs):
+        self.initialized = True
+
     async def async_validate(self, *args):
         await asyncio.sleep(0.1)
         # The return value doesn't really matter here.

--- a/tests/unit_tests/mocks/mock_sequential_validator_service.py
+++ b/tests/unit_tests/mocks/mock_sequential_validator_service.py
@@ -1,3 +1,8 @@
 class MockSequentialValidatorService:
+    initialized: bool
+
+    def __init__(self, *args, **kwargs):
+        self.initialized = True
+
     def validate(self, *args):
         return "MockSequentialValidatorService.validate", {"sync": True}


### PR DESCRIPTION
Should fix the issue reported in discord: https://discord.com/channels/1085077079697150023/1086092225122926614/1216673781691711509

The only way I was able to reproduce the failure reported there was to add multiple empty newlines to the `.guardrailsrc` file manually.  Since both reporters of this issue were using Windows I assume it has to do with differences in how `readlines` works between different operating systems.  The current fix first filters out any empty lines, then asserts that each line has a key and a value before trying to deconstruct them for assignment.  If we still somehow encounter a line with only one item in the tuple after splitting on `=`, we log a warning and move on.  This should reveal any other issues and allow the end user to both debug on their own and include more information when reporting any issues.

Also, since we are now using the logger in the Credentials class which is shared between the cli and library, I send the logger via dependency injection so that we can use the appropriate logger based on the situation.  After fixing this, tests regarding multi-processing started failing.  I'm not completely sure why these changes triggered those failures, but the root cause of the failures were duplicated logs hence the removal on line 299 of validator_service.  I also updated the failing test to be more clear what instances we're comparing in the assertions.

[EDIT]: Forgot to add that this PR also reduces the number of times we're loading credentials from the rc file during the Guard/validation lifecycle.  As part of that, I also defaulted to disabling the tracer if not specified.  @zsimjee this would make our anonymous metrics opt-in instead of opt-out.  