### PR TITLE
Lite chaining updates

### DIFF
--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -34,6 +34,7 @@ from guardrails_api_client.types import UNSET
 from langchain_core.messages import BaseMessage
 from langchain_core.runnables import Runnable, RunnableConfig
 from pydantic import BaseModel
+from typing_extensions import deprecated
 
 from guardrails.api_client import GuardrailsApiClient
 from guardrails.classes import OT, InputType, ValidationOutcome
@@ -1065,6 +1066,13 @@ class Guard(Runnable, Generic[OT]):
 
         return ValidationOutcome[OT].from_guard_history(call)
 
+    @deprecated(
+        """The `with_prompt_validation` method is deprecated,
+        and will be removed in 0.5.x. Instead, please use
+        `Guard().use(YourValidator, on='prompt')`.""",
+        FutureWarning,
+        stacklevel=2,
+    )
     def with_prompt_validation(
         self,
         validators: Sequence[Validator],
@@ -1074,12 +1082,6 @@ class Guard(Runnable, Generic[OT]):
         Args:
             validators: The validators to add to the prompt.
         """
-        warnings.warn(
-            """The `with_prompt_validation` method is deprecated,
-            and will be removed in 0.5.x. Instead, please use
-            `Guard().use(YourValidator, on='prompt')`.""",
-            FutureWarning,
-        )
         if self.rail.prompt_schema:
             warnings.warn("Overriding existing prompt validators.")
         schema = StringSchema.from_string(
@@ -1088,6 +1090,13 @@ class Guard(Runnable, Generic[OT]):
         self.rail.prompt_schema = schema
         return self
 
+    @deprecated(
+        """The `with_instructions_validation` method is deprecated,
+        and will be removed in 0.5.x. Instead, please use
+        `Guard().use(YourValidator, on='instructions')`.""",
+        FutureWarning,
+        stacklevel=2,
+    )
     def with_instructions_validation(
         self,
         validators: Sequence[Validator],
@@ -1097,12 +1106,6 @@ class Guard(Runnable, Generic[OT]):
         Args:
             validators: The validators to add to the instructions.
         """
-        warnings.warn(
-            """The `with_instructions_validation` method is deprecated,
-            and will be removed in 0.5.x. Instead, please use
-            `Guard().use(YourValidator, on='instructions')`.""",
-            FutureWarning,
-        )
         if self.rail.instructions_schema:
             warnings.warn("Overriding existing instructions validators.")
         schema = StringSchema.from_string(
@@ -1111,6 +1114,13 @@ class Guard(Runnable, Generic[OT]):
         self.rail.instructions_schema = schema
         return self
 
+    @deprecated(
+        """The `with_msg_history_validation` method is deprecated,
+        and will be removed in 0.5.x. Instead, please use
+        `Guard().use(YourValidator, on='msg_history')`.""",
+        FutureWarning,
+        stacklevel=2,
+    )
     def with_msg_history_validation(
         self,
         validators: Sequence[Validator],
@@ -1120,12 +1130,6 @@ class Guard(Runnable, Generic[OT]):
         Args:
             validators: The validators to add to the msg_history.
         """
-        warnings.warn(
-            """The `with_msg_history_validation` method is deprecated,
-            and will be removed in 0.5.x. Instead, please use
-            `Guard().use(YourValidator, on='msg_history')`.""",
-            FutureWarning,
-        )
         if self.rail.msg_history_schema:
             warnings.warn("Overriding existing msg_history validators.")
         schema = StringSchema.from_string(

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -1074,6 +1074,12 @@ class Guard(Runnable, Generic[OT]):
         Args:
             validators: The validators to add to the prompt.
         """
+        warnings.warn(
+            """The `with_prompt_validation` method is deprecated,
+            and will be removed in 0.5.x. Instead, please use
+            `Guard().use(YourValidator, on='prompt')`.""",
+            FutureWarning,
+        )
         if self.rail.prompt_schema:
             warnings.warn("Overriding existing prompt validators.")
         schema = StringSchema.from_string(
@@ -1091,6 +1097,12 @@ class Guard(Runnable, Generic[OT]):
         Args:
             validators: The validators to add to the instructions.
         """
+        warnings.warn(
+            """The `with_instructions_validation` method is deprecated,
+            and will be removed in 0.5.x. Instead, please use
+            `Guard().use(YourValidator, on='instructions')`.""",
+            FutureWarning,
+        )
         if self.rail.instructions_schema:
             warnings.warn("Overriding existing instructions validators.")
         schema = StringSchema.from_string(
@@ -1108,6 +1120,12 @@ class Guard(Runnable, Generic[OT]):
         Args:
             validators: The validators to add to the msg_history.
         """
+        warnings.warn(
+            """The `with_msg_history_validation` method is deprecated,
+            and will be removed in 0.5.x. Instead, please use
+            `Guard().use(YourValidator, on='msg_history')`.""",
+            FutureWarning,
+        )
         if self.rail.msg_history_schema:
             warnings.warn("Overriding existing msg_history validators.")
         schema = StringSchema.from_string(

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -1070,7 +1070,7 @@ class Guard(Runnable, Generic[OT]):
         """The `with_prompt_validation` method is deprecated,
         and will be removed in 0.5.x. Instead, please use
         `Guard().use(YourValidator, on='prompt')`.""",
-        FutureWarning,
+        category=FutureWarning,
         stacklevel=2,
     )
     def with_prompt_validation(
@@ -1094,7 +1094,7 @@ class Guard(Runnable, Generic[OT]):
         """The `with_instructions_validation` method is deprecated,
         and will be removed in 0.5.x. Instead, please use
         `Guard().use(YourValidator, on='instructions')`.""",
-        FutureWarning,
+        category=FutureWarning,
         stacklevel=2,
     )
     def with_instructions_validation(
@@ -1118,7 +1118,7 @@ class Guard(Runnable, Generic[OT]):
         """The `with_msg_history_validation` method is deprecated,
         and will be removed in 0.5.x. Instead, please use
         `Guard().use(YourValidator, on='msg_history')`.""",
-        FutureWarning,
+        category=FutureWarning,
         stacklevel=2,
     )
     def with_msg_history_validation(
@@ -1185,7 +1185,7 @@ class Guard(Runnable, Generic[OT]):
             )
 
     @overload
-    def use(self, validator: Validator, on: str = "output") -> "Guard":
+    def use(self, validator: Validator, *, on: str = "output") -> "Guard":
         ...
 
     @overload

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -841,7 +841,7 @@ def test_guard_as_runnable(output: str, throws: bool):
     model = MockModel()
     guard = (
         Guard()
-        .use(RegexMatch("Ice cream", match_type="search"))
+        .use(RegexMatch("Ice cream", match_type="search"), on="output")
         .use(ReadingTime(0.05))  # 3 seconds
     )
     output_parser = StrOutputParser()

--- a/tests/integration_tests/test_litellm.py
+++ b/tests/integration_tests/test_litellm.py
@@ -5,8 +5,13 @@ from typing import List
 import pytest
 
 import guardrails as gd
-from guardrails.validators import LowerCase
-
+from guardrails.validators import (
+    LowerCase,
+    UpperCase,
+    OneLine,
+    EndsWith,
+    ValidLength
+)
 
 # Mock the litellm.completion function and
 # the classes it returns
@@ -14,47 +19,179 @@ from guardrails.validators import LowerCase
 class Message:
     content: str
 
-
 @dataclass
 class Choice:
     message: Message
-
 
 @dataclass
 class Usage:
     prompt_tokens: int
     completion_tokens: int
 
-
 @dataclass
 class MockResponse:
     choices: List[Choice]
     usage: Usage
 
-
 class MockCompletion:
     @staticmethod
-    def create() -> MockResponse:
+    def create(output) -> MockResponse:
         return MockResponse(
-            choices=[Choice(message=Message(content="GUARDRAILS AI"))],
+            choices=[Choice(message=Message(content=output))],
             usage=Usage(prompt_tokens=10, completion_tokens=20),
         )
-
-
-TEST_PROMPT = "Suggest a name for an AI company. The name should be short and catchy."
-guard = gd.Guard.from_string(validators=[LowerCase(on_fail="fix")], prompt=TEST_PROMPT)
-
 
 @pytest.mark.skipif(
     not importlib.util.find_spec("litellm"),
     reason="`litellm` is not installed",
 )
-def test_litellm_completion(mocker):
+@pytest.mark.parametrize(
+    "input_text, expected", 
+    [
+        ("Suggestions for a name for an AI company. The name should be short and catchy.", "GUARDRAILS AI"),
+        ("What is the capital of France?", "PARIS"),
+    ]
+)
+def test_litellm_completion(mocker, input_text, expected):
     """Test that Guardrails can use litellm for completions."""
     import litellm
 
-    mocker.patch("litellm.completion", return_value=MockCompletion.create())
+    mocker.patch("litellm.completion", return_value=MockCompletion.create(expected))
 
+    guard = gd.Guard.from_string(validators=[LowerCase(on_fail="fix")], prompt=input_text)
+    
     raw, validated, *rest = guard(litellm.completion)
-    assert raw == "GUARDRAILS AI"
-    assert validated == "guardrails ai"
+    assert raw == expected
+    assert validated == expected.lower()
+
+# Test Guard().use() with just output validators
+@pytest.mark.skipif(
+    not importlib.util.find_spec("litellm"),
+    reason="`litellm` is not installed",
+)
+@pytest.mark.parametrize(
+    "input_text, raw_response, pass_output", 
+    [
+        ("Name one Oscar-nominated film", "may december", True),
+        ("Name one Oscar-nominated film", "PAST LIVES", False),
+    ]
+)
+def test_guard_use_output_validators(mocker, input_text, raw_response, pass_output):
+    """Test Guard().use() with just output validators."""
+    import litellm
+    mocker.patch("litellm.completion", return_value=MockCompletion.create(raw_response))
+
+    guard = gd.Guard().use(LowerCase, on="output", on_fail="fix").use(OneLine, on="output", on_fail="noop")
+    raw, validated, *rest = guard(litellm.completion, prompt=input_text)
+
+    assert raw == raw_response
+    if pass_output:
+        assert validated == raw_response
+    else:
+        assert validated == raw_response.lower()
+
+# Test Guard().use() with a combination of prompt and output validators
+@pytest.mark.skipif(
+    not importlib.util.find_spec("litellm"),
+    reason="`litellm` is not installed",
+)
+@pytest.mark.parametrize(
+    "input_text, pass_input, raw_response, pass_output", 
+    [
+        ("name one oscar-nominated film", True, "MAY DECEMBER", True),
+        ("Name one Oscar-nominated film", False, "PAST LIVES", True),
+        ("Name one Oscar-nominated film", False, "past lives", False),
+        ("name one oscar-nominated film", True, "past lives", False),
+    ]
+)
+def test_guard_use_combination_validators(mocker, input_text, pass_input, raw_response, pass_output):
+    """Test Guard().use() with a combination of prompt and output validators."""
+    import litellm
+    mocker.patch("litellm.completion", return_value=MockCompletion.create(raw_response))
+
+    guard = gd.Guard().use(LowerCase, on="prompt", on_fail="exception").use(UpperCase, on="output", on_fail="fix")
+    
+    if pass_input:
+        raw, validated, *rest = guard(litellm.completion, prompt=input_text)
+
+        assert raw == raw_response
+        if pass_output:
+            assert validated == raw_response
+        else:
+            assert validated == raw_response.upper()
+    else:
+        with pytest.raises(Exception):
+            raw, validated, *rest = guard(litellm.completion, prompt=input_text)
+
+
+
+# Test Guard().use_many() with just output validators
+@pytest.mark.skipif(
+    not importlib.util.find_spec("litellm"),
+    reason="`litellm` is not installed",
+)
+@pytest.mark.parametrize(
+    "input_text, raw_response, pass_output", 
+    [
+        ("Name one Oscar-nominated film", "may december", True),
+        ("Name one Oscar-nominated film", "PAST LIVES", False),
+    ]
+)
+def test_guard_use_many_output_validators(mocker, input_text, raw_response, pass_output):
+    """Test Guard().use_many() with just output validators."""
+    import litellm
+    mocker.patch("litellm.completion", return_value=MockCompletion.create(raw_response))
+
+    guard = gd.Guard().use_many(
+        LowerCase(on_fail="fix"),
+        OneLine(on_fail="noop"),
+        on="output"
+    )
+    raw, validated, *rest = guard(litellm.completion, prompt=input_text)
+
+    assert raw == raw_response
+    if pass_output:
+        assert validated == raw_response
+    else:
+        assert validated == raw_response.lower()
+
+
+# Test Guard().use_many() with a combination of prompt and output validators
+@pytest.mark.skipif(
+    not importlib.util.find_spec("litellm"),
+    reason="`litellm` is not installed",
+)
+@pytest.mark.parametrize(
+    "input_text, pass_input, raw_response, pass_output", 
+    [
+        ("name one oscar-nominated film", True, "MAY DECEMBER", True),
+        ("Name one Oscar-nominated film", False, "PAST LIVES", True),
+        ("Name one Oscar-nominated film", False, "past lives", False),
+        ("name one oscar-nominated film", True, "past lives", False),
+    ]
+)
+def test_guard_use_many_combination_validators(mocker, input_text, pass_input, raw_response, pass_output):
+    """Test Guard().use() with a combination of prompt and output validators."""
+    import litellm
+    mocker.patch("litellm.completion", return_value=MockCompletion.create(raw_response))
+
+    # guard = gd.Guard().use(LowerCase, on="prompt", on_fail="exception").use(UpperCase, on="output", on_fail="fix")
+    guard = gd.Guard().use_many(
+        LowerCase(on_fail="exception"),
+        on="prompt"
+    ).use_many(
+        UpperCase(on_fail="fix"),
+        on="output"
+    )
+    
+    if pass_input:
+        raw, validated, *rest = guard(litellm.completion, prompt=input_text)
+
+        assert raw == raw_response
+        if pass_output:
+            assert validated == raw_response
+        else:
+            assert validated == raw_response.upper()
+    else:
+        with pytest.raises(Exception):
+            raw, validated, *rest = guard(litellm.completion, prompt=input_text)

--- a/tests/unit_tests/test_guard.py
+++ b/tests/unit_tests/test_guard.py
@@ -225,7 +225,8 @@ def test_use():
         py_guard.use(EndsWith("a"), OneLine(), LowerCase(), TwoWords(on_fail="reask"))
 
     # Use a combination of prompt, instructions, msg_history and output validators
-    # Should only have the output validators in the guard, everything else is in the schema
+    # Should only have the output validators in the guard,
+    # everything else is in the schema
     guard: Guard = (
         Guard()
         .use(LowerCase, on="prompt")
@@ -252,6 +253,7 @@ def test_use():
             .use(EndsWith("a"), on="response")  # invalid on parameter
             .use(OneLine, on="prompt")  # valid on parameter
         )
+
 
 def test_use_many_instances():
     guard: Guard = Guard().use_many(
@@ -375,11 +377,14 @@ def test_use_many_tuple():
             on="response",
         )
 
+
 def test_validate():
     guard: Guard = (
         Guard()
         .use(OneLine)
-        .use(LowerCase(on_fail="fix"), on="output")  # default on="output", still explicitly set
+        .use(
+            LowerCase(on_fail="fix"), on="output"
+        )  # default on="output", still explicitly set
         .use(TwoWords)
         .use(ValidLength, 0, 12, on_fail="refrain")
     )
@@ -423,6 +428,7 @@ def test_validate():
 
     assert response_2.validation_passed is False
     assert response_2.validated_output is None
+
 
 # def test_call():
 #     five_seconds = 5 / 60


### PR DESCRIPTION
- Add keyword argument `on` to both `Guard().use()` and `Guard().use_many()` to specify where the validation will take place. Valid options for `on` are : `prompt`, `instructions`, `msg_history` and `output`. This is as per new design choices for a better developer experience.
- Refactor `use()` and `use_many()` accordingly to make these changes
- Add both unit and integration tests that significantly and especially `prompt` and `output` validation.
- The following methods are now deprecated:
   - `with_prompt_validation`
   - `with_msg_history_validation`
   - `with_instructions_validation`