### PR TITLE
pyproject.toml: add homepage and documentation links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.4.5"
 description = "Adding guardrails to large language models."
 authors = ["Guardrails AI <contact@guardrailsai.com>"]
 license = "Apache License 2.0"
+homepage = "https://www.guardrailsai.com/"
+documentation = "https://www.guardrailsai.com/docs"
 readme = "README.md"
 packages = [
     { include = "guardrails", from = "." }


### PR DESCRIPTION
I have added the Homepage and Documentation links as they are not currently available when using the command 

```pip show guardrailsai```

Current Ouput

```
Name: guardrails-ai
Version: 0.4.5
Summary: Adding guardrails to large language models.
Home-page: 
Author: Guardrails AI
Author-email: contact@guardrailsai.com
License: Apache-2.0
Location: /.../python3.10/site-packages
Requires: coloredlogs, griffe, guardrails-api-client, jwt, langchain-core, lxml, nltk, openai, opentelemetry-exporter-otlp-proto-grpc, opentelemetry-exporter-otlp-proto-http, opentelemetry-sdk, pip, pydantic, pydash, python-dateutil, regex, requests, rich, rstr, tenacity, tiktoken, typer, typing-extensions
Required-by: 
```