### PR TITLE
non-working input standardization

### DIFF
--- a/guardrails/classes/history/call_inputs.py
+++ b/guardrails/classes/history/call_inputs.py
@@ -17,6 +17,7 @@ class CallInputs(Inputs):
     instructions: Optional[str] = Field(
         description="The instructions string as provided by the user.", default=None
     )
+
     args: List[Any] = Field(
         description="Additional arguments for the LLM as provided by the user.",
         default_factory=list,

--- a/guardrails/classes/history/inputs.py
+++ b/guardrails/classes/history/inputs.py
@@ -46,3 +46,8 @@ class Inputs(ArbitraryModel):
         "or at the field level.",
         default=None,
     )
+
+    kwargs: Optional[Dict[str, Any]] = Field(
+        description="The kwargs provided by the user for the LLM call.",
+        default=None,
+    )

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -465,6 +465,7 @@ class Guard(Runnable, Generic[OT]):
         metadata: Optional[Dict] = None,
         full_schema_reask: Optional[bool] = None,
         stream: Optional[bool] = False,
+        messages: Optional[List[Dict]] = None,
         *args,
         **kwargs,
     ) -> Union[ValidationOutcome[OT], Iterable[ValidationOutcome[OT]]]:
@@ -481,6 +482,7 @@ class Guard(Runnable, Generic[OT]):
         msg_history: Optional[List[Dict]] = None,
         metadata: Optional[Dict] = None,
         full_schema_reask: Optional[bool] = None,
+        messages: Optional[List[Dict]] = None,
         *args,
         **kwargs,
     ) -> Awaitable[ValidationOutcome[OT]]:
@@ -496,6 +498,7 @@ class Guard(Runnable, Generic[OT]):
         msg_history: Optional[List[Dict]] = None,
         metadata: Optional[Dict] = None,
         full_schema_reask: Optional[bool] = None,
+        messages: Optional[List[Dict]] = None,
         *args,
         **kwargs,
     ) -> Union[
@@ -533,6 +536,7 @@ class Guard(Runnable, Generic[OT]):
             msg_history: Optional[List[Dict]] = None,
             metadata: Optional[Dict] = None,
             full_schema_reask: Optional[bool] = None,
+            messages: Optional[List[Dict]] = None,
             *args,
             **kwargs,
         ):
@@ -659,6 +663,7 @@ class Guard(Runnable, Generic[OT]):
         prompt: Optional[str],
         instructions: Optional[str],
         msg_history: Optional[List[Dict]],
+        messages: Optional[List[Dict]],
         metadata: Dict,
         full_schema_reask: bool,
         call_log: Call,
@@ -668,12 +673,6 @@ class Guard(Runnable, Generic[OT]):
         instructions_obj = instructions or self.instructions
         prompt_obj = prompt or self.prompt
         msg_history_obj = msg_history or []
-        if prompt_obj is None:
-            if msg_history is not None and not len(msg_history_obj):
-                raise RuntimeError(
-                    "You must provide a prompt if msg_history is empty. "
-                    "Alternatively, you can provide a prompt in the Schema constructor."
-                )
 
         # Check whether stream is set
         if kwargs.get("stream", False):
@@ -683,6 +682,7 @@ class Guard(Runnable, Generic[OT]):
                 prompt=prompt_obj,
                 msg_history=msg_history_obj,
                 api=get_llm_ask(llm_api, *args, **kwargs),
+                # Remove prompt_schema, instructions_schema, msg_history_schema in 0.5.0
                 prompt_schema=self.prompt_schema,
                 instructions_schema=self.instructions_schema,
                 msg_history_schema=self.msg_history_schema,
@@ -697,10 +697,13 @@ class Guard(Runnable, Generic[OT]):
         else:
             # Otherwise, use Runner
             runner = Runner(
+                api=get_llm_ask(llm_api, *args, **kwargs),
                 instructions=instructions_obj,
                 prompt=prompt_obj,
                 msg_history=msg_history_obj,
-                api=get_llm_ask(llm_api, *args, **kwargs),
+                messages=messages,
+
+                # Remove prompt_schema, instructions_schema, msg_history_schema in 0.5.0
                 prompt_schema=self.prompt_schema,
                 instructions_schema=self.instructions_schema,
                 msg_history_schema=self.msg_history_schema,

--- a/guardrails/run/llm_mapping.py
+++ b/guardrails/run/llm_mapping.py
@@ -1,0 +1,93 @@
+from pydash import get
+
+llms_and_params = {
+  "ai21": {
+    "input": ["prompt"],
+    "output": ["response.completions.data[0].text"],
+    "streaming_output": []
+  },
+  "anthropic": {
+    "input": ["system", "messages"],
+    "output": ["message.content"],
+    "streaming_output": []
+  },
+  "aleph-alpha": {
+    "input": ["prompt"],
+    "output": ["completions[0].completion"],
+    "streaming_output": []
+  },
+  "azure-openai": {
+    "input": ["prompt", "messages"],
+    "output": [
+      "completion.choices[0].message.content", # chat
+      "choices[0].text", # completion
+      "choices[0].message.function_call.arguments", # function calling
+    ],
+    "streaming_output": [
+      "chunk.choices[0].delta.content", #streaming
+    ]
+  },
+  "cohere": {
+    "input": ["chat_history", "message"],
+    "output": [
+      ""
+    ],
+    "streaming_output": []
+  },
+  "gemini": {
+    "input": ["messages"],
+    "output": [
+      "text",
+      "chunk.text" # streaming
+    ],
+    "streaming_output": []
+  },
+  "ollama": {
+    "input": ["prompt", "messages"],
+    "output": [
+      "response['message']['content']",
+    ],
+    "streaming_output": [
+      "chunk['message']['content']" # streaming
+    ]
+  },
+  "openai": {
+    "input": ["prompt", "messages"],
+    "output": [
+      "completion.choices[0].message.content", # chat
+      "openai_response.choices[0].text", # completion
+      "openai_response.choices[0].message.function_call.arguments", # function calling
+    ],
+    "streaming_output": [
+      "chunk.choices[0].delta.content", #streaming
+    ]
+  },
+  "together": {
+    "input": ["prompt"],
+    "output": ["['output']['choices'][0]['text']"],
+    "streaming_output": []
+  },
+}
+
+
+def extract_text_from_output(response):
+  # iterate llms_and_params
+  for llm, params in llms_and_params.items():
+    for output_path in params["output"]:
+      # check if response has that output path in it
+      text_check = get(response, output_path)
+      if text_check is not None:
+        return text_check
+  
+  raise ValueError("No output path found in response")
+
+def extract_text_from_streaming_output(response):
+  # iterate llms_and_params
+  for llm, params in llms_and_params.items():
+    for output_path in params["streaming_output"]:
+      # check if response has that output path in it
+      text_check = get(response, output_path)
+      if text_check is not None:
+        return text_check
+  
+  raise ValueError("No output path found in response")

--- a/guardrails/run/llms.md
+++ b/guardrails/run/llms.md
@@ -1,0 +1,8 @@
+# AI21
+prompt
+
+# Anthropic
+system
+messages
+
+# 


### PR DESCRIPTION
This does not currently work.

This pr attempts to use input/output mapping to deal with LLMs in a more generic way. What I've discovered is that there's simply too much going on with both our existing implementation as well as in individual LLM clients. I think that overhauling to this level is too big a change for the minor version update with regards to the risk and testing surface area involved.

This PR is missing a few key parts:
1. mapping inputs for the injection of schema and reask instructions
2. dealing with function calling
3. testing around streaming, async

Fundamentally, I do think this approach can work, and is a better mapping solution than the one that we currently have since in some ways it's "looser". It does not include recreating clients or trying to type-match into them, which I think is a huge benefit from a maintainability perspective.

All that being said, I would propose a difference in deliverables for 0.4.3 that I think are still achievable, help with debug scenarios, and keep backwards compatability without being too huge a change. However, I only think these changes are appropriate if we do necessary pruning on 0.5.0.

0.4.3
1. make the `__call__`  `llm_api` callable optional. When it is optional, we pass through information to a LiteLLM client we create internally
2. expose a `naked_llm_call` function on `guard`. This function would have inputs styled the same way we style `__call__` inputs, but purely uses our internal mapping to make a call to the LLM without guarding. This would help users debug and translate from their call pattern to the guard-style call pattern.

0.5.0
1. delete all custom mappings in llm_providers other than OpenAICallable, LiteLLMCallable, and Sync/AsycnBaseCallable
2. make clear in docs that those callables are the only supported ones. If you have a callable other than those and don't want to wrap in a BaseCallable, then orchestrate your own llm api callable and 
3. remove msg_history, prompt, instructions. Expect `messages` for BaseCallable. For everything else, pass through args as is
4. in OpenAI, cohere, and anthropic, never recreate a client
5. get rid of old openai versions across the codebase
6. create 1 doc notebook with examples for each llm type present in llms.py
7. support streaming and asycn for openai and litellm callables natively but through a similar output mapping strategy as found in this PR.