### PR TITLE
Update getting_started.md

### DIFF
--- a/docs/guardrails_ai/getting_started.md
+++ b/docs/guardrails_ai/getting_started.md
@@ -17,7 +17,7 @@ pip install guardrails-ai
 2. Install a guardrail from Guardrails Hub.
 
     ```bash
-    gudardrails hub install hub://guardrails/regex_match
+    guardrails hub install hub://guardrails/regex_match
     ```
 3. Create a Guard from the installed guardrail.
 


### PR DESCRIPTION
Fixed an error in the command for installing a guardrail from Guardrails Hub. Corrected from `gudardrails` to `guardrails`.