### PR TITLE
Fix: Small typo fixes for 'gudardrails' and for variable replacement.

### DIFF
--- a/docs-graveyard/getting_started.md
+++ b/docs-graveyard/getting_started.md
@@ -17,7 +17,7 @@ pip install guardrails-ai
 2. Install a guardrail from Guardrails Hub.
 
     ```bash
-    gudardrails hub install hub://guardrails/regex_match
+    guardrails hub install hub://guardrails/regex_match
     ```
 3. Create a Guard from the installed guardrail.
 
@@ -27,7 +27,7 @@ pip install guardrails-ai
     from guardrails import Guard
 
     # Initialize the Guard with 
-    val = Guard().use(
+    guard = Guard().use(
         RegexMatch(regex="^[A-Z][a-z]*$")
     )
 

--- a/docs/guardrails_ai/getting_started.md
+++ b/docs/guardrails_ai/getting_started.md
@@ -27,7 +27,7 @@ pip install guardrails-ai
     from guardrails import Guard
 
     # Initialize the Guard with 
-    val = Guard().use(
+    guard = Guard().use(
         RegexMatch(regex="^[A-Z][a-z]*$")
     )
 

--- a/docs/hub/how_to_guides/input_validation.md
+++ b/docs/hub/how_to_guides/input_validation.md
@@ -5,7 +5,7 @@ Validators that are tagged as input validators can be used to validate the input
 In order to use an input validator, first make sure that the validator is installed. You can install the validator using the `guardrails hub install` command. For example, to install the `two-words` validator, you can run:
 
 ```bash
-gudardrails hub install hub://guardrails/detect_pii
+guardrails hub install hub://guardrails/detect_pii
 ```
 
 Then, add the input validator to the `Guard` object using the `with_prompt_validation` method. For example, to use the `detect_pii` validator with OpenAI's GPT-3, you can run:


### PR DESCRIPTION
Very minor typo fixes in the documentation. 'gudardrails' -> 'guardrails'. Replace mis-assigned variable 'val' with 'guard'.