### PR TITLE
Prompt Primitive Pre-Migration

### DIFF
--- a/guardrails/constants.xml
+++ b/guardrails/constants.xml
@@ -133,4 +133,110 @@ Here are examples of simple (XML, JSON) pairs that show the expected behavior:
 - `<![CDATA[<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>]]>` => `{'baz': {'foo': 'Some String', 'index': 1}}`
 </high_level_json_instructions>
 
+<xml_suffix_prompt>
+Return a valid JSON object that respects this XML format and extracts only the information requested in this document. Respect the types indicated in the XML -- the information you extract should be converted into the correct 'type'. Try to be as correct and concise as possible. Find all relevant information in the document. If you are unsure of the answer, enter 'None'. If you answer incorrectly, you will be asked again until you get it right which is expensive.
+</xml_suffix_prompt>
+
+
+<xml_suffix_prompt_v2>
+ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter "None".
+</xml_suffix_prompt_v2>
+
+
+<xml_suffix_prompt_v2_wo_none>
+ONLY return a valid JSON object (no other text is necessary). The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise.
+</xml_suffix_prompt_v2_wo_none>
+
+<high_level_xml_reask_prompt>
+I was given the following JSON response, which had problems due to incorrect values.
+
+${previous_response}
+
+Help me correct the incorrect values based on the given error messages.
+</high_level_xml_reask_prompt>
+
+
+<high_level_xml_parsing_reask_prompt>
+I was given the following response, which was not parseable as JSON.
+
+${previous_response}
+
+Help me correct this by making it valid JSON.
+</high_level_xml_parsing_reask_prompt>
+
+<xml_suffix_without_examples>
+Given below is XML that describes the information to extract from this document and the tags to extract it into.
+
+${output_schema}
+
+ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `null`.
+</xml_suffix_without_examples>
+
+<xml_suffix_with_structure_example>
+${gr.xml_suffix_without_examples}
+Here's an example of the structure:
+${xml_example}
+</xml_suffix_with_structure_example>
+
+<complete_xml_suffix>
+Given below is XML that describes the information to extract from this document and the tags to extract it into.
+
+${output_schema}
+
+ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `null`.
+
+Here are examples of simple (XML, JSON) pairs that show the expected behavior:
+- `<![CDATA[<string name='foo' format='two-words lower-case' />`]]> => `{'foo': 'example one'}`
+- `<![CDATA[<list name='bar'><string format='upper-case' /></list>]]>` => `{"bar": ['STRING ONE', 'STRING TWO', etc.]}`
+- `<![CDATA[<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>]]>` => `{'baz': {'foo': 'Some String', 'index': 1}}`
+</complete_xml_suffix>
+
+<complete_xml_suffix_v2>
+Given below is XML that describes the information to extract from this document and the tags to extract it into.
+
+${output_schema}
+
+ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise.
+
+Here are examples of simple (XML, JSON) pairs that show the expected behavior:
+- `<![CDATA[<string name='foo' format='two-words lower-case' />`]]> => `{'foo': 'example one'}`
+- `<![CDATA[<list name='bar'><string format='upper-case' /></list>]]>` => `{"bar": ['STRING ONE', 'STRING TWO', etc.]}`
+- `<![CDATA[<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>]]>` => `{'baz': {'foo': 'Some String', 'index': 1}}`
+</complete_xml_suffix_v2>
+
+
+<complete_xml_suffix_v3>
+Given below is XML that describes the information to extract from this document and the tags to extract it into.
+
+${output_schema}
+
+ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, try your best guess.
+
+Here are examples of simple (XML, JSON) pairs that show the expected behavior:
+- `<![CDATA[<string name='foo' format='two-words lower-case' />`]]> => `{'foo': 'example one'}`
+- `<![CDATA[<list name='bar'><string format='upper-case' /></list>]]>` => `{"bar": ['STRING ONE', 'STRING TWO', etc.]}`
+- `<![CDATA[<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>]]>` => `{'baz': {'foo': 'Some String', 'index': 1}}`
+</complete_xml_suffix_v3>
+
+
+<xml_suffix_prompt_examples>
+ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `null`.
+
+Here are examples of simple (XML, JSON) pairs that show the expected behavior:
+- `<![CDATA[<string name='foo' format='two-words lower-case' />`]]> => `{'foo': 'example one'}`
+- `<![CDATA[<list name='bar'><string format='upper-case' /></list>]]>` => `{"bar": ['STRING ONE', 'STRING TWO', etc.]}`
+- `<![CDATA[<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>]]>` => `{'baz': {'foo': 'Some String', 'index': 1}}`
+</xml_suffix_prompt_examples>
+
+<high_level_xml_instructions>
+You are a helpful assistant only capable of communicating with valid JSON, and no other text.
+
+ONLY return a valid JSON object (no other text is necessary), where the key of the field in JSON is the `name` attribute of the corresponding XML, and the value is of the type specified by the corresponding XML's tag. The JSON MUST conform to the XML format, including any types and format requests e.g. requests for lists, objects and specific types. Be correct and concise. If you are unsure anywhere, enter `null`.
+
+Here are examples of simple (XML, JSON) pairs that show the expected behavior:
+- `<![CDATA[<string name='foo' format='two-words lower-case' />`]]> => `{'foo': 'example one'}`
+- `<![CDATA[<list name='bar'><string format='upper-case' /></list>]]>` => `{"bar": ['STRING ONE', 'STRING TWO', etc.]}`
+- `<![CDATA[<object name='baz'><string name="foo" format="capitalize two-words" /><integer name="index" format="1-indexed" /></object>]]>` => `{'baz': {'foo': 'Some String', 'index': 1}}`
+</high_level_xml_instructions>
+
 </constants>

--- a/guardrails/prompt/base_prompt.py
+++ b/guardrails/prompt/base_prompt.py
@@ -5,7 +5,7 @@ from string import Template
 from typing import Optional
 
 import regex
-
+from warnings import warn
 from guardrails.namespace_template import NamespaceTemplate
 from guardrails.utils.constants import constants
 from guardrails.utils.parsing_utils import get_template_variables
@@ -53,6 +53,21 @@ class BasePrompt:
 
         # Substitute all occurrences of ${gr.<constant_name>}
         #   with the value of the constant.
+        json_constants = [m for m in matches if "json_" in m]
+        if len(json_constants) > 0:
+            first_const: str = json_constants[0]
+            warn(
+                Template(
+                    "Prompt Primitives are moving! "
+                    "To keep the same behaviour, "
+                    "switch from `json` constants to `xml` constants. "
+                    "Example: ${gr.${first_const}} -> ${gr.${xml_const}}",
+                ).safe_substitute(
+                    first_const=first_const,
+                    xml_const=first_const.replace("json_", "xml_"),
+                ),
+                FutureWarning,
+            )
         for match in matches:
             template = NamespaceTemplate(text)
             mapping = {f"gr.{match}": constants[match]}


### PR DESCRIPTION
In preparation for 0.5.x, this PR includes the following:

- Adds xml constants that duplicate existing `json_*` constants for prompt primitives
- Adds warning about constant migration and how to retain same behaviour with example specific to the constants the user specifies in a prompt.