### PR TITLE
Make JSONFormer a dependency of transformers.  Add 'make update-lock'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,7 @@ refresh:
 	python3 -m venv ./.venv;
 	echo "Sourcing and installing"
 	source ./.venv/bin/activate && make full;
+
+update-lock:
+	poetry lock --no-update
+

--- a/guardrails/formatters/__init__.py
+++ b/guardrails/formatters/__init__.py
@@ -1,11 +1,16 @@
 from guardrails.formatters.base_formatter import BaseFormatter, PassthroughFormatter
-from guardrails.formatters.json_formatter import JsonFormatter
+try:
+    from guardrails.formatters.json_formatter import JsonFormatter
+except ImportError:
+    JsonFormatter = None
 
 
 def get_formatter(name: str, *args, **kwargs) -> BaseFormatter:
     """Returns a class."""
     name = name.lower()
     if name == "jsonformer":
+        if JsonFormatter is None:
+            raise ValueError(f"jsonformatter requires transformers to be installed.")
         return JsonFormatter(*args, **kwargs)
     elif name == "none":
         return PassthroughFormatter(*args, **kwargs)

--- a/guardrails/formatters/__init__.py
+++ b/guardrails/formatters/__init__.py
@@ -1,4 +1,5 @@
 from guardrails.formatters.base_formatter import BaseFormatter, PassthroughFormatter
+
 try:
     from guardrails.formatters.json_formatter import JsonFormatter
 except ImportError:
@@ -10,7 +11,7 @@ def get_formatter(name: str, *args, **kwargs) -> BaseFormatter:
     name = name.lower()
     if name == "jsonformer":
         if JsonFormatter is None:
-            raise ValueError(f"jsonformatter requires transformers to be installed.")
+            raise ValueError("jsonformatter requires transformers to be installed.")
         return JsonFormatter(*args, **kwargs)
     elif name == "none":
         return PassthroughFormatter(*args, **kwargs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2044,7 +2044,7 @@ files = [
 name = "jsonformer"
 version = "0.12.0"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.8,<4.0"
 files = [
     {file = "jsonformer-0.12.0-py3-none-any.whl", hash = "sha256:67339a764cb17e33d9a567293470f59b856ca38f2c456da6aad07652a2daf69a"},
@@ -5827,7 +5827,7 @@ test = ["pytest", "tornado (>=4.5)", "typeguard"]
 name = "termcolor"
 version = "2.4.0"
 description = "ANSI color formatting for output in terminal"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "termcolor-2.4.0-py3-none-any.whl", hash = "sha256:9297c0df9c99445c2412e832e882a7884038a25617c60cea2ad69488d4040d63"},
@@ -6872,7 +6872,7 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [extras]
 anthropic = ["anthropic"]
 docs-build = ["docspec_python", "nbdoc", "pydoc-markdown"]
-huggingface = ["torch", "transformers"]
+huggingface = ["jsonformer", "torch", "transformers"]
 litellm = ["litellm"]
 manifest = ["manifest-ml"]
 sql = ["sqlalchemy", "sqlglot", "sqlvalidator"]
@@ -6881,4 +6881,4 @@ vectordb = ["faiss-cpu", "numpy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4e19eee5a58f8590a27f4f7b6a67308079299fdf279732dfaf0724b58c9b48d1"
+content-hash = "78c2c1087b57fdef24163ed7bb78b3b8098f19a46efe369c3408b28cc550f823"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ typing-extensions = "^4.8.0"
 python-dateutil = "^2.8.2"
 tiktoken = ">=0.5.1"
 nltk = "^3.8.1"
-jsonformer = "0.12.0"
 
 sqlvalidator = {version = "^0.0.20", optional = true}
 sqlalchemy = {version = ">=2.0.9", optional = true}
@@ -50,6 +49,7 @@ coloredlogs = "^15.0.1"
 requests = "^2.31.0"
 faker = "^25.2.0"
 jsonref = "^1.1.0"
+jsonformer = {version = "0.12.0", optional = true}
 jsonschema = {version = "^4.22.0", extras = ["format"]}
 jwt = "^1.3.1"
 pip = ">=22"
@@ -65,7 +65,7 @@ manifest = ["manifest-ml"]
 litellm = ["litellm"]
 anthropic = ["anthropic"]
 docs-build = ["nbdoc", "docspec_python", "pydoc-markdown"]
-huggingface = ["transformers", "torch"]
+huggingface = ["transformers", "torch", "jsonformer"]
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
JSONFormer has transformers as a sibling dependency.  Make a child dependency of transformers in the poetry lock so that we only get the functionality if we need it.  This also fixes all notebook runs.