### PR TITLE
Endpoint is reachable zero-click vulnerability fix

### DIFF
--- a/guardrails/validators/endpoint_is_reachable.py
+++ b/guardrails/validators/endpoint_is_reachable.py
@@ -27,27 +27,46 @@ class EndpointIsReachable(Validator):
         logger.debug(f"Validating {value} is a valid URL...")
 
         import requests
+        from urllib.parse import urlparse
+        from tldextract import extract
 
         # Check that the URL exists and can be reached
         try:
-            response = requests.get(value)
+            url = urlparse(value)
+            extracted = extract(value)
+
+            # Check that the URL has a scheme and network location
+            if not url.scheme or not extracted.domain or not extracted.suffix:
+                return FailResult(
+                    error_message=f"URL {value} is not valid.",
+                )
+
+            # Reconstruct the URL with consideration for 'www' subdomain
+            subdomain = f"{extracted.subdomain}." if "www" in extracted.subdomain else ""
+            sanitized_url = f"{url.scheme}://{subdomain}{extracted.domain}.{extracted.suffix}/"
+
+            response = requests.get(sanitized_url)
             if response.status_code != 200:
                 return FailResult(
-                    error_message=f"URL {value} returned "
+                    error_message=f"URL {sanitized_url} returned "
                     f"status code {response.status_code}",
                 )
         except requests.exceptions.ConnectionError:
             return FailResult(
-                error_message=f"URL {value} could not be reached",
+                error_message=f"URL {sanitized_url} could not be reached",
             )
         except requests.exceptions.InvalidSchema:
             return FailResult(
-                error_message=f"URL {value} does not specify "
+                error_message=f"URL {sanitized_url} does not specify "
                 f"a valid connection adapter",
             )
         except requests.exceptions.MissingSchema:
             return FailResult(
-                error_message=f"URL {value} does not contain " f"a http schema",
+                error_message=f"URL {sanitized_url} does not contain " f"a http schema",
+            )
+        except ValueError:
+            return FailResult(
+                error_message=f"URL {value} is not valid.",
             )
 
         return PassResult()


### PR DESCRIPTION
Read Issue #662 for more info on why I made this PR.
This is the implementation of the 2nd proposed solution from the issue description.

I don't like that I imported `tldextract` method, but I wanted to make it robust.
Please let me know if there's a way to implement this without importing it.

Here are some of the cases that I used to test the functionality:
`https://www.subdomain.domain.co.uk/path/path-2?id=2` -> `https://www.domain.co.uk `
`https://subdomain.domain.co.uk/path/path-2?id=2` -> `https://domain.co.uk`
`https://www.subdomain.domain.com/path/path-2?id=2` -> `https://www.domain.com `
`https://subdomain.domain.com/path/path-2?id=2` -> `https://domain.com`
`https://www.domain.com/path/path-2?id=2` -> `https://www.domain.com `
`https://domain.com/path/path-2?id=2` -> `https://domain.com`

P.S. It's not the ideal solution in my opinion. I would suggest maybe even removing `endpoint is reachable` validator.

Fixing #662 