### PR TITLE
Deprecate superfluous read-only properties.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,22 +17,22 @@ type:
 	@make $(TYPING_CMD)
 
 type-pydantic-v1-openai-v0:
-	echo '{"exclude": ["guardrails/utils/pydantic_utils/v2.py", "guardrails/utils/openai_utils/v1.py"]}' > pyrightconfig.json
+	echo '{"reportDeprecated": true, "exclude": ["guardrails/utils/pydantic_utils/v2.py", "guardrails/utils/openai_utils/v1.py"]}' > pyrightconfig.json
 	poetry run pyright guardrails/
 	rm pyrightconfig.json
 
 type-pydantic-v1-openai-v1:
-	echo '{"exclude": ["guardrails/utils/pydantic_utils/v2.py", "guardrails/utils/openai_utils/v0.py"]}' > pyrightconfig.json
+	echo '{"reportDeprecated": true, "exclude": ["guardrails/utils/pydantic_utils/v2.py", "guardrails/utils/openai_utils/v0.py"]}' > pyrightconfig.json
 	poetry run pyright guardrails/
 	rm pyrightconfig.json
 
 type-pydantic-v2-openai-v0:
-	echo '{"exclude": ["guardrails/utils/pydantic_utils/v1.py", "guardrails/utils/openai_utils/v1.py"]}' > pyrightconfig.json
+	echo '{"reportDeprecated": true, "exclude": ["guardrails/utils/pydantic_utils/v1.py", "guardrails/utils/openai_utils/v1.py"]}' > pyrightconfig.json
 	poetry run pyright guardrails/
 	rm pyrightconfig.json
 
 type-pydantic-v2-openai-v1:
-	echo '{"exclude": ["guardrails/utils/pydantic_utils/v1.py", "guardrails/utils/openai_utils/v0.py"]}' > pyrightconfig.json
+	echo '{"reportDeprecated": true, "exclude": ["guardrails/utils/pydantic_utils/v1.py", "guardrails/utils/openai_utils/v0.py"]}' > pyrightconfig.json
 	poetry run pyright guardrails/
 	rm pyrightconfig.json
 

--- a/guardrails/applications/text2sql.py
+++ b/guardrails/applications/text2sql.py
@@ -140,7 +140,7 @@ class Text2Sql:
             rail_spec_str = Template(rail_spec_str).safe_substitute(**rail_params)
 
         guard = Guard.from_rail_string(rail_spec_str)
-        guard.reask_prompt = reask_prompt
+        guard.rail.output_schema.reask_prompt_template = reask_prompt
 
         return guard
 


### PR DESCRIPTION
This PR deprecates the read-only shortcut properties on the Guard class in preparation for v0.5.x.  Some of these properties have migration patterns, typically to using Guard.history.  Others simply will not exist in 0.5.x.