### PR TITLE
Add Quiet Install

### DIFF
--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -248,12 +248,7 @@ def install(
         logger.error("Invalid URI!")
         sys.exit(1)
 
-    if not quiet:
-        console.print(f"\nInstalling {package_uri}...\n")
-        logger.log(
-            level=LEVELS.get("SPAM"),  # type: ignore
-            msg=f"Installing {package_uri}...",
-        )
+    console.print(f"\nInstalling {package_uri}...\n")
 
     # Validation
     module_name = package_uri.replace("hub://", "")
@@ -277,6 +272,8 @@ def install(
             status.update("Running post-install setup")
         run_post_install(module_manifest, site_packages)
         add_to_hub_inits(module_manifest, site_packages)
+    
+    console.print("Installation complete")
 
     if not quiet:
         success_message_cli = Template(

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -284,7 +284,7 @@ def install(
             "[bold]Import validator:[/bold]\n"
             "from guardrails.hub import ${export}\n\n"
             "[bold]Get more info:[/bold]\n"
-            "https://hub.guardrailsai.com/validator/${id}"
+            "https://hub.guardrailsai.com/validator/${id}\n"
         ).safe_substitute(
             module_name=package_uri,
             id=module_manifest.id,
@@ -295,7 +295,7 @@ def install(
             "Import validator:\n"
             "from guardrails.hub import ${export}\n\n"
             "Get more info:\n"
-            "https://hub.guardrailsai.com/validator/${id}"
+            "https://hub.guardrailsai.com/validator/${id}\n"
         ).safe_substitute(
             module_name=package_uri,
             id=module_manifest.id,

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -248,7 +248,7 @@ def install(
         logger.error("Invalid URI!")
         sys.exit(1)
 
-    console.print(f"\nInstalling {package_uri}...\n")
+    logger.info(f"\nInstalling {package_uri}...\n")
 
     # Validation
     module_name = package_uri.replace("hub://", "")
@@ -273,7 +273,7 @@ def install(
         run_post_install(module_manifest, site_packages)
         add_to_hub_inits(module_manifest, site_packages)
 
-    console.print("Installation complete")
+    logger.info("Installation complete")
 
     if not quiet:
         success_message_cli = Template(

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -251,10 +251,10 @@ def install(
     if not quiet:
         console.print(f"\nInstalling {package_uri}...\n")
 
-    logger.log(
-        level=LEVELS.get("SPAM"),  # type: ignore
-        msg=f"Installing {package_uri}...",
-    )
+        logger.log(
+            level=LEVELS.get("SPAM"),  # type: ignore
+            msg=f"Installing {package_uri}...",
+        )
 
     # Validation
     module_name = package_uri.replace("hub://", "")

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -248,7 +248,7 @@ def install(
         logger.error("Invalid URI!")
         sys.exit(1)
 
-    logger.log(level=5, msg=f"Installing {package_uri}...")  
+    logger.log(level=5, msg=f"Installing {package_uri}...")
     logger.info(f"\nInstalling {package_uri}...\n")
 
     # Validation

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -289,7 +289,7 @@ def install(
             module_name=package_uri,
             id=module_manifest.id,
             export=module_manifest.exports[0],
-            )
+        )
         success_message_logger = Template(
             "✅Successfully installed ${module_name}!\n\n"
             "Import validator:\n"

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -237,7 +237,8 @@ def install(
     package_uri: str = typer.Argument(
         help="URI to the package to install. Example: hub://guardrails/regex_match."
     ),
-    quiet: bool = typer.Option(False, "--quiet", help="Run the command in quiet mode to reduce output verbosity.")
+    quiet: bool = typer.Option(False, "--quiet", 
+        help="Run the command in quiet mode to reduce output verbosity.")
 ):
     """Install a validator from the Hub."""
     if not package_uri.startswith("hub://"):

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -250,7 +250,6 @@ def install(
 
     if not quiet:
         console.print(f"\nInstalling {package_uri}...\n")
-
         logger.log(
             level=LEVELS.get("SPAM"),  # type: ignore
             msg=f"Installing {package_uri}...",
@@ -281,28 +280,14 @@ def install(
 
     if not quiet:
         success_message_cli = Template(
-            """✅Successfully installed ${module_name}!
-
-    [bold]Import validator:[/bold]
-    from guardrails.hub import ${export}
-
-    [bold]Get more info:[/bold]
-    https://hub.guardrailsai.com/validator/${id}
-    """
+            """✅Successfully installed ${module_name}!\n\n[bold]Import validator:[/bold]\nfrom guardrails.hub import ${export}\n\n[bold]Get more info:[/bold]\nhttps://hub.guardrailsai.com/validator/${id}"""
         ).safe_substitute(
             module_name=package_uri,
             id=module_manifest.id,
             export=module_manifest.exports[0],
         )
         success_message_logger = Template(
-            """✅Successfully installed ${module_name}!
-
-    Import validator:
-    from guardrails.hub import ${export}
-
-    Get more info:
-    https://hub.guardrailsai.com/validator/${id}
-    """
+            """✅Successfully installed ${module_name}!\n\nImport validator:\nfrom guardrails.hub import ${export}\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/${id}"""
         ).safe_substitute(
             module_name=package_uri,
             id=module_manifest.id,

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -272,7 +272,7 @@ def install(
             status.update("Running post-install setup")
         run_post_install(module_manifest, site_packages)
         add_to_hub_inits(module_manifest, site_packages)
-    
+
     console.print("Installation complete")
 
     if not quiet:

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -237,13 +237,16 @@ def install(
     package_uri: str = typer.Argument(
         help="URI to the package to install. Example: hub://guardrails/regex_match."
     ),
+    quiet: bool = typer.Option(False, "--quiet", help="Run the command in quiet mode to reduce output verbosity.")
 ):
     """Install a validator from the Hub."""
     if not package_uri.startswith("hub://"):
         logger.error("Invalid URI!")
         sys.exit(1)
 
-    console.print(f"\nInstalling {package_uri}...\n")
+    if not quiet: 
+        console.print(f"\nInstalling {package_uri}...\n")
+    
     logger.log(
         level=LEVELS.get("SPAM"),  # type: ignore
         msg=f"Installing {package_uri}...",
@@ -253,46 +256,53 @@ def install(
     module_name = package_uri.replace("hub://", "")
 
     # Prep
-    with console.status("Fetching manifest", spinner="bouncingBar"):
+    with console.status("Fetching manifest", spinner="bouncingBar") as status:
+        if not quiet: 
+            status.update("Fetching manifest")
         module_manifest = get_validator_manifest(module_name)
         site_packages = get_site_packages_location()
 
     # Install
-    with console.status("Downloading dependencies", spinner="bouncingBar"):
+    with console.status("Downloading dependencies", spinner="bouncingBar") as status:
+        if not quiet:
+            status.update("Downloading dependencies")
         install_hub_module(module_manifest, site_packages)
 
     # Post-install
-    with console.status("Running post-install setup", spinner="bouncingBar"):
+    with console.status("Running post-install setup", spinner="bouncingBar") as status:
+        if not quiet:
+            status.update("Running post-install setup")
         run_post_install(module_manifest, site_packages)
         add_to_hub_inits(module_manifest, site_packages)
 
-    success_message_cli = Template(
-        """✅Successfully installed ${module_name}!
+    if not quiet: 
+        success_message_cli = Template(
+            """✅Successfully installed ${module_name}!
 
-[bold]Import validator:[/bold]
-from guardrails.hub import ${export}
+    [bold]Import validator:[/bold]
+    from guardrails.hub import ${export}
 
-[bold]Get more info:[/bold]
-https://hub.guardrailsai.com/validator/${id}
-"""
-    ).safe_substitute(
-        module_name=package_uri,
-        id=module_manifest.id,
-        export=module_manifest.exports[0],
-    )
-    success_message_logger = Template(
-        """✅Successfully installed ${module_name}!
+    [bold]Get more info:[/bold]
+    https://hub.guardrailsai.com/validator/${id}
+    """
+        ).safe_substitute(
+            module_name=package_uri,
+            id=module_manifest.id,
+            export=module_manifest.exports[0],
+        )
+        success_message_logger = Template(
+            """✅Successfully installed ${module_name}!
 
-Import validator:
-from guardrails.hub import ${export}
+    Import validator:
+    from guardrails.hub import ${export}
 
-Get more info:
-https://hub.guardrailsai.com/validator/${id}
-"""
-    ).safe_substitute(
-        module_name=package_uri,
-        id=module_manifest.id,
-        export=module_manifest.exports[0],
-    )
-    console.print(success_message_cli)  # type: ignore
-    logger.log(level=LEVELS.get("SPAM"), msg=success_message_logger)  # type: ignore
+    Get more info:
+    https://hub.guardrailsai.com/validator/${id}
+    """
+        ).safe_substitute(
+            module_name=package_uri,
+            id=module_manifest.id,
+            export=module_manifest.exports[0],
+        )
+        console.print(success_message_cli)  # type: ignore
+        logger.log(level=LEVELS.get("SPAM"), msg=success_message_logger)  # type: ignore

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -237,17 +237,20 @@ def install(
     package_uri: str = typer.Argument(
         help="URI to the package to install. Example: hub://guardrails/regex_match."
     ),
-    quiet: bool = typer.Option(False, "--quiet", 
-        help="Run the command in quiet mode to reduce output verbosity.")
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        help="Run the command in quiet mode to reduce output verbosity.",
+    ),
 ):
     """Install a validator from the Hub."""
     if not package_uri.startswith("hub://"):
         logger.error("Invalid URI!")
         sys.exit(1)
 
-    if not quiet: 
+    if not quiet:
         console.print(f"\nInstalling {package_uri}...\n")
-    
+
     logger.log(
         level=LEVELS.get("SPAM"),  # type: ignore
         msg=f"Installing {package_uri}...",
@@ -258,7 +261,7 @@ def install(
 
     # Prep
     with console.status("Fetching manifest", spinner="bouncingBar") as status:
-        if not quiet: 
+        if not quiet:
             status.update("Fetching manifest")
         module_manifest = get_validator_manifest(module_name)
         site_packages = get_site_packages_location()
@@ -276,7 +279,7 @@ def install(
         run_post_install(module_manifest, site_packages)
         add_to_hub_inits(module_manifest, site_packages)
 
-    if not quiet: 
+    if not quiet:
         success_message_cli = Template(
             """✅Successfully installed ${module_name}!
 

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -280,14 +280,22 @@ def install(
 
     if not quiet:
         success_message_cli = Template(
-            """✅Successfully installed ${module_name}!\n\n[bold]Import validator:[/bold]\nfrom guardrails.hub import ${export}\n\n[bold]Get more info:[/bold]\nhttps://hub.guardrailsai.com/validator/${id}"""
+            "✅Successfully installed ${module_name}!\n\n"
+            "[bold]Import validator:[/bold]\n"
+            "from guardrails.hub import ${export}\n\n"
+            "[bold]Get more info:[/bold]\n"
+            "https://hub.guardrailsai.com/validator/${id}"
         ).safe_substitute(
             module_name=package_uri,
             id=module_manifest.id,
             export=module_manifest.exports[0],
-        )
+            )
         success_message_logger = Template(
-            """✅Successfully installed ${module_name}!\n\nImport validator:\nfrom guardrails.hub import ${export}\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/${id}"""
+            "✅Successfully installed ${module_name}!\n\n"
+            "Import validator:\n"
+            "from guardrails.hub import ${export}\n\n"
+            "Get more info:\n"
+            "https://hub.guardrailsai.com/validator/${id}"
         ).safe_substitute(
             module_name=package_uri,
             id=module_manifest.id,

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -248,6 +248,7 @@ def install(
         logger.error("Invalid URI!")
         sys.exit(1)
 
+    logger.log(level=5, msg=f"Installing {package_uri}...")  
     logger.info(f"\nInstalling {package_uri}...\n")
 
     # Validation

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -24,34 +24,41 @@ class TestInstall:
         # Mocking the dependencies
         mock_logger_log = mocker.patch("guardrails.cli.hub.install.logger.log")
         mock_get_validator_manifest = mocker.patch(
-            "guardrails.cli.hub.install.get_validator_manifest")
+            "guardrails.cli.hub.install.get_validator_manifest"
+        )
         mock_console_print = mocker.patch("guardrails.cli.hub.console.print")
 
-        manifest = ModuleManifest.from_dict({
-            "id": "id",
-            "name": "name",
-            "author": {"name": "me", "email": "me@me.me"},
-            "maintainers": [],
-            "repository": {"url": "some-repo"},
-            "namespace": "guardrails",
-            "package_name": "test-validator",
-            "module_name": "test_validator",
-            "exports": ["TestValidator"],
-            "tags": {},
-        })
+        manifest = ModuleManifest.from_dict(
+            {
+                "id": "id",
+                "name": "name",
+                "author": {"name": "me", "email": "me@me.me"},
+                "maintainers": [],
+                "repository": {"url": "some-repo"},
+                "namespace": "guardrails",
+                "package_name": "test-validator",
+                "module_name": "test_validator",
+                "exports": ["TestValidator"],
+                "tags": {},
+            }
+        )
         mock_get_validator_manifest.return_value = manifest
 
         mock_get_site_packages_location = mocker.patch(
-            "guardrails.cli.hub.install.get_site_packages_location")
+            "guardrails.cli.hub.install.get_site_packages_location"
+        )
         site_packages = "./.venv/lib/python3.X/site-packages"
         mock_get_site_packages_location.return_value = site_packages
 
         mock_install_hub_module = mocker.patch(
-            "guardrails.cli.hub.install.install_hub_module")
+            "guardrails.cli.hub.install.install_hub_module"
+        )
         mock_run_post_install = mocker.patch(
-            "guardrails.cli.hub.install.run_post_install")
+            "guardrails.cli.hub.install.run_post_install"
+        )
         mock_add_to_hub_init = mocker.patch(
-            "guardrails.cli.hub.install.add_to_hub_inits")
+            "guardrails.cli.hub.install.add_to_hub_inits"
+        )
 
         from guardrails.cli.hub.install import install
 
@@ -59,17 +66,19 @@ class TestInstall:
         install("hub://guardrails/test-validator")
         normal_mode_log_calls = [
             call(level=5, msg="Installing hub://guardrails/test-validator..."),
-            call(level=5, msg=
-                 """✅Successfully installed hub://guardrails/test-validator!
+            call(
+                level=5,
+                msg="""✅Successfully installed hub://guardrails/test-validator!
     
                 Import validator:
                 from guardrails.hub import TestValidator
                 
                 Get more info:
                 https://hub.guardrailsai.com/validator/id""",
-            )]
+            ),
+        ]
         mock_logger_log.assert_has_calls(normal_mode_log_calls, any_order=True)
-        assert mock_console_print.call_count > 0  
+        assert mock_console_print.call_count > 0
 
         mock_logger_log.reset_mock()
         mock_console_print.reset_mock()
@@ -120,11 +129,9 @@ class TestPipProcess:
         assert response == "string output"
 
     def test_json_format(self, mocker):
-        mock_logger_debug = mocker.patch(
-            "guardrails.cli.hub.install.logger.debug")
+        mock_logger_debug = mocker.patch("guardrails.cli.hub.install.logger.debug")
 
-        mock_sys_executable = mocker.patch(
-            "guardrails.cli.hub.install.sys.executable")
+        mock_sys_executable = mocker.patch("guardrails.cli.hub.install.sys.executable")
 
         mock_subprocess_check_output = mocker.patch(
             "guardrails.cli.hub.install.subprocess.check_output"

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -69,7 +69,7 @@ class TestInstall:
                 msg="✅Successfully installed hub://guardrails/test-validator!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/id\n",  # noqa
             ),  # noqa
         ]
-        assert mock_logger_log.call_count == 2
+        assert mock_logger_log.call_count == 1
         print(mock_logger_log)
         mock_logger_log.assert_has_calls(log_calls)
 
@@ -706,3 +706,16 @@ def test_install_hub_module(mocker):
         call("install", "pydash>=7.0.6,<8.0.0"),
     ]
     mock_pip_process.assert_has_calls(pip_calls)
+    
+    def test_quiet_install(self, mocker):
+        mock_console_print = mocker.patch("guardrails.cli.hub.install.console.print")
+
+        from guardrails.cli.hub.install import install
+        install("hub://guardrails/test-validator", quiet=True)
+
+        # Expect no output other than the mandatory lines
+        mock_console_print.assert_has_calls([
+            call("Installing validator..."),
+            call("Installation complete"),
+        ])
+        assert mock_console_print.call_count == 2

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -21,67 +21,74 @@ class TestInstall:
         sys_exit_spy.assert_called_once_with(1)
 
     def test_happy_path(self, mocker):
+        # Mocking the dependencies
         mock_logger_log = mocker.patch("guardrails.cli.hub.install.logger.log")
-
         mock_get_validator_manifest = mocker.patch(
-            "guardrails.cli.hub.install.get_validator_manifest"
-        )
-        manifest = ModuleManifest.from_dict(
-            {
-                "id": "id",
-                "name": "name",
-                "author": {"name": "me", "email": "me@me.me"},
-                "maintainers": [],
-                "repository": {"url": "some-repo"},
-                "namespace": "guardrails",
-                "package_name": "test-validator",
-                "module_name": "test_validator",
-                "exports": ["TestValidator"],
-                "tags": {},
-            }
-        )
+            "guardrails.cli.hub.install.get_validator_manifest")
+        mock_console_print = mocker.patch("guardrails.cli.hub.console.print")
+
+        manifest = ModuleManifest.from_dict({
+            "id": "id",
+            "name": "name",
+            "author": {"name": "me", "email": "me@me.me"},
+            "maintainers": [],
+            "repository": {"url": "some-repo"},
+            "namespace": "guardrails",
+            "package_name": "test-validator",
+            "module_name": "test_validator",
+            "exports": ["TestValidator"],
+            "tags": {},
+        })
         mock_get_validator_manifest.return_value = manifest
 
         mock_get_site_packages_location = mocker.patch(
-            "guardrails.cli.hub.install.get_site_packages_location"
-        )
+            "guardrails.cli.hub.install.get_site_packages_location")
         site_packages = "./.venv/lib/python3.X/site-packages"
         mock_get_site_packages_location.return_value = site_packages
 
         mock_install_hub_module = mocker.patch(
-            "guardrails.cli.hub.install.install_hub_module"
-        )
+            "guardrails.cli.hub.install.install_hub_module")
         mock_run_post_install = mocker.patch(
-            "guardrails.cli.hub.install.run_post_install"
-        )
+            "guardrails.cli.hub.install.run_post_install")
         mock_add_to_hub_init = mocker.patch(
-            "guardrails.cli.hub.install.add_to_hub_inits"
-        )
+            "guardrails.cli.hub.install.add_to_hub_inits")
 
         from guardrails.cli.hub.install import install
 
+        # Test without quiet mode
         install("hub://guardrails/test-validator")
-
-        log_calls = [
+        normal_mode_log_calls = [
             call(level=5, msg="Installing hub://guardrails/test-validator..."),
-            call(
-                level=5,
-                msg="✅Successfully installed hub://guardrails/test-validator!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/id\n",  # noqa
-            ),  # noqa
+            call(level=5, msg=
+                 """✅Successfully installed hub://guardrails/test-validator!
+    
+                Import validator:
+                from guardrails.hub import TestValidator
+                
+                Get more info:
+                https://hub.guardrailsai.com/validator/id""",
+            )]
+        mock_logger_log.assert_has_calls(normal_mode_log_calls, any_order=True)
+        assert mock_console_print.call_count > 0  
+
+        mock_logger_log.reset_mock()
+        mock_console_print.reset_mock()
+
+        install("hub://guardrails/test-validator", quiet=True)
+        quiet_mode_log_calls = [
+            call(level=5, msg="Installing hub://guardrails/test-validator..."),
         ]
-        assert mock_logger_log.call_count == 2
-        print(mock_logger_log)
-        mock_logger_log.assert_has_calls(log_calls)
+        # Expect no additional log message for the success since it's quiet mode
+        assert mock_logger_log.call_count == 1
+        mock_logger_log.assert_has_calls(quiet_mode_log_calls, any_order=True)
+        assert mock_console_print.call_count == 0
 
-        mock_get_validator_manifest.assert_called_once_with("guardrails/test-validator")
-
-        assert mock_get_site_packages_location.call_count == 1
-
-        mock_install_hub_module.assert_called_once_with(manifest, site_packages)
-
-        mock_run_post_install.assert_called_once_with(manifest, site_packages)
-
-        mock_add_to_hub_init.assert_called_once_with(manifest, site_packages)
+        # Check that all other mocks are called as expected
+        assert mock_get_validator_manifest.call_count == 2
+        assert mock_get_site_packages_location.call_count == 2
+        assert mock_install_hub_module.call_count == 2
+        assert mock_run_post_install.call_count == 2
+        assert mock_add_to_hub_init.call_count == 2
 
 
 class TestPipProcess:
@@ -113,9 +120,11 @@ class TestPipProcess:
         assert response == "string output"
 
     def test_json_format(self, mocker):
-        mock_logger_debug = mocker.patch("guardrails.cli.hub.install.logger.debug")
+        mock_logger_debug = mocker.patch(
+            "guardrails.cli.hub.install.logger.debug")
 
-        mock_sys_executable = mocker.patch("guardrails.cli.hub.install.sys.executable")
+        mock_sys_executable = mocker.patch(
+            "guardrails.cli.hub.install.sys.executable")
 
         mock_subprocess_check_output = mocker.patch(
             "guardrails.cli.hub.install.subprocess.check_output"

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -706,16 +706,19 @@ def test_install_hub_module(mocker):
         call("install", "pydash>=7.0.6,<8.0.0"),
     ]
     mock_pip_process.assert_has_calls(pip_calls)
-    
+
     def test_quiet_install(self, mocker):
         mock_console_print = mocker.patch("guardrails.cli.hub.install.console.print")
 
         from guardrails.cli.hub.install import install
+
         install("hub://guardrails/test-validator", quiet=True)
 
         # Expect no output other than the mandatory lines
-        mock_console_print.assert_has_calls([
-            call("Installing validator..."),
-            call("Installation complete"),
-        ])
+        mock_console_print.assert_has_calls(
+            [
+                call("Installing validator..."),
+                call("Installation complete"),
+            ]
+        )
         assert mock_console_print.call_count == 2

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -60,7 +60,7 @@ class TestInstall:
 
         from guardrails.cli.hub.install import install
 
-        install("hub://guardrails/test-validator")
+        install("hub://guardrails/test-validator", quiet=False)
 
         log_calls = [
             call(level=5, msg="Installing hub://guardrails/test-validator..."),
@@ -706,4 +706,3 @@ def test_install_hub_module(mocker):
         call("install", "pydash>=7.0.6,<8.0.0"),
     ]
     mock_pip_process.assert_has_calls(pip_calls)
-    

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -69,7 +69,7 @@ class TestInstall:
                 msg="✅Successfully installed hub://guardrails/test-validator!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/id\n",  # noqa
             ),  # noqa
         ]
-        assert mock_logger_log.call_count == 1
+        assert mock_logger_log.call_count == 2
         print(mock_logger_log)
         mock_logger_log.assert_has_calls(log_calls)
 

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -706,3 +706,4 @@ def test_install_hub_module(mocker):
         call("install", "pydash>=7.0.6,<8.0.0"),
     ]
     mock_pip_process.assert_has_calls(pip_calls)
+    

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -21,13 +21,11 @@ class TestInstall:
         sys_exit_spy.assert_called_once_with(1)
 
     def test_happy_path(self, mocker):
-        # Mocking the dependencies
         mock_logger_log = mocker.patch("guardrails.cli.hub.install.logger.log")
+
         mock_get_validator_manifest = mocker.patch(
             "guardrails.cli.hub.install.get_validator_manifest"
         )
-        mock_console_print = mocker.patch("guardrails.cli.hub.console.print")
-
         manifest = ModuleManifest.from_dict(
             {
                 "id": "id",
@@ -62,42 +60,28 @@ class TestInstall:
 
         from guardrails.cli.hub.install import install
 
-        # Test without quiet mode
         install("hub://guardrails/test-validator")
-        normal_mode_log_calls = [
+
+        log_calls = [
             call(level=5, msg="Installing hub://guardrails/test-validator..."),
             call(
                 level=5,
-                msg="""✅Successfully installed hub://guardrails/test-validator!
-    
-                Import validator:
-                from guardrails.hub import TestValidator
-                
-                Get more info:
-                https://hub.guardrailsai.com/validator/id""",
-            ),
+                msg="✅Successfully installed hub://guardrails/test-validator!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/id\n",  # noqa
+            ),  # noqa
         ]
-        mock_logger_log.assert_has_calls(normal_mode_log_calls, any_order=True)
-        assert mock_console_print.call_count > 0
+        assert mock_logger_log.call_count == 2
+        print(mock_logger_log)
+        mock_logger_log.assert_has_calls(log_calls)
 
-        mock_logger_log.reset_mock()
-        mock_console_print.reset_mock()
+        mock_get_validator_manifest.assert_called_once_with("guardrails/test-validator")
 
-        install("hub://guardrails/test-validator", quiet=True)
-        quiet_mode_log_calls = [
-            call(level=5, msg="Installing hub://guardrails/test-validator..."),
-        ]
-        # Expect no additional log message for the success since it's quiet mode
-        assert mock_logger_log.call_count == 1
-        mock_logger_log.assert_has_calls(quiet_mode_log_calls, any_order=True)
-        assert mock_console_print.call_count == 0
+        assert mock_get_site_packages_location.call_count == 1
 
-        # Check that all other mocks are called as expected
-        assert mock_get_validator_manifest.call_count == 2
-        assert mock_get_site_packages_location.call_count == 2
-        assert mock_install_hub_module.call_count == 2
-        assert mock_run_post_install.call_count == 2
-        assert mock_add_to_hub_init.call_count == 2
+        mock_install_hub_module.assert_called_once_with(manifest, site_packages)
+
+        mock_run_post_install.assert_called_once_with(manifest, site_packages)
+
+        mock_add_to_hub_init.assert_called_once_with(manifest, site_packages)
 
 
 class TestPipProcess:


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/guardrails-ai/guardrails/issues/677) and adds a quiet option when installing a validator from guardrails hub. With this change, we can install validators in quiet mode using this command: 

```guardrails hub install hub://guardrails/detect_pii --quiet```

