### PR TITLE
Fix: `validated_output, *rest = guard()` is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ prompt = """
 """
 guard = Guard.from_pydantic(output_class=Pet, prompt=prompt)
 
-validated_output, *rest = guard(
+raw_output, validated_output, *rest = guard(
     llm_api=openai.completions.create,
     engine="gpt-3.5-turbo-instruct"
 )

--- a/docs/guardrails_ai/getting_started.md
+++ b/docs/guardrails_ai/getting_started.md
@@ -86,7 +86,7 @@ prompt = """
 """
 guard = Guard.from_pydantic(output_class=Pet, prompt=prompt)
 
-validated_output, *rest = guard(
+raw_output, validated_output, *rest = guard(
     llm_api=openai.chat.completions.create,
     engine="gpt-3.5-turbo"
 )


### PR DESCRIPTION
Fix pain point: "[docs] the return type of a Guard is very unclear".  Some places in documentation listed the output of the guard as a tuple rather than a triplet, which can be pretty confusing because it means the raw_text from the model is assigned to "validated_output".  Footgun.