### PR TITLE
Resolved - Error in Guard validation code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ pip install guardrails-ai
 
     guard = Guard().use_many(
         CompetitorCheck(["Apple", "Microsoft", "Google"], on_fail=OnFailAction.EXCEPTION),
-        ToxicLanguage(threshold=0.5, validation_method="sentence", on_fail=OnFailAction.EXCEPTION),),
+        ToxicLanguage(threshold=0.5, validation_method="sentence", on_fail=OnFailAction.EXCEPTION)
     )
 
     guard.validate(


### PR DESCRIPTION
I've encountered an issue with the code example provided for using Guard with CompetitorCheck and ToxicLanguage.  The issue is related to the syntax and the use of the use_many method in the Guard class.

Issue Details:
Syntax Error: There is a trailing comma in the use_many method call which leads to a syntax error.

Suggested Solution:
Remove the trailing comma.