### PR TITLE
Solve notebook check CI error

### DIFF
--- a/.github/workflows/examples_check.yml
+++ b/.github/workflows/examples_check.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       run: |
         make full;
-        poetry add "openai>=1.2.4" jupyter nbconvert cohere;
+        poetry add "openai>=1.2.4" jupyter nbconvert cohere==5.3.2;
     - name: Check for pypdfium2
       run: poetry run pip show pypdfium2
     - name: Huggingface Hub Login


### PR DESCRIPTION
- Culprit: Cohere's new version v5.3.3 (released Apr 23) that causes some versioning conflicts with `spacy-transformers` as seen [here](https://github.com/guardrails-ai/guardrails/actions/runs/8801942826)
- Locked Cohere's version to v5.3.2 - ran notebook checks manually [here](https://github.com/guardrails-ai/guardrails/actions/runs/8820417515) that work fine!