### PR TITLE
Fix `validated_output` rendering for guard.history.logs.tree

### DIFF
--- a/guardrails/classes/history/iteration.py
+++ b/guardrails/classes/history/iteration.py
@@ -215,7 +215,9 @@ versions 0.5.0 and beyond. Use 'guarded_output' instead."""
                     self.raw_output or "", title="Raw LLM Output", style="on #F5F5DC"
                 ),
                 Panel(
-                    pretty_repr(self.validation_response),
+                    self.validation_response
+                    if isinstance(self.validation_response, str)
+                    else pretty_repr(self.validation_response),
                     title="Validated Output",
                     style="on #F0FFF0",
                 ),


### PR DESCRIPTION
This PR fixes the rendering of the validated output in the `guard.history.last.tree`, which was messed up because we did `pretty_repr` on the panel for `validated_output`.