### PR TITLE
Fix Broken Link in docusaurus.config.js

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -53,7 +53,7 @@ const config = {
         // Remove this to remove the "edit this page" links.
         path: 'docs-build',
         editUrl:
-          "https://github.com/guardrails-ai/guardrails/tree/main/packages/create-docusaurus/templates/shared/",
+          "https://github.com/guardrails-ai/guardrails/tree/main/",
       },
     },
   ]],


### PR DESCRIPTION
Fixed a broken `editUrl` link in the `docusaurus.config.js` file. The updated URL now correctly leads to the intended directory on GitHub