### PR TITLE
Bug/onfail status updates

### DIFF
--- a/guardrails/classes/history/call.py
+++ b/guardrails/classes/history/call.py
@@ -20,7 +20,7 @@ from guardrails.utils.reask_utils import (
     sub_reasks_with_fixed_values,
 )
 from guardrails.utils.safe_get import get_value_from_path
-from guardrails.validator_base import FailResult, Filter, Refrain
+from guardrails.validator_base import Filter, Refrain
 
 
 # We can't inherit from Iteration because python
@@ -226,9 +226,12 @@ versions 0.5.0 and beyond. Use 'validation_response' instead."""
         if (
             self.inputs.full_schema_reask
             or number_of_iterations < 2
-            or isinstance(
-                self.iterations.last.validation_response,
-                ReAsk,  # type: ignore
+            or (
+                self.iterations.last
+                and isinstance(
+                    self.iterations.last.validation_response,
+                    ReAsk,  # type: ignore
+                )
             )
             or isinstance(self.iterations.last.validation_response, str)  # type: ignore
         ):
@@ -274,10 +277,9 @@ versions 0.5.0 and beyond. Use 'validation_response' instead."""
         OR if the action is no-op.
         """
 
-
         if self.status == pass_status:
             return self.fixed_output
-        
+
         if not self.has_unresolved_failures() and self._has_resolved_failures():
             return self.fixed_output
 
@@ -387,7 +389,7 @@ versions 0.5.0 and beyond. Use 'guarded_output' instead."""
 
         # No ReAsks and no unresolved failed validations
         return False
-    
+
     def _has_resolved_failures(self) -> bool:
         # Check for unresolved ReAsks
         if len(self.reasks) > 0:
@@ -443,7 +445,7 @@ versions 0.5.0 and beyond. Use 'guarded_output' instead."""
                 title="Validated Output",
                 style="on #F0FFF0",
             )
-            tree.children[-1].label.renderable._renderables = previous_panels + (  # type: ignore
+            tree.children[-1].label.renderable._renderables = previous_panels + (  # type: ignore # noqa
                 validated_outcome_panel,
             )
 

--- a/guardrails/classes/history/call.py
+++ b/guardrails/classes/history/call.py
@@ -269,10 +269,28 @@ versions 0.5.0 and beyond. Use 'validation_response' instead."""
         validated output may be "fixed" values that were corrected
         during validation.
 
-        This will only have a value if the Guard is in a passing state.
+        This will only have a value if the Guard is in a passing state
+        OR if the action is no-op.
         """
         if self.status == pass_status:
             return self.fixed_output
+        last_iteration = self.iterations.last
+        if (
+            not self.status == pass_status
+            and last_iteration
+            and last_iteration.failed_validations
+        ):
+            # check that all failed validations are noop or none
+            all_noop = True
+            for failed_validation in last_iteration.failed_validations:
+                if (
+                    failed_validation.value_after_validation
+                    is not failed_validation.value_before_validation
+                ):
+                    all_noop = False
+                    break
+            if all_noop:
+                return last_iteration.guarded_output
 
     @property
     @deprecated(

--- a/guardrails/validator_base.py
+++ b/guardrails/validator_base.py
@@ -422,14 +422,23 @@ class Validator(Runnable):
                     """,
                     FutureWarning,
                 )
+        self.on_fail_descriptor: str | OnFailAction = "custom"
 
         if on_fail is None:
             on_fail = OnFailAction.NOOP
         if isinstance(on_fail, OnFailAction):
             self.on_fail_descriptor = on_fail
             self.on_fail_method = None
+        elif (
+            isinstance(on_fail, str)
+            and OnFailAction.__members__.get(on_fail.upper()) is not None
+        ):
+            self.on_fail_descriptor = (
+                OnFailAction.__members__.get(on_fail.upper())
+                or ""  # this default isn't needed, it's just for pyright
+            )
+            self.on_fail_method = None
         else:
-            self.on_fail_descriptor = "custom"
             self.on_fail_method = on_fail
 
         # Store the kwargs for the validator.

--- a/guardrails/validator_base.py
+++ b/guardrails/validator_base.py
@@ -422,7 +422,7 @@ class Validator(Runnable):
                     """,
                     FutureWarning,
                 )
-        self.on_fail_descriptor: str | OnFailAction = "custom"
+        self.on_fail_descriptor: Union[str, OnFailAction] = "custom"
 
         if on_fail is None:
             on_fail = OnFailAction.NOOP

--- a/tests/integration_tests/test_async.py
+++ b/tests/integration_tests/test_async.py
@@ -91,13 +91,10 @@ async def test_entity_extraction_with_noop(mocker):
     )
 
     # Assertions are made on the guard state object.
-
-    # Old assertion which is wrong
-    # This should not pass validation and therefore will not have a validated output
-    # assert final_output.validated_output == entity_extraction.VALIDATED_OUTPUT_NOOP
-
     assert final_output.validation_passed is False
-    assert final_output.validated_output is None
+    assert final_output.validated_output is not None
+    assert final_output.validated_output["fees"]
+    assert final_output.validated_output["interest_rates"]
 
     call = guard.history.first
 
@@ -131,7 +128,9 @@ async def test_entity_extraction_with_noop_pydantic(mocker):
 
     # Assertions are made on the guard state object.
     assert final_output.validation_passed is False
-    assert final_output.validated_output is None
+    assert final_output.validated_output is not None
+    assert final_output.validated_output["fees"]
+    assert final_output.validated_output["interest_rates"]
 
     call = guard.history.first
 
@@ -199,7 +198,7 @@ async def test_entity_extraction_with_fix(mocker):
     )
 
     # Assertions are made on the guard state object.
-    assert final_output.validation_passed is True
+    assert final_output.validation_passed is False
     assert final_output.validated_output == entity_extraction.VALIDATED_OUTPUT_FIX
 
     call = guard.history.first

--- a/tests/integration_tests/test_multi_reask.py
+++ b/tests/integration_tests/test_multi_reask.py
@@ -43,5 +43,5 @@ def test_multi_reask(mocker):
     # The output here fails some validators but passes others.
     # Since those that it fails in the end are noop fixes, validation fails.
     assert call.validation_response == python_rail.VALIDATOR_PARALLELISM_RESPONSE_3
-    assert call.guarded_output is None
+    assert call.guarded_output is not None and isinstance(call.guarded_output, str)
     assert call.status == "fail"

--- a/tests/integration_tests/test_validator_base.py
+++ b/tests/integration_tests/test_validator_base.py
@@ -1,20 +1,25 @@
 from typing import Any, Dict
+
 from guardrails.guard import Guard
-from guardrails.validator_base import FailResult, ValidationResult, Validator, register_validator
+from guardrails.validator_base import (
+    FailResult,
+    ValidationResult,
+    Validator,
+    register_validator,
+)
 
 
-@register_validator("failure", 'string')
+@register_validator("failure", "string")
 class FailureValidator(Validator):
     def validate(self, value: Any, metadata: Dict[str, Any]) -> ValidationResult:
         return FailResult(
-            error_message=(
-                "Failed cuz this is the failure validator"
-            ),
-            fix_value='FIXED',
+            error_message=("Failed cuz this is the failure validator"),
+            fix_value="FIXED",
         )
 
-def test_failure_mode():    
-    guard = Guard().use(FailureValidator, on_fail='fix')
-    res = guard.parse('hi')
-    assert res.validated_output == 'FIXED'
-    assert res.validation_passed # Should this even be true though?
+
+def test_failure_mode():
+    guard = Guard().use(FailureValidator, on_fail="fix")
+    res = guard.parse("hi")
+    assert res.validated_output == "FIXED"
+    assert res.validation_passed  # Should this even be true though?

--- a/tests/integration_tests/test_validator_base.py
+++ b/tests/integration_tests/test_validator_base.py
@@ -26,6 +26,7 @@ def test_fix():
     assert res.validated_output == "FIXED"
     assert not res.validation_passed
 
+
 def test_default_noop():
     guard = Guard().use(FailureValidator, on_fail="noop")
     res = guard.parse("hi")

--- a/tests/integration_tests/test_validator_base.py
+++ b/tests/integration_tests/test_validator_base.py
@@ -18,8 +18,41 @@ class FailureValidator(Validator):
         )
 
 
-def test_failure_mode():
+# TODO: Add reask tests. Reask is fairly well covered through notebooks
+# but it's good to have it here too.
+def test_fix():
     guard = Guard().use(FailureValidator, on_fail="fix")
     res = guard.parse("hi")
     assert res.validated_output == "FIXED"
     assert res.validation_passed  # Should this even be true though?
+
+
+def test_default_noop():
+    guard = Guard().use(FailureValidator, on_fail="noop")
+    res = guard.parse("hi")
+    assert res.validated_output == "hi"
+    assert not res.validation_passed
+
+
+def test_filter():
+    guard = Guard().use(FailureValidator, on_fail="filter")
+    res = guard.parse("hi")
+    assert res.validated_output is None
+    assert not res.validation_passed
+
+
+def test_refrain():
+    guard = Guard().use(FailureValidator, on_fail="refrain")
+    res = guard.parse("hi")
+    assert res.validated_output is None
+    assert not res.validation_passed
+
+
+def test_exception():
+    guard = Guard().use(FailureValidator, on_fail="exception")
+    try:
+        guard.parse("hi")
+    except Exception as e:
+        assert "Failed cuz this is the failure validator" in str(e)
+    else:
+        assert False, "Expected an exception"

--- a/tests/integration_tests/test_validator_base.py
+++ b/tests/integration_tests/test_validator_base.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict
+from guardrails.guard import Guard
+from guardrails.validator_base import FailResult, ValidationResult, Validator, register_validator
+
+
+@register_validator("failure", 'string')
+class FailureValidator(Validator):
+    def validate(self, value: Any, metadata: Dict[str, Any]) -> ValidationResult:
+        return FailResult(
+            error_message=(
+                "Failed cuz this is the failure validator"
+            ),
+            fix_value='FIXED',
+        )
+
+def test_failure_mode():    
+    guard = Guard().use(FailureValidator, on_fail='fix')
+    res = guard.parse('hi')
+    assert res.validated_output == 'FIXED'
+    assert res.validation_passed # Should this even be true though?

--- a/tests/integration_tests/test_validator_base.py
+++ b/tests/integration_tests/test_validator_base.py
@@ -24,8 +24,7 @@ def test_fix():
     guard = Guard().use(FailureValidator, on_fail="fix")
     res = guard.parse("hi")
     assert res.validated_output == "FIXED"
-    assert res.validation_passed  # Should this even be true though?
-
+    assert not res.validation_passed
 
 def test_default_noop():
     guard = Guard().use(FailureValidator, on_fail="noop")

--- a/tests/unit_tests/classes/history/test_call.py
+++ b/tests/unit_tests/classes/history/test_call.py
@@ -189,7 +189,7 @@ def test_non_empty_initialization():
     assert call.validator_logs == Stack(first_validator_log, second_validator_log)
     assert call.error is None
     assert call.failed_validations == Stack(first_validator_log)
-    assert call.status == pass_status
+    assert call.status == 'fail'
     # TODO: How to do shallow comparison
     # assert call.tree == "something"
     assert call.tree is not None

--- a/tests/unit_tests/classes/history/test_call.py
+++ b/tests/unit_tests/classes/history/test_call.py
@@ -4,7 +4,7 @@ from guardrails.classes.history.call_inputs import CallInputs
 from guardrails.classes.history.inputs import Inputs
 from guardrails.classes.history.iteration import Iteration
 from guardrails.classes.history.outputs import Outputs
-from guardrails.constants import not_run_status, pass_status
+from guardrails.constants import not_run_status
 from guardrails.llm_providers import ArbitraryCallable
 from guardrails.prompt.instructions import Instructions
 from guardrails.prompt.prompt import Prompt
@@ -189,7 +189,7 @@ def test_non_empty_initialization():
     assert call.validator_logs == Stack(first_validator_log, second_validator_log)
     assert call.error is None
     assert call.failed_validations == Stack(first_validator_log)
-    assert call.status == 'fail'
+    assert call.status == "fail"
     # TODO: How to do shallow comparison
     # assert call.tree == "something"
     assert call.tree is not None

--- a/tests/unit_tests/test_guard.py
+++ b/tests/unit_tests/test_guard.py
@@ -492,7 +492,7 @@ def test_validate():
 
     response = guard.validate(llm_output)
 
-    assert response.validation_passed is True
+    assert response.validation_passed is False
     assert response.validated_output == llm_output.lower()
 
     llm_output_2 = "Star Spangled Banner"  # to stick with the theme
@@ -518,7 +518,7 @@ def test_validate():
 
     response = guard.validate(llm_output)
 
-    assert response.validation_passed is True
+    assert response.validation_passed is False
     assert response.validated_output == llm_output.lower()
 
     llm_output_2 = "Star Spangled Banner"  # to stick with the theme


### PR DESCRIPTION
This PR changes the way we define statuses on ValidationOutcome. Before, the status was defined by whether or not there were any unresolved errors remaining in the outcome (with some bugs). For example, if a guard ran out of reasks and the payload still failed validation at the end, the status was reported as 'fail'. However, if a field failed validation and was modified (refrained, filtered, or fixes), that was reported as a non-failure. In this way, ValidationOutcome's status was intentioned as a reflection of whether the `guarded_output` is useable at it's final destination. To see which validators had actually failed, users would need to iterate over `guard.history.last.iterations[n].failed_validations`.

If this PR is accepted, the new definition of ValidationOutcome status is whether or not on final pass (i.e. after all reasks etc) any validation failed at all. This means that if a result was `fix`ed, `refrain`ed, or `filter`ed, the guarded_output would be set appropriately, but the ValidationOutcome would be `status='fail'`. In the case of a reask where the reask'ed values pass validations, the ValidationOutcome would be `status='pass'`.

The big gap with this new definition is what to do with scenarios where reasks are exhausted. Currently, they're treated as 'failures', but the problem with this is that if they are `status='fail'` and actual usable outcomes are also `status='fail'`, then how do users differentiate usable vs unusable outcomes?