### PR TITLE
Add uninstall command for validators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,22 +17,22 @@ type:
 	@make $(TYPING_CMD)
 
 type-pydantic-v1-openai-v0:
-	echo '{"exclude": ["guardrails/utils/pydantic_utils/v2.py", "guardrails/utils/openai_utils/v1.py"]}' > pyrightconfig.json
+	echo '{"reportDeprecated": true, "exclude": ["guardrails/utils/pydantic_utils/v2.py", "guardrails/utils/openai_utils/v1.py"]}' > pyrightconfig.json
 	poetry run pyright guardrails/
 	rm pyrightconfig.json
 
 type-pydantic-v1-openai-v1:
-	echo '{"exclude": ["guardrails/utils/pydantic_utils/v2.py", "guardrails/utils/openai_utils/v0.py"]}' > pyrightconfig.json
+	echo '{"reportDeprecated": true, "exclude": ["guardrails/utils/pydantic_utils/v2.py", "guardrails/utils/openai_utils/v0.py"]}' > pyrightconfig.json
 	poetry run pyright guardrails/
 	rm pyrightconfig.json
 
 type-pydantic-v2-openai-v0:
-	echo '{"exclude": ["guardrails/utils/pydantic_utils/v1.py", "guardrails/utils/openai_utils/v1.py"]}' > pyrightconfig.json
+	echo '{"reportDeprecated": true, "exclude": ["guardrails/utils/pydantic_utils/v1.py", "guardrails/utils/openai_utils/v1.py"]}' > pyrightconfig.json
 	poetry run pyright guardrails/
 	rm pyrightconfig.json
 
 type-pydantic-v2-openai-v1:
-	echo '{"exclude": ["guardrails/utils/pydantic_utils/v1.py", "guardrails/utils/openai_utils/v0.py"]}' > pyrightconfig.json
+	echo '{"reportDeprecated": true, "exclude": ["guardrails/utils/pydantic_utils/v1.py", "guardrails/utils/openai_utils/v0.py"]}' > pyrightconfig.json
 	poetry run pyright guardrails/
 	rm pyrightconfig.json
 

--- a/guardrails/applications/text2sql.py
+++ b/guardrails/applications/text2sql.py
@@ -140,7 +140,7 @@ class Text2Sql:
             rail_spec_str = Template(rail_spec_str).safe_substitute(**rail_params)
 
         guard = Guard.from_rail_string(rail_spec_str)
-        guard.reask_prompt = reask_prompt
+        guard.rail.output_schema.reask_prompt_template = reask_prompt
 
         return guard
 

--- a/guardrails/cli/hub/__init__.py
+++ b/guardrails/cli/hub/__init__.py
@@ -1,5 +1,5 @@
 import guardrails.cli.hub.create_validator  # noqa
 import guardrails.cli.hub.install  # noqa
-import guardrails.cli.hub.uninstall
+import guardrails.cli.hub.uninstall # noqa
 import guardrails.cli.hub.submit  # noqa
 from guardrails.cli.hub.hub import hub_command  # noqa

--- a/guardrails/cli/hub/__init__.py
+++ b/guardrails/cli/hub/__init__.py
@@ -1,4 +1,5 @@
 import guardrails.cli.hub.create_validator  # noqa
 import guardrails.cli.hub.install  # noqa
+import guardrails.cli.hub.uninstall
 import guardrails.cli.hub.submit  # noqa
 from guardrails.cli.hub.hub import hub_command  # noqa

--- a/guardrails/cli/hub/__init__.py
+++ b/guardrails/cli/hub/__init__.py
@@ -1,5 +1,5 @@
 import guardrails.cli.hub.create_validator  # noqa
 import guardrails.cli.hub.install  # noqa
-import guardrails.cli.hub.uninstall # noqa
+import guardrails.cli.hub.uninstall  # noqa
 import guardrails.cli.hub.submit  # noqa
 from guardrails.cli.hub.hub import hub_command  # noqa

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -15,6 +15,8 @@ from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
+from utils import pip_process, get_site_packages_location, get_org_and_package_dirs, get_hub_directory
+
 from .console import console
 
 
@@ -29,70 +31,6 @@ def removesuffix(string: str, suffix: str) -> str:
 
 string_format: Literal["string"] = "string"
 json_format: Literal["json"] = "json"
-
-
-def pip_process(
-    action: str,
-    package: str = "",
-    flags: List[str] = [],
-    format: Union[Literal["string"], Literal["json"]] = string_format,
-) -> Union[str, dict]:
-    try:
-        logger.debug(f"running pip {action} {' '.join(flags)} {package}")
-        command = [sys.executable, "-m", "pip", action]
-        command.extend(flags)
-        if package:
-            command.append(package)
-        output = subprocess.check_output(command)
-        logger.debug(f"decoding output from pip {action} {package}")
-        if format == json_format:
-            parsed = BytesHeaderParser().parsebytes(output)
-            try:
-                return json.loads(str(parsed))
-            except Exception:
-                logger.debug(
-                    f"json parse exception in decoding output from pip {action} {package}. Falling back to accumulating the byte stream",  # noqa
-                )
-            accumulator = {}
-            for key, value in parsed.items():
-                accumulator[key] = value
-            return accumulator
-        return str(output.decode())
-    except subprocess.CalledProcessError as exc:
-        logger.error(
-            (
-                f"Failed to {action} {package}\n"
-                f"Exit code: {exc.returncode}\n"
-                f"stdout: {exc.output}"
-            )
-        )
-        sys.exit(1)
-    except Exception as e:
-        logger.error(
-            f"An unexpected exception occurred while try to {action} {package}!",
-            e,
-        )
-        sys.exit(1)
-
-
-def get_site_packages_location():
-    output = pip_process("show", "pip", format=json_format)
-    pip_location = output["Location"]  # type: ignore
-    return pip_location
-
-
-def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:
-    org_name = manifest.namespace
-    package_name = manifest.package_name
-    org = snake_case(org_name if len(org_name) > 1 else "")
-    package = snake_case(package_name if len(package_name) > 1 else package_name)
-    return list(filter(None, [org, package]))
-
-
-def get_hub_directory(manifest: ModuleManifest, site_packages: str) -> str:
-    org_package = get_org_and_package_dirs(manifest)
-    return os.path.join(site_packages, "guardrails", "hub", *org_package)
-
 
 # NOTE: I don't like this but don't see another way without
 #  shimming the init file with all hub validators

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -12,12 +12,11 @@ from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
-from .utils import (
-    pip_process,
-    get_site_packages_location,
-    get_org_and_package_dirs,
-    get_hub_directory,
-)
+from guardrails.cli.hub.utils import pip_process
+from guardrails.cli.hub.utils import get_site_packages_location
+from guardrails.cli.hub.utils import get_org_and_package_dirs
+from guardrails.cli.hub.utils import get_hub_directory
+
 from .console import console
 
 

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -234,3 +234,4 @@ https://hub.guardrailsai.com/validator/${id}
     )
     console.print(success_message_cli)  # type: ignore
     logger.log(level=LEVELS.get("SPAM"), msg=success_message_logger)  # type: ignore
+    

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -14,6 +14,8 @@ from guardrails.cli.hub.hub import hub_command
 from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
+from utils import get_site_packages_location, get_org_and_package_dirs, pip_process, get_hub_directory
+
 
 from .console import console
 
@@ -29,70 +31,6 @@ def removesuffix(string: str, suffix: str) -> str:
 
 string_format: Literal["string"] = "string"
 json_format: Literal["json"] = "json"
-
-
-def pip_process(
-    action: str,
-    package: str = "",
-    flags: List[str] = [],
-    format: Union[Literal["string"], Literal["json"]] = string_format,
-) -> Union[str, dict]:
-    try:
-        logger.debug(f"running pip {action} {' '.join(flags)} {package}")
-        command = [sys.executable, "-m", "pip", action]
-        command.extend(flags)
-        if package:
-            command.append(package)
-        output = subprocess.check_output(command)
-        logger.debug(f"decoding output from pip {action} {package}")
-        if format == json_format:
-            parsed = BytesHeaderParser().parsebytes(output)
-            try:
-                return json.loads(str(parsed))
-            except Exception:
-                logger.debug(
-                    f"json parse exception in decoding output from pip {action} {package}. Falling back to accumulating the byte stream",  # noqa
-                )
-            accumulator = {}
-            for key, value in parsed.items():
-                accumulator[key] = value
-            return accumulator
-        return str(output.decode())
-    except subprocess.CalledProcessError as exc:
-        logger.error(
-            (
-                f"Failed to {action} {package}\n"
-                f"Exit code: {exc.returncode}\n"
-                f"stdout: {exc.output}"
-            )
-        )
-        sys.exit(1)
-    except Exception as e:
-        logger.error(
-            f"An unexpected exception occurred while try to {action} {package}!",
-            e,
-        )
-        sys.exit(1)
-
-
-def get_site_packages_location():
-    output = pip_process("show", "pip", format=json_format)
-    pip_location = output["Location"]  # type: ignore
-    return pip_location
-
-
-def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:
-    org_name = manifest.namespace
-    package_name = manifest.package_name
-    org = snake_case(org_name if len(org_name) > 1 else "")
-    package = snake_case(package_name if len(package_name) > 1 else package_name)
-    return list(filter(None, [org, package]))
-
-
-def get_hub_directory(manifest: ModuleManifest, site_packages: str) -> str:
-    org_package = get_org_and_package_dirs(manifest)
-    return os.path.join(site_packages, "guardrails", "hub", *org_package)
-
 
 # NOTE: I don't like this but don't see another way without
 #  shimming the init file with all hub validators

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -1,13 +1,10 @@
-import json
 import os
 import subprocess
 import sys
-from email.parser import BytesHeaderParser
 from string import Template
-from typing import List, Literal, Union
+from typing import List, Literal
 
 import typer
-from pydash.strings import snake_case
 
 from guardrails.classes.generic import Stack
 from guardrails.cli.hub.hub import hub_command
@@ -15,8 +12,12 @@ from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
-from utils import pip_process, get_site_packages_location, get_org_and_package_dirs, get_hub_directory
-
+from utils import (
+    pip_process, 
+    get_site_packages_location, 
+    get_org_and_package_dirs, 
+    get_hub_directory
+)
 from .console import console
 
 
@@ -234,4 +235,3 @@ https://hub.guardrailsai.com/validator/${id}
     )
     console.print(success_message_cli)  # type: ignore
     logger.log(level=LEVELS.get("SPAM"), msg=success_message_logger)  # type: ignore
-    

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -13,10 +13,10 @@ from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
 from utils import (
-    pip_process, 
-    get_site_packages_location, 
-    get_org_and_package_dirs, 
-    get_hub_directory
+    pip_process,
+    get_site_packages_location,
+    get_org_and_package_dirs,
+    get_hub_directory,
 )
 from .console import console
 
@@ -32,6 +32,7 @@ def removesuffix(string: str, suffix: str) -> str:
 
 string_format: Literal["string"] = "string"
 json_format: Literal["json"] = "json"
+
 
 # NOTE: I don't like this but don't see another way without
 #  shimming the init file with all hub validators

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 from string import Template
-from typing import List, Literal
+from typing import List, Literal, Union
 
 import typer
 

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -19,7 +19,6 @@ from utils import get_site_packages_location, get_org_and_package_dirs, pip_proc
 
 from .console import console
 
-
 def removesuffix(string: str, suffix: str) -> str:
     if sys.version_info.minor >= 9:
         return string.removesuffix(suffix)  # type: ignore

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -14,10 +14,9 @@ from guardrails.cli.hub.hub import hub_command
 from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
-from utils import get_site_packages_location, get_org_and_package_dirs, pip_process, get_hub_directory
-
 
 from .console import console
+
 
 def removesuffix(string: str, suffix: str) -> str:
     if sys.version_info.minor >= 9:
@@ -30,6 +29,70 @@ def removesuffix(string: str, suffix: str) -> str:
 
 string_format: Literal["string"] = "string"
 json_format: Literal["json"] = "json"
+
+
+def pip_process(
+    action: str,
+    package: str = "",
+    flags: List[str] = [],
+    format: Union[Literal["string"], Literal["json"]] = string_format,
+) -> Union[str, dict]:
+    try:
+        logger.debug(f"running pip {action} {' '.join(flags)} {package}")
+        command = [sys.executable, "-m", "pip", action]
+        command.extend(flags)
+        if package:
+            command.append(package)
+        output = subprocess.check_output(command)
+        logger.debug(f"decoding output from pip {action} {package}")
+        if format == json_format:
+            parsed = BytesHeaderParser().parsebytes(output)
+            try:
+                return json.loads(str(parsed))
+            except Exception:
+                logger.debug(
+                    f"json parse exception in decoding output from pip {action} {package}. Falling back to accumulating the byte stream",  # noqa
+                )
+            accumulator = {}
+            for key, value in parsed.items():
+                accumulator[key] = value
+            return accumulator
+        return str(output.decode())
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            (
+                f"Failed to {action} {package}\n"
+                f"Exit code: {exc.returncode}\n"
+                f"stdout: {exc.output}"
+            )
+        )
+        sys.exit(1)
+    except Exception as e:
+        logger.error(
+            f"An unexpected exception occurred while try to {action} {package}!",
+            e,
+        )
+        sys.exit(1)
+
+
+def get_site_packages_location():
+    output = pip_process("show", "pip", format=json_format)
+    pip_location = output["Location"]  # type: ignore
+    return pip_location
+
+
+def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:
+    org_name = manifest.namespace
+    package_name = manifest.package_name
+    org = snake_case(org_name if len(org_name) > 1 else "")
+    package = snake_case(package_name if len(package_name) > 1 else package_name)
+    return list(filter(None, [org, package]))
+
+
+def get_hub_directory(manifest: ModuleManifest, site_packages: str) -> str:
+    org_package = get_org_and_package_dirs(manifest)
+    return os.path.join(site_packages, "guardrails", "hub", *org_package)
+
 
 # NOTE: I don't like this but don't see another way without
 #  shimming the init file with all hub validators

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -16,7 +16,7 @@ from .utils import (
     pip_process,
     get_site_packages_location,
     get_org_and_package_dirs,
-    get_hub_directory,
+    get_hub_directory, 
 )
 from .console import console
 

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -12,7 +12,7 @@ from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
-from utils import (
+from .utils import (
     pip_process,
     get_site_packages_location,
     get_org_and_package_dirs,

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 from string import Template
-from typing import List, Literal, Union
+from typing import List, Literal
 
 import typer
 
@@ -16,7 +16,7 @@ from .utils import (
     pip_process,
     get_site_packages_location,
     get_org_and_package_dirs,
-    get_hub_directory, 
+    get_hub_directory,
 )
 from .console import console
 

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -94,3 +94,4 @@ def uninstall(
 
     console.print("✅ Successfully uninstalled!")  # type: ignore
     logger.log(level=LEVELS.get("SPAM"), msg="✅ Successfully uninstalled!")  # type: ignore
+

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -20,12 +20,11 @@ json_format: Literal["json"] = "json"
 string_format: Literal["string"] = "string"
 
 
-def update_file(file_path: str, line_content: str, remove: bool = False):
+def remove_line(file_path: str, line_content: str):
     with open(file_path, "r+") as file:
         lines = file.readlines()
         file.seek(0)
-        if remove:
-            lines = [line for line in lines if line.strip() != line_content.strip()]
+        lines = [line for line in lines if line.strip() != line_content.strip()]
         file.writelines(lines)
         file.truncate()
 
@@ -42,14 +41,14 @@ def remove_from_hub_inits(manifest: ModuleManifest, site_packages: str):
 
     # Remove import line from main __init__.py
     hub_init_location = os.path.join(site_packages, "guardrails", "hub", "__init__.py")
-    update_file(hub_init_location, import_line, remove=True)
+    remove_line(hub_init_location, import_line)
 
     # Remove import line from namespace __init__.py
     namespace = org_package[0]
     namespace_init_location = os.path.join(
         site_packages, "guardrails", "hub", namespace, "__init__.py"
     )
-    update_file(namespace_init_location, import_line, remove=True)
+    remove_line(namespace_init_location, import_line)
 
 
 def uninstall_hub_module(manifest: ModuleManifest, site_packages: str):

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -15,9 +15,71 @@ from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
-from utils import get_site_packages_location, get_org_and_package_dirs, get_hub_directory
+#from utils import get_site_packages_location, get_org_and_package_dirs, get_hub_directory
 
 from .console import console
+
+json_format: Literal["json"] = "json"
+string_format: Literal["string"] = "string"
+
+
+def pip_process(
+    action: str,
+    package: str = "",
+    flags: List[str] = [],
+    format: Union[Literal["string"], Literal["json"]] = string_format,
+) -> Union[str, dict]:
+    try:
+        logger.debug(f"running pip {action} {' '.join(flags)} {package}")
+        command = [sys.executable, "-m", "pip", action]
+        command.extend(flags)
+        if package:
+            command.append(package)
+        output = subprocess.check_output(command)
+        logger.debug(f"decoding output from pip {action} {package}")
+        if format == json_format:
+            parsed = BytesHeaderParser().parsebytes(output)
+            try:
+                return json.loads(str(parsed))
+            except Exception:
+                logger.debug(
+                    f"json parse exception in decoding output from pip {action} {package}. Falling back to accumulating the byte stream",  # noqa
+                )
+            accumulator = {}
+            for key, value in parsed.items():
+                accumulator[key] = value
+            return accumulator
+        return str(output.decode())
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            (
+                f"Failed to {action} {package}\n"
+                f"Exit code: {exc.returncode}\n"
+                f"stdout: {exc.output}"
+            )
+        )
+        sys.exit(1)
+    except Exception as e:
+        logger.error(
+            f"An unexpected exception occurred while try to {action} {package}!",
+            e,
+        )
+        sys.exit(1)
+
+def get_site_packages_location() -> str:
+    output = pip_process("show", "pip", format=json_format)
+    return output["Location"]
+
+def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:
+    org_name = manifest.namespace
+    package_name = manifest.package_name
+    org = snake_case(org_name if len(org_name) > 1 else "")
+    package = snake_case(package_name if len(package_name) > 1 else package_name)
+    return list(filter(None, [org, package]))
+
+def get_hub_directory(manifest: ModuleManifest, site_packages: str) -> str:
+    org_package = get_org_and_package_dirs(manifest)
+    return os.path.join(site_packages, "guardrails", "hub", *org_package)
 
 def update_file(file_path: str, line_content: str, remove: bool = False):
     with open(file_path, "r+") as file:

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -15,71 +15,12 @@ from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
-#from utils import get_site_packages_location, get_org_and_package_dirs, get_hub_directory
+from utils import get_site_packages_location, get_org_and_package_dirs, get_hub_directory
 
 from .console import console
 
 json_format: Literal["json"] = "json"
 string_format: Literal["string"] = "string"
-
-
-def pip_process(
-    action: str,
-    package: str = "",
-    flags: List[str] = [],
-    format: Union[Literal["string"], Literal["json"]] = string_format,
-) -> Union[str, dict]:
-    try:
-        logger.debug(f"running pip {action} {' '.join(flags)} {package}")
-        command = [sys.executable, "-m", "pip", action]
-        command.extend(flags)
-        if package:
-            command.append(package)
-        output = subprocess.check_output(command)
-        logger.debug(f"decoding output from pip {action} {package}")
-        if format == json_format:
-            parsed = BytesHeaderParser().parsebytes(output)
-            try:
-                return json.loads(str(parsed))
-            except Exception:
-                logger.debug(
-                    f"json parse exception in decoding output from pip {action} {package}. Falling back to accumulating the byte stream",  # noqa
-                )
-            accumulator = {}
-            for key, value in parsed.items():
-                accumulator[key] = value
-            return accumulator
-        return str(output.decode())
-    except subprocess.CalledProcessError as exc:
-        logger.error(
-            (
-                f"Failed to {action} {package}\n"
-                f"Exit code: {exc.returncode}\n"
-                f"stdout: {exc.output}"
-            )
-        )
-        sys.exit(1)
-    except Exception as e:
-        logger.error(
-            f"An unexpected exception occurred while try to {action} {package}!",
-            e,
-        )
-        sys.exit(1)
-
-def get_site_packages_location() -> str:
-    output = pip_process("show", "pip", format=json_format)
-    return output["Location"]
-
-def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:
-    org_name = manifest.namespace
-    package_name = manifest.package_name
-    org = snake_case(org_name if len(org_name) > 1 else "")
-    package = snake_case(package_name if len(package_name) > 1 else package_name)
-    return list(filter(None, [org, package]))
-
-def get_hub_directory(manifest: ModuleManifest, site_packages: str) -> str:
-    org_package = get_org_and_package_dirs(manifest)
-    return os.path.join(site_packages, "guardrails", "hub", *org_package)
 
 def update_file(file_path: str, line_content: str, remove: bool = False):
     with open(file_path, "r+") as file:

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -15,9 +15,18 @@ from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
-from utils import get_site_packages_location, get_org_and_package_dirs, update_file, get_hub_directory
+from utils import get_site_packages_location, get_org_and_package_dirs, get_hub_directory
 
 from .console import console
+
+def update_file(file_path: str, line_content: str, remove: bool = False):
+    with open(file_path, "r+") as file:
+        lines = file.readlines()
+        file.seek(0)
+        if remove:
+            lines = [line for line in lines if line.strip() != line_content.strip()]
+        file.writelines(lines)
+        file.truncate()
 
 def remove_from_hub_inits(manifest: ModuleManifest, site_packages: str):
     org_package = get_org_and_package_dirs(manifest)

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -1,0 +1,83 @@
+import json
+import os
+import subprocess
+import sys
+from email.parser import BytesHeaderParser
+from string import Template
+from typing import List, Literal, Union
+
+import typer
+from pydash.strings import snake_case
+
+from guardrails.classes.generic import Stack
+from guardrails.cli.hub.hub import hub_command
+from guardrails.cli.logger import LEVELS, logger
+from guardrails.cli.server.hub_client import get_validator_manifest
+from guardrails.cli.server.module_manifest import ModuleManifest
+
+from utils import get_site_packages_location, get_org_and_package_dirs, update_file, get_hub_directory
+
+from .console import console
+
+def remove_from_hub_inits(manifest: ModuleManifest, site_packages: str):
+    org_package = get_org_and_package_dirs(manifest)
+    exports: List[str] = manifest.exports or []
+    sorted_exports = sorted(exports, reverse=True)
+    module_name = manifest.module_name
+    relative_path = ".".join([*org_package, module_name])
+    import_line = (
+        f"from guardrails.hub.{relative_path} import {', '.join(sorted_exports)}"
+    )
+
+    # Remove import line from main __init__.py
+    hub_init_location = os.path.join(site_packages, "guardrails", "hub", "__init__.py")
+    update_file(hub_init_location, import_line, remove=True)
+
+    # Remove import line from namespace __init__.py
+    namespace = org_package[0]
+    namespace_init_location = os.path.join(
+        site_packages, "guardrails", "hub", namespace, "__init__.py"
+    )
+    update_file(namespace_init_location, import_line, remove=True)
+
+def uninstall_hub_module(manifest: ModuleManifest, site_packages: str):
+    uninstall_directory = get_hub_directory(manifest, site_packages)
+    logger.info(f"Removing directory {uninstall_directory}")
+    subprocess.check_call(["rm", "-rf", uninstall_directory])
+
+
+@hub_command.command()
+def uninstall(
+    package_uri: str = typer.Argument(
+        help="URI to the package to uninstall. Example: hub://guardrails/regex_match."
+    ),
+):
+    """Uninstall a validator from the Hub."""
+    if not package_uri.startswith("hub://"):
+        logger.error("Invalid URI!")
+        sys.exit(1)
+
+    console.print(f"\nUninstalling {package_uri}...\n")
+    logger.log(
+        level=LEVELS.get("SPAM"),
+        msg=f"Uninstalling {package_uri}...",
+    )
+
+    # Validation
+    module_name = package_uri.replace("hub://", "")
+
+    # Prep
+    with console.status("Fetching manifest", spinner="bouncingBar"):
+        module_manifest = get_validator_manifest(module_name)
+        site_packages = get_site_packages_location()
+
+    # Uninstall
+    with console.status("Removing module", spinner="bouncingBar"):
+        uninstall_hub_module(module_manifest, site_packages)
+
+    # Cleanup
+    with console.status("Cleaning up", spinner="bouncingBar"):
+        remove_from_hub_inits(module_manifest, site_packages)
+
+    console.print("✅ Successfully uninstalled!")  # type: ignore
+    logger.log(level=LEVELS.get("SPAM"), msg="✅ Successfully uninstalled!")  # type: ignore

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -10,11 +10,10 @@ from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
-from utils import (
-    get_site_packages_location,
-    get_org_and_package_dirs,
-    get_hub_directory,
-)
+from guardrails.cli.hub.utils import get_site_packages_location
+from guardrails.cli.hub.utils import get_org_and_package_dirs
+from guardrails.cli.hub.utils import get_hub_directory
+
 from .console import console
 
 json_format: Literal["json"] = "json"

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -1,22 +1,20 @@
-import json
 import os
 import subprocess
 import sys
-from email.parser import BytesHeaderParser
-from string import Template
-from typing import List, Literal, Union
+from typing import List, Literal
 
 import typer
-from pydash.strings import snake_case
 
-from guardrails.classes.generic import Stack
 from guardrails.cli.hub.hub import hub_command
 from guardrails.cli.logger import LEVELS, logger
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
-from utils import get_site_packages_location, get_org_and_package_dirs, get_hub_directory
-
+from utils import (
+    get_site_packages_location, 
+    get_org_and_package_dirs, 
+    get_hub_directory
+)
 from .console import console
 
 json_format: Literal["json"] = "json"

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -94,4 +94,3 @@ def uninstall(
 
     console.print("✅ Successfully uninstalled!")  # type: ignore
     logger.log(level=LEVELS.get("SPAM"), msg="✅ Successfully uninstalled!")  # type: ignore
-

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -72,7 +72,7 @@ def uninstall(
 
     console.print(f"\nUninstalling {package_uri}...\n")
     logger.log(
-        level=LEVELS.get("SPAM"),
+        level=LEVELS.get("SPAM", 0),
         msg=f"Uninstalling {package_uri}...",
     )
 

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -11,14 +11,15 @@ from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
 from utils import (
-    get_site_packages_location, 
-    get_org_and_package_dirs, 
-    get_hub_directory
+    get_site_packages_location,
+    get_org_and_package_dirs,
+    get_hub_directory,
 )
 from .console import console
 
 json_format: Literal["json"] = "json"
 string_format: Literal["string"] = "string"
+
 
 def update_file(file_path: str, line_content: str, remove: bool = False):
     with open(file_path, "r+") as file:
@@ -28,6 +29,7 @@ def update_file(file_path: str, line_content: str, remove: bool = False):
             lines = [line for line in lines if line.strip() != line_content.strip()]
         file.writelines(lines)
         file.truncate()
+
 
 def remove_from_hub_inits(manifest: ModuleManifest, site_packages: str):
     org_package = get_org_and_package_dirs(manifest)
@@ -49,6 +51,7 @@ def remove_from_hub_inits(manifest: ModuleManifest, site_packages: str):
         site_packages, "guardrails", "hub", namespace, "__init__.py"
     )
     update_file(namespace_init_location, import_line, remove=True)
+
 
 def uninstall_hub_module(manifest: ModuleManifest, site_packages: str):
     uninstall_directory = get_hub_directory(manifest, site_packages)

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -6,7 +6,7 @@ from email.parser import BytesHeaderParser
 from typing import List, Literal, Union
 from pydash.strings import snake_case
 
-from guardrails.classes.generic import ModuleManifest
+from guardrails.cli.server.module_manifest import ModuleManifest
 from guardrails.cli.logger import logger
 
 

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -1,0 +1,83 @@
+import json
+import os
+import subprocess
+import sys
+from email.parser import BytesHeaderParser
+from typing import List, Literal, Union
+from pydash.strings import snake_case
+
+from guardrails.classes.generic import ModuleManifest
+from guardrails.cli.logger import logger
+
+
+json_format: Literal["json"] = "json"
+string_format: Literal["string"] = "string"
+
+def pip_process(
+    action: str,
+    package: str = "",
+    flags: List[str] = [],
+    format: Union[Literal["string"], Literal["json"]] = string_format,
+) -> Union[str, dict]:
+    try:
+        logger.debug(f"running pip {action} {' '.join(flags)} {package}")
+        command = [sys.executable, "-m", "pip", action]
+        command.extend(flags)
+        if package:
+            command.append(package)
+        output = subprocess.check_output(command)
+        logger.debug(f"decoding output from pip {action} {package}")
+        if format == json_format:
+            parsed = BytesHeaderParser().parsebytes(output)
+            try:
+                return json.loads(str(parsed))
+            except Exception:
+                logger.debug(
+                    f"json parse exception in decoding output from pip {action} {package}. Falling back to accumulating the byte stream",  # noqa
+                )
+            accumulator = {}
+            for key, value in parsed.items():
+                accumulator[key] = value
+            return accumulator
+        return str(output.decode())
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            (
+                f"Failed to {action} {package}\n"
+                f"Exit code: {exc.returncode}\n"
+                f"stdout: {exc.output}"
+            )
+        )
+        sys.exit(1)
+    except Exception as e:
+        logger.error(
+            f"An unexpected exception occurred while try to {action} {package}!",
+            e,
+        )
+        sys.exit(1)
+
+def get_site_packages_location() -> str:
+    output = pip_process("show", "pip", format=json_format)
+    return output["Location"]
+
+def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:
+    org_name = manifest.namespace
+    package_name = manifest.package_name
+    org = snake_case(org_name if len(org_name) > 1 else "")
+    package = snake_case(package_name if len(package_name) > 1 else package_name)
+    return list(filter(None, [org, package]))
+
+def update_file(file_path: str, line_content: str, remove: bool = False):
+    with open(file_path, "r+") as file:
+        lines = file.readlines()
+        file.seek(0)
+        if remove:
+            lines = [line for line in lines if line.strip() != line_content.strip()]
+        file.writelines(lines)
+        file.truncate()
+
+def get_hub_directory(manifest: ModuleManifest, site_packages: str) -> str:
+    org_package = get_org_and_package_dirs(manifest)
+    return os.path.join(site_packages, "guardrails", "hub", *org_package)
+
+

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -60,8 +60,8 @@ def pip_process(
 
 def get_site_packages_location() -> str:
     output = pip_process("show", "pip", format=json_format)
-    print(type(output), output)
-    return output["Location"]
+    pip_location = output["Location"]  # type: ignore
+    return pip_location
 
 
 def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -61,6 +61,7 @@ def pip_process(
 
 def get_site_packages_location() -> str:
     output = pip_process("show", "pip", format=json_format)
+    print(type(output), output)
     return output["Location"]
 
 

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -58,11 +58,10 @@ def pip_process(
         sys.exit(1)
 
 
-
 def get_site_packages_location() -> str:
     output = pip_process("show", "pip", format=json_format)
     print(type(output), output)
-    return output.get("Location", "")
+    return output["Location"]
 
 
 def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -60,7 +60,7 @@ def pip_process(
 
 def get_site_packages_location() -> str:
     output = pip_process("show", "pip", format=json_format)
-    return output["Location"]
+    return output.get("Location", "")
 
 
 def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 from email.parser import BytesHeaderParser
-from typing import List, Literal, Union
+from typing import List, Literal, Union, Dict
 from pydash.strings import snake_case
 
 from guardrails.cli.server.module_manifest import ModuleManifest
@@ -19,7 +19,7 @@ def pip_process(
     package: str = "",
     flags: List[str] = [],
     format: Union[Literal["string"], Literal["json"]] = string_format,
-) -> Union[str, dict]:
+) -> Union[str, Dict[str, str]]:
     try:
         logger.debug(f"running pip {action} {' '.join(flags)} {package}")
         command = [sys.executable, "-m", "pip", action]

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -13,6 +13,7 @@ from guardrails.cli.logger import logger
 json_format: Literal["json"] = "json"
 string_format: Literal["string"] = "string"
 
+
 def pip_process(
     action: str,
     package: str = "",
@@ -56,9 +57,11 @@ def pip_process(
         )
         sys.exit(1)
 
+
 def get_site_packages_location() -> str:
     output = pip_process("show", "pip", format=json_format)
     return output["Location"]
+
 
 def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:
     org_name = manifest.namespace
@@ -67,8 +70,7 @@ def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:
     package = snake_case(package_name if len(package_name) > 1 else package_name)
     return list(filter(None, [org, package]))
 
+
 def get_hub_directory(manifest: ModuleManifest, site_packages: str) -> str:
     org_package = get_org_and_package_dirs(manifest)
     return os.path.join(site_packages, "guardrails", "hub", *org_package)
-
-

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 from email.parser import BytesHeaderParser
-from typing import List, Literal, Union, Dict
+from typing import List, Literal, Union
 from pydash.strings import snake_case
 
 from guardrails.cli.server.module_manifest import ModuleManifest
@@ -62,7 +62,7 @@ def pip_process(
 def get_site_packages_location() -> str:
     output = pip_process("show", "pip", format=json_format)
     print(type(output), output)
-    return output["Location"]
+    return output.get("Location", "")
 
 
 def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -22,39 +22,26 @@ def pip_process(
 ) -> Union[str, Dict[str, str]]:
     try:
         logger.debug(f"running pip {action} {' '.join(flags)} {package}")
-        command = [sys.executable, "-m", "pip", action]
-        command.extend(flags)
-        if package:
-            command.append(package)
+        command = [sys.executable, "-m", "pip", action] + flags + ([package] if package else [])
         output = subprocess.check_output(command)
+
         logger.debug(f"decoding output from pip {action} {package}")
         if format == json_format:
             parsed = BytesHeaderParser().parsebytes(output)
+            parsed_dict = dict(parsed.items())  # Convert email.message.Message to dict
             try:
-                return json.loads(str(parsed))
-            except Exception:
-                logger.debug(
-                    f"json parse exception in decoding output from pip {action} {package}. Falling back to accumulating the byte stream",  # noqa
-                )
-            accumulator = {}
-            for key, value in parsed.items():
-                accumulator[key] = value
-            return accumulator
-        return str(output.decode())
+                # Assuming the JSON data is within a single value of the parsed dictionary
+                return json.loads(parsed_dict.get("content", "{}"))
+            except Exception as e:
+                logger.debug(f"JSON parsing exception: {str(e)}")
+                return parsed_dict  # return as a dict if JSON parsing fails
+        else:
+            return output.decode()
     except subprocess.CalledProcessError as exc:
-        logger.error(
-            (
-                f"Failed to {action} {package}\n"
-                f"Exit code: {exc.returncode}\n"
-                f"stdout: {exc.output}"
-            )
-        )
+        logger.error(f"Failed to {action} {package}\nExit code: {exc.returncode}\nstdout: {exc.output}")
         sys.exit(1)
     except Exception as e:
-        logger.error(
-            f"An unexpected exception occurred while try to {action} {package}!",
-            e,
-        )
+        logger.error(f"An unexpected exception occurred while trying to {action} {package}!", e)
         sys.exit(1)
 
 

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -67,15 +67,6 @@ def get_org_and_package_dirs(manifest: ModuleManifest) -> List[str]:
     package = snake_case(package_name if len(package_name) > 1 else package_name)
     return list(filter(None, [org, package]))
 
-def update_file(file_path: str, line_content: str, remove: bool = False):
-    with open(file_path, "r+") as file:
-        lines = file.readlines()
-        file.seek(0)
-        if remove:
-            lines = [line for line in lines if line.strip() != line_content.strip()]
-        file.writelines(lines)
-        file.truncate()
-
 def get_hub_directory(manifest: ModuleManifest, site_packages: str) -> str:
     org_package = get_org_and_package_dirs(manifest)
     return os.path.join(site_packages, "guardrails", "hub", *org_package)

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -205,7 +205,7 @@ class TestPipProcess:
 
 
 def test_get_site_packages_location(mocker):
-    mock_pip_process = mocker.patch("guardrails.cli.hub.install.pip_process")
+    mock_pip_process = mocker.patch("guardrails.cli.hub.utils.pip_process")
     mock_pip_process.return_value = {"Location": "/site-pacakges"}
 
     from guardrails.cli.hub.install import get_site_packages_location
@@ -286,7 +286,7 @@ def test_get_hub_directory():
 
     assert hub_dir == "./site-packages/guardrails/hub/guardrails_ai/test_validator"
 
- 
+
 class TestAddToHubInits:
     def test_closes_early_if_already_added(self, mocker):
         manifest = ModuleManifest.from_dict(

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -126,7 +126,7 @@ class TestPipProcess:
             def parsebytes(self, *args):
                 return {"output": "json"}
 
-        mock_bytes_parser = mocker.patch("guardrails.cli.hub.install.BytesHeaderParser")
+        mock_bytes_parser = mocker.patch("guardrails.cli.hub.utils.BytesHeaderParser")
         mock_bytes_header_parser = MockBytesHeaderParser()
         mock_bytes_parser.return_value = mock_bytes_header_parser
 

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -286,7 +286,7 @@ def test_get_hub_directory():
 
     assert hub_dir == "./site-packages/guardrails/hub/guardrails_ai/test_validator"
 
-
+ 
 class TestAddToHubInits:
     def test_closes_early_if_already_added(self, mocker):
         manifest = ModuleManifest.from_dict(

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -1,5 +1,4 @@
 import pytest
-from unittest.mock import call, patch, MagicMock
 from guardrails.cli.server.module_manifest import ModuleManifest
 
 # Define a function to create a basic ModuleManifest instance for testing
@@ -23,7 +22,8 @@ class TestUninstall:
     def setup_manifest_and_site_packages(self, mocker):
         manifest = create_test_manifest()
         mocker.patch("uninstall.get_validator_manifest", return_value=manifest)
-        mocker.patch("uninstall.get_site_packages_location", return_value="/fake/site-packages")
+        mocker.patch("uninstall.get_site_packages_location", 
+                     return_value="/fake/site-packages")
         return manifest
 
     def test_uninstall_invalid_uri(self, mocker):
@@ -47,8 +47,10 @@ class TestUninstall:
         from guardrails.cli.hub.uninstall import uninstall
         uninstall("hub://guardrails/test-validator")
 
-        mock_uninstall_hub_module.assert_called_once_with(setup_manifest_and_site_packages, "/fake/site-packages")
-        mock_remove_from_hub_inits.assert_called_once_with(setup_manifest_and_site_packages, "/fake/site-packages")
+        mock_uninstall_hub_module.assert_called_once_with(
+            setup_manifest_and_site_packages, "/fake/site-packages")
+        mock_remove_from_hub_inits.assert_called_once_with(
+            setup_manifest_and_site_packages, "/fake/site-packages")
         
         assert mock_console.call_count == 2
         mock_console.assert_called_with("✅ Successfully uninstalled!")
@@ -56,7 +58,8 @@ class TestUninstall:
 
     def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
         # Simulate an error during uninstall
-        mocker.patch("uninstall.uninstall_hub_module", side_effect=Exception("Test error during uninstall"))
+        mocker.patch("uninstall.uninstall_hub_module", 
+                     side_effect=Exception("Test error during uninstall"))
         mock_exit = mocker.patch("uninstall.sys.exit")
         mock_console = mocker.patch("uninstall.console.print")
         mock_logger = mocker.patch("uninstall.logger.error")
@@ -65,6 +68,7 @@ class TestUninstall:
         with pytest.raises(Exception):
             uninstall("hub://guardrails/test-validator")
 
-        mock_logger.assert_called_with("Failed during uninstall: Test error during uninstall")
+        mock_logger.assert_called_with(
+            "Failed during uninstall: Test error during uninstall")
         mock_console.assert_not_called()
         mock_exit.assert_not_called()  

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import call, patch, MagicMock
+from guardrails.cli.server.module_manifest import ModuleManifest
+
+# Define a function to create a basic ModuleManifest instance for testing
+def create_test_manifest():
+    return ModuleManifest(
+        id="id",
+        name="name",
+        author={"name": "me", "email": "me@me.me"},
+        maintainers=[],
+        repository={"url": "some-repo"},
+        namespace="guardrails",
+        package_name="test-validator",
+        module_name="test_validator",
+        exports=["TestValidator"],
+        tags={},
+    )
+
+# Define tests for uninstalling a hub module
+class TestUninstall:
+    @pytest.fixture
+    def setup_manifest_and_site_packages(self, mocker):
+        manifest = create_test_manifest()
+        mocker.patch("uninstall.get_validator_manifest", return_value=manifest)
+        mocker.patch("uninstall.get_site_packages_location", return_value="/fake/site-packages")
+        return manifest
+
+    def test_uninstall_invalid_uri(self, mocker):
+        # Setup mocks
+        mock_exit = mocker.patch("uninstall.sys.exit")
+        mock_logger = mocker.patch("uninstall.logger.error")
+        
+        from guardrails.cli.hub.uninstall import uninstall
+        uninstall("not a hub uri")
+
+        mock_logger.assert_called_once_with("Invalid URI!")
+        mock_exit.assert_called_once_with(1)
+
+    def test_uninstall_successful(self, setup_manifest_and_site_packages, mocker):
+        # Setup mocks
+        mock_uninstall_hub_module = mocker.patch("uninstall.uninstall_hub_module")
+        mock_remove_from_hub_inits = mocker.patch("uninstall.remove_from_hub_inits")
+        mock_console = mocker.patch("uninstall.console.print")
+        mock_logger = mocker.patch("uninstall.logger.log")
+
+        from guardrails.cli.hub.uninstall import uninstall
+        uninstall("hub://guardrails/test-validator")
+
+        mock_uninstall_hub_module.assert_called_once_with(setup_manifest_and_site_packages, "/fake/site-packages")
+        mock_remove_from_hub_inits.assert_called_once_with(setup_manifest_and_site_packages, "/fake/site-packages")
+        
+        assert mock_console.call_count == 2
+        mock_console.assert_called_with("✅ Successfully uninstalled!")
+        mock_logger.assert_called()
+
+    def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
+        # Simulate an error during uninstall
+        mocker.patch("uninstall.uninstall_hub_module", side_effect=Exception("Test error during uninstall"))
+        mock_exit = mocker.patch("uninstall.sys.exit")
+        mock_console = mocker.patch("uninstall.console.print")
+        mock_logger = mocker.patch("uninstall.logger.error")
+
+        from guardrails.cli.hub.uninstall import uninstall
+        with pytest.raises(Exception):
+            uninstall("hub://guardrails/test-validator")
+
+        mock_logger.assert_called_with("Failed during uninstall: Test error during uninstall")
+        mock_console.assert_not_called()
+        mock_exit.assert_not_called()  

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -1,92 +1,97 @@
-import pytest
+from unittest.mock import mock_open, call
+
 from guardrails.cli.server.module_manifest import ModuleManifest
+from guardrails.cli.hub.uninstall import remove_from_hub_inits
+
+manifest_mock = ModuleManifest(
+    encoder="some_encoder",
+    id="module_id",
+    name="test_module",
+    author={"name": "Author Name", "email": "author@example.com"},
+    maintainers=[{"name": "Maintainer Name", "email": "maintainer@example.com"}],
+    repository={"url": "https://github.com/example/repo"},
+    namespace="guardrails",
+    package_name="test_package",
+    module_name="test_module",
+    exports=["Validator", "Helper"],
+)
 
 
-# Define a function to create a basic ModuleManifest instance for testing
-def create_test_manifest():
-    return ModuleManifest(
-        id="id",
-        name="name",
-        author={"name": "me", "email": "me@me.me"},
-        maintainers=[],
-        repository={"url": "some-repo"},
-        namespace="guardrails",
-        package_name="test-validator",
-        module_name="test_validator",
-        exports=["TestValidator"],
-        tags={},
+def test_remove_from_hub_inits(mocker):
+    mocker.patch(
+        "guardrails.cli.hub.uninstall.get_org_and_package_dirs",
+        return_value=["guardrails", "test_package"],
+    )
+    mock_remove_line = mocker.patch("guardrails.cli.hub.uninstall.remove_line")
+
+    remove_from_hub_inits(manifest_mock, "/site-packages")
+
+    expected_calls = [
+        call(
+            "/site-packages/guardrails/hub/__init__.py",
+            "from guardrails.hub.guardrails.test_package.test_module import "
+            "Validator, Helper",
+        ),
+        call(
+            "/site-packages/guardrails/hub/guardrails/__init__.py",
+            "from guardrails.hub.guardrails.test_package.test_module import "
+            "Validator, Helper",
+        ),
+    ]
+
+    mock_remove_line.assert_has_calls(expected_calls, any_order=True)
+
+
+def test_uninstall_invalid_uri(mocker):
+    mock_logger_error = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
+    mock_exit = mocker.patch("sys.exit")
+    mocker.patch(
+        "guardrails.cli.hub.uninstall.get_validator_manifest",
+        return_value=manifest_mock,
+    )
+    mocker.patch(
+        "guardrails.cli.hub.utils.pip_process",
+        return_value={"Location": "/fake/site-packages"},
     )
 
+    m_open = mock_open(read_data="import something")
+    mocker.patch("builtins.open", m_open)
+    mocker.patch("os.path.exists", return_value=True)
 
-# Define tests for uninstalling a hub module
-class TestUninstall:
-    @pytest.fixture
-    def setup_manifest_and_site_packages(self, mocker):
-        manifest = create_test_manifest()
-        mocker.patch(
-            "guardrails.cli.hub.uninstall.get_validator_manifest", return_value=manifest
-        )
-        mocker.patch(
-            "guardrails.cli.hub.uninstall.get_site_packages_location",
-            return_value="/fake/site-packages",
-        )
-        return manifest
+    mocker.patch("subprocess.check_call")
+    from guardrails.cli.hub.uninstall import uninstall
 
-    def test_uninstall_invalid_uri(self, mocker):
-        # Setup mocks
-        mock_exit = mocker.patch("guardrails.cli.hub.uninstall.sys.exit")
-        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
+    uninstall("not a hub uri")
 
-        from guardrails.cli.hub.uninstall import uninstall
+    mock_logger_error.assert_called_once_with("Invalid URI!")
+    mock_exit.assert_called_once_with(1)
 
-        uninstall("not a hub uri")
+    m_open.assert_called()
 
-        mock_logger.assert_called_once_with("Invalid URI!")
-        mock_exit.assert_called_once_with(1)
+    mock_subprocess_check_call = mocker.patch("subprocess.check_call")
+    mock_subprocess_check_call.assert_not_called()
 
-    def test_uninstall_successful(self, setup_manifest_and_site_packages, mocker):
-        # Setup mocks
-        mock_uninstall_hub_module = mocker.patch(
-            "guardrails.cli.hub.uninstall.uninstall_hub_module"
-        )
-        mock_remove_from_hub_inits = mocker.patch(
-            "guardrails.cli.hub.uninstall.remove_from_hub_inits"
-        )
-        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
-        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.log")
 
-        from guardrails.cli.hub.uninstall import uninstall
+def test_uninstall_valid_uri(mocker):
+    mocker.patch(
+        "guardrails.cli.hub.uninstall.get_validator_manifest",
+        return_value=manifest_mock,
+    )
+    mocker.patch(
+        "guardrails.cli.hub.uninstall.get_site_packages_location",
+        return_value="/site-packages",
+    )
+    mock_uninstall_hub_module = mocker.patch(
+        "guardrails.cli.hub.uninstall.uninstall_hub_module"
+    )
+    mock_remove_from_hub_inits = mocker.patch(
+        "guardrails.cli.hub.uninstall.remove_from_hub_inits"
+    )
+    mocker.patch("guardrails.cli.hub.uninstall.console")
 
-        uninstall("hub://guardrails/test-validator")
+    from guardrails.cli.hub.uninstall import uninstall
 
-        mock_uninstall_hub_module.assert_called_once_with(
-            setup_manifest_and_site_packages, "/fake/site-packages"
-        )
-        mock_remove_from_hub_inits.assert_called_once_with(
-            setup_manifest_and_site_packages, "/fake/site-packages"
-        )
+    uninstall("hub://guardrails/test-validator")
 
-        assert mock_console.call_count == 2
-        mock_console.assert_called_with("✅ Successfully uninstalled!")
-        mock_logger.assert_called()
-
-    def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
-        # Simulate an error during uninstall
-        mocker.patch(
-            "guardrails.cli.hub.uninstall.uninstall_hub_module",
-            side_effect=Exception("Test error during uninstall"),
-        )
-        mock_exit = mocker.patch("guardrails.cli.hub.uninstall.sys.exit")
-        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
-        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
-
-        from guardrails.cli.hub.uninstall import uninstall
-
-        with pytest.raises(Exception):
-            uninstall("hub://guardrails/test-validator")
-
-        mock_logger.assert_called_with(
-            "Failed during uninstall: Test error during uninstall"
-        )
-        mock_console.assert_not_called()
-        mock_exit.assert_not_called()
+    mock_uninstall_hub_module.assert_called_once_with(manifest_mock, "/site-packages")
+    mock_remove_from_hub_inits.assert_called_once_with(manifest_mock, "/site-packages")

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -34,7 +34,7 @@ class TestUninstall:
         mock_exit = mocker.patch("uninstall.sys.exit")
         mock_logger = mocker.patch("uninstall.logger.error")
 
-        from guardrails.cli.hub import uninstall
+        from guardrails.cli.hub.uninstall import uninstall
 
         uninstall("not a hub uri")
 
@@ -48,7 +48,7 @@ class TestUninstall:
         mock_console = mocker.patch("uninstall.console.print")
         mock_logger = mocker.patch("uninstall.logger.log")
 
-        from guardrails.cli.hub import uninstall
+        from guardrails.cli.hub.uninstall import uninstall
 
         uninstall("hub://guardrails/test-validator")
 
@@ -73,7 +73,7 @@ class TestUninstall:
         mock_console = mocker.patch("uninstall.console.print")
         mock_logger = mocker.patch("uninstall.logger.error")
 
-        from guardrails.cli.hub import uninstall
+        from guardrails.cli.hub.uninstall import uninstall
 
         with pytest.raises(Exception):
             uninstall("hub://guardrails/test-validator")

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -1,6 +1,6 @@
 import pytest
-
 from guardrails.cli.server.module_manifest import ModuleManifest
+
 
 # Define a function to create a basic ModuleManifest instance for testing
 def create_test_manifest():
@@ -17,45 +17,36 @@ def create_test_manifest():
         tags={},
     )
 
+
+# Define tests for uninstalling a hub module
 class TestUninstall:
     @pytest.fixture
     def setup_manifest_and_site_packages(self, mocker):
         manifest = create_test_manifest()
-        mocker.patch("guardrails.cli.hub.uninstall.get_validator_manifest",
-                     return_value=manifest)
+        mocker.patch("uninstall.get_validator_manifest", return_value=manifest)
         mocker.patch(
-            "guardrails.cli.hub.uninstall.get_site_packages_location", 
-            return_value="/fake/site-packages"
+            "uninstall.get_site_packages_location", return_value="/fake/site-packages"
         )
         return manifest
 
-    def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
-        mocker.patch(
-            "guardrails.cli.hub.uninstall.uninstall_hub_module",
-            side_effect=Exception("Test error during uninstall")
-        )
-        mock_exit = mocker.patch("guardrails.cli.hub.uninstall.sys.exit")
-        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
-        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
+    def test_uninstall_invalid_uri(self, mocker):
+        # Setup mocks
+        mock_exit = mocker.patch("uninstall.sys.exit")
+        mock_logger = mocker.patch("uninstall.logger.error")
 
         from guardrails.cli.hub.uninstall import uninstall
 
-        uninstall("hub://guardrails/test-validator")
+        uninstall("not a hub uri")
 
-        mock_logger.assert_called_once_with(
-            "Failed during uninstall: Test error during uninstall"
-        )
-        mock_console.assert_not_called()
-        mock_exit.assert_not_called()
-
+        mock_logger.assert_called_once_with("Invalid URI!")
+        mock_exit.assert_called_once_with(1)
 
     def test_uninstall_successful(self, setup_manifest_and_site_packages, mocker):
-        mock_uninstall_hub_module = mocker.patch(
-            "guardrails.cli.hub.uninstall.uninstall_hub_module")
-        mock_remove_from_hub_inits = mocker.patch(
-            "guardrails.cli.hub.uninstall.remove_from_hub_inits")
-        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
-        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.log")
+        # Setup mocks
+        mock_uninstall_hub_module = mocker.patch("uninstall.uninstall_hub_module")
+        mock_remove_from_hub_inits = mocker.patch("uninstall.remove_from_hub_inits")
+        mock_console = mocker.patch("uninstall.console.print")
+        mock_logger = mocker.patch("uninstall.logger.log")
 
         from guardrails.cli.hub.uninstall import uninstall
 
@@ -71,3 +62,24 @@ class TestUninstall:
         assert mock_console.call_count == 2
         mock_console.assert_called_with("✅ Successfully uninstalled!")
         mock_logger.assert_called()
+
+    def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
+        # Simulate an error during uninstall
+        mocker.patch(
+            "uninstall.uninstall_hub_module",
+            side_effect=Exception("Test error during uninstall"),
+        )
+        mock_exit = mocker.patch("uninstall.sys.exit")
+        mock_console = mocker.patch("uninstall.console.print")
+        mock_logger = mocker.patch("uninstall.logger.error")
+
+        from guardrails.cli.hub.uninstall import uninstall
+
+        with pytest.raises(Exception):
+            uninstall("hub://guardrails/test-validator")
+
+        mock_logger.assert_called_with(
+            "Failed during uninstall: Test error during uninstall"
+        )
+        mock_console.assert_not_called()
+        mock_exit.assert_not_called()

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -1,6 +1,4 @@
 import pytest
-from unittest.mock import call
-import sys
 
 from guardrails.cli.server.module_manifest import ModuleManifest
 
@@ -23,27 +21,39 @@ class TestUninstall:
     @pytest.fixture
     def setup_manifest_and_site_packages(self, mocker):
         manifest = create_test_manifest()
-        mocker.patch("guardrails.cli.hub.uninstall.get_validator_manifest", return_value=manifest)
+        mocker.patch("guardrails.cli.hub.uninstall.get_validator_manifest",
+                     return_value=manifest)
         mocker.patch(
-            "guardrails.cli.hub.uninstall.get_site_packages_location", return_value="/fake/site-packages"
+            "guardrails.cli.hub.uninstall.get_site_packages_location", 
+            return_value="/fake/site-packages"
         )
         return manifest
 
-    def test_uninstall_invalid_uri(self, mocker):
-        mock_logger_error = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
-        mock_exit = mocker.spy(sys, "exit")
+    def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
+        mocker.patch(
+            "guardrails.cli.hub.uninstall.uninstall_hub_module",
+            side_effect=Exception("Test error during uninstall")
+        )
+        mock_exit = mocker.patch("guardrails.cli.hub.uninstall.sys.exit")
+        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
+        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
 
         from guardrails.cli.hub.uninstall import uninstall
 
-        with pytest.raises(SystemExit):
-            uninstall("not a hub uri")
+        uninstall("hub://guardrails/test-validator")
 
-        mock_logger_error.assert_called_once_with("Invalid URI!")
-        mock_exit.assert_called_once_with(1)
+        mock_logger.assert_called_once_with(
+            "Failed during uninstall: Test error during uninstall"
+        )
+        mock_console.assert_not_called()
+        mock_exit.assert_not_called()
+
 
     def test_uninstall_successful(self, setup_manifest_and_site_packages, mocker):
-        mock_uninstall_hub_module = mocker.patch("guardrails.cli.hub.uninstall.uninstall_hub_module")
-        mock_remove_from_hub_inits = mocker.patch("guardrails.cli.hub.uninstall.remove_from_hub_inits")
+        mock_uninstall_hub_module = mocker.patch(
+            "guardrails.cli.hub.uninstall.uninstall_hub_module")
+        mock_remove_from_hub_inits = mocker.patch(
+            "guardrails.cli.hub.uninstall.remove_from_hub_inits")
         mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
         mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.log")
 
@@ -61,23 +71,3 @@ class TestUninstall:
         assert mock_console.call_count == 2
         mock_console.assert_called_with("✅ Successfully uninstalled!")
         mock_logger.assert_called()
-
-    def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
-        mocker.patch(
-            "guardrails.cli.hub.uninstall.uninstall_hub_module",
-            side_effect=Exception("Test error during uninstall"),
-        )
-        mock_exit = mocker.patch("guardrails.cli.hub.uninstall.sys.exit")
-        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
-        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
-
-        from guardrails.cli.hub.uninstall import uninstall
-
-        with pytest.raises(Exception):
-            uninstall("hub://guardrails/test-validator")
-
-        mock_logger.assert_called_with(
-            "Failed during uninstall: Test error during uninstall"
-        )
-        mock_console.assert_not_called()
-        mock_exit.assert_not_called()

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -1,6 +1,8 @@
 import pytest
-from guardrails.cli.server.module_manifest import ModuleManifest
+from unittest.mock import call
+import sys
 
+from guardrails.cli.server.module_manifest import ModuleManifest
 
 # Define a function to create a basic ModuleManifest instance for testing
 def create_test_manifest():
@@ -17,36 +19,33 @@ def create_test_manifest():
         tags={},
     )
 
-
-# Define tests for uninstalling a hub module
 class TestUninstall:
     @pytest.fixture
     def setup_manifest_and_site_packages(self, mocker):
         manifest = create_test_manifest()
-        mocker.patch("uninstall.get_validator_manifest", return_value=manifest)
+        mocker.patch("guardrails.cli.hub.uninstall.get_validator_manifest", return_value=manifest)
         mocker.patch(
-            "uninstall.get_site_packages_location", return_value="/fake/site-packages"
+            "guardrails.cli.hub.uninstall.get_site_packages_location", return_value="/fake/site-packages"
         )
         return manifest
 
     def test_uninstall_invalid_uri(self, mocker):
-        # Setup mocks
-        mock_exit = mocker.patch("uninstall.sys.exit")
-        mock_logger = mocker.patch("uninstall.logger.error")
+        mock_logger_error = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
+        mock_exit = mocker.spy(sys, "exit")
 
         from guardrails.cli.hub.uninstall import uninstall
 
-        uninstall("not a hub uri")
+        with pytest.raises(SystemExit):
+            uninstall("not a hub uri")
 
-        mock_logger.assert_called_once_with("Invalid URI!")
+        mock_logger_error.assert_called_once_with("Invalid URI!")
         mock_exit.assert_called_once_with(1)
 
     def test_uninstall_successful(self, setup_manifest_and_site_packages, mocker):
-        # Setup mocks
-        mock_uninstall_hub_module = mocker.patch("uninstall.uninstall_hub_module")
-        mock_remove_from_hub_inits = mocker.patch("uninstall.remove_from_hub_inits")
-        mock_console = mocker.patch("uninstall.console.print")
-        mock_logger = mocker.patch("uninstall.logger.log")
+        mock_uninstall_hub_module = mocker.patch("guardrails.cli.hub.uninstall.uninstall_hub_module")
+        mock_remove_from_hub_inits = mocker.patch("guardrails.cli.hub.uninstall.remove_from_hub_inits")
+        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
+        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.log")
 
         from guardrails.cli.hub.uninstall import uninstall
 
@@ -64,14 +63,13 @@ class TestUninstall:
         mock_logger.assert_called()
 
     def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
-        # Simulate an error during uninstall
         mocker.patch(
-            "uninstall.uninstall_hub_module",
+            "guardrails.cli.hub.uninstall.uninstall_hub_module",
             side_effect=Exception("Test error during uninstall"),
         )
-        mock_exit = mocker.patch("uninstall.sys.exit")
-        mock_console = mocker.patch("uninstall.console.print")
-        mock_logger = mocker.patch("uninstall.logger.error")
+        mock_exit = mocker.patch("guardrails.cli.hub.uninstall.sys.exit")
+        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
+        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
 
         from guardrails.cli.hub.uninstall import uninstall
 

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -23,16 +23,19 @@ class TestUninstall:
     @pytest.fixture
     def setup_manifest_and_site_packages(self, mocker):
         manifest = create_test_manifest()
-        mocker.patch("uninstall.get_validator_manifest", return_value=manifest)
         mocker.patch(
-            "uninstall.get_site_packages_location", return_value="/fake/site-packages"
+            "guardrails.cli.hub.uninstall.get_validator_manifest", return_value=manifest
+        )
+        mocker.patch(
+            "guardrails.cli.hub.uninstall.get_site_packages_location",
+            return_value="/fake/site-packages",
         )
         return manifest
 
     def test_uninstall_invalid_uri(self, mocker):
         # Setup mocks
-        mock_exit = mocker.patch("uninstall.sys.exit")
-        mock_logger = mocker.patch("uninstall.logger.error")
+        mock_exit = mocker.patch("guardrails.cli.hub.uninstall.sys.exit")
+        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
 
         from guardrails.cli.hub.uninstall import uninstall
 
@@ -43,10 +46,14 @@ class TestUninstall:
 
     def test_uninstall_successful(self, setup_manifest_and_site_packages, mocker):
         # Setup mocks
-        mock_uninstall_hub_module = mocker.patch("uninstall.uninstall_hub_module")
-        mock_remove_from_hub_inits = mocker.patch("uninstall.remove_from_hub_inits")
-        mock_console = mocker.patch("uninstall.console.print")
-        mock_logger = mocker.patch("uninstall.logger.log")
+        mock_uninstall_hub_module = mocker.patch(
+            "guardrails.cli.hub.uninstall.uninstall_hub_module"
+        )
+        mock_remove_from_hub_inits = mocker.patch(
+            "guardrails.cli.hub.uninstall.remove_from_hub_inits"
+        )
+        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
+        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.log")
 
         from guardrails.cli.hub.uninstall import uninstall
 
@@ -66,12 +73,12 @@ class TestUninstall:
     def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
         # Simulate an error during uninstall
         mocker.patch(
-            "uninstall.uninstall_hub_module",
+            "guardrails.cli.hub.uninstall.uninstall_hub_module",
             side_effect=Exception("Test error during uninstall"),
         )
-        mock_exit = mocker.patch("uninstall.sys.exit")
-        mock_console = mocker.patch("uninstall.console.print")
-        mock_logger = mocker.patch("uninstall.logger.error")
+        mock_exit = mocker.patch("guardrails.cli.hub.uninstall.sys.exit")
+        mock_console = mocker.patch("guardrails.cli.hub.uninstall.console.print")
+        mock_logger = mocker.patch("guardrails.cli.hub.uninstall.logger.error")
 
         from guardrails.cli.hub.uninstall import uninstall
 

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -1,6 +1,7 @@
 import pytest
 from guardrails.cli.server.module_manifest import ModuleManifest
 
+
 # Define a function to create a basic ModuleManifest instance for testing
 def create_test_manifest():
     return ModuleManifest(
@@ -16,22 +17,25 @@ def create_test_manifest():
         tags={},
     )
 
+
 # Define tests for uninstalling a hub module
 class TestUninstall:
     @pytest.fixture
     def setup_manifest_and_site_packages(self, mocker):
         manifest = create_test_manifest()
         mocker.patch("uninstall.get_validator_manifest", return_value=manifest)
-        mocker.patch("uninstall.get_site_packages_location", 
-                     return_value="/fake/site-packages")
+        mocker.patch(
+            "uninstall.get_site_packages_location", return_value="/fake/site-packages"
+        )
         return manifest
 
     def test_uninstall_invalid_uri(self, mocker):
         # Setup mocks
         mock_exit = mocker.patch("uninstall.sys.exit")
         mock_logger = mocker.patch("uninstall.logger.error")
-        
+
         from guardrails.cli.hub.uninstall import uninstall
+
         uninstall("not a hub uri")
 
         mock_logger.assert_called_once_with("Invalid URI!")
@@ -45,30 +49,37 @@ class TestUninstall:
         mock_logger = mocker.patch("uninstall.logger.log")
 
         from guardrails.cli.hub.uninstall import uninstall
+
         uninstall("hub://guardrails/test-validator")
 
         mock_uninstall_hub_module.assert_called_once_with(
-            setup_manifest_and_site_packages, "/fake/site-packages")
+            setup_manifest_and_site_packages, "/fake/site-packages"
+        )
         mock_remove_from_hub_inits.assert_called_once_with(
-            setup_manifest_and_site_packages, "/fake/site-packages")
-        
+            setup_manifest_and_site_packages, "/fake/site-packages"
+        )
+
         assert mock_console.call_count == 2
         mock_console.assert_called_with("✅ Successfully uninstalled!")
         mock_logger.assert_called()
 
     def test_uninstall_failures(self, setup_manifest_and_site_packages, mocker):
         # Simulate an error during uninstall
-        mocker.patch("uninstall.uninstall_hub_module", 
-                     side_effect=Exception("Test error during uninstall"))
+        mocker.patch(
+            "uninstall.uninstall_hub_module",
+            side_effect=Exception("Test error during uninstall"),
+        )
         mock_exit = mocker.patch("uninstall.sys.exit")
         mock_console = mocker.patch("uninstall.console.print")
         mock_logger = mocker.patch("uninstall.logger.error")
 
         from guardrails.cli.hub.uninstall import uninstall
+
         with pytest.raises(Exception):
             uninstall("hub://guardrails/test-validator")
 
         mock_logger.assert_called_with(
-            "Failed during uninstall: Test error during uninstall")
+            "Failed during uninstall: Test error during uninstall"
+        )
         mock_console.assert_not_called()
-        mock_exit.assert_not_called()  
+        mock_exit.assert_not_called()

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -34,7 +34,7 @@ class TestUninstall:
         mock_exit = mocker.patch("uninstall.sys.exit")
         mock_logger = mocker.patch("uninstall.logger.error")
 
-        from guardrails.cli.hub.uninstall import uninstall
+        from guardrails.cli.hub import uninstall
 
         uninstall("not a hub uri")
 
@@ -48,7 +48,7 @@ class TestUninstall:
         mock_console = mocker.patch("uninstall.console.print")
         mock_logger = mocker.patch("uninstall.logger.log")
 
-        from guardrails.cli.hub.uninstall import uninstall
+        from guardrails.cli.hub import uninstall
 
         uninstall("hub://guardrails/test-validator")
 
@@ -73,7 +73,7 @@ class TestUninstall:
         mock_console = mocker.patch("uninstall.console.print")
         mock_logger = mocker.patch("uninstall.logger.error")
 
-        from guardrails.cli.hub.uninstall import uninstall
+        from guardrails.cli.hub import uninstall
 
         with pytest.raises(Exception):
             uninstall("hub://guardrails/test-validator")


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/guardrails-ai/guardrails/issues/736) and adds an uninstall command so that users can uninstall validators.