### PR TITLE
Bugfix: Sidestep MacOS Segfault in OpenMP.

### DIFF
--- a/tests/unit_tests/mocks/mock_hf_models.py
+++ b/tests/unit_tests/mocks/mock_hf_models.py
@@ -4,6 +4,7 @@ import os
 def make_mock_model_and_tokenizer():
     """Returns a tuple of HF AutoModelForCausalLM and AutoTokenizer."""
     import torch
+
     torch.set_num_threads(1)
 
     from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/tests/unit_tests/mocks/mock_hf_models.py
+++ b/tests/unit_tests/mocks/mock_hf_models.py
@@ -3,6 +3,9 @@ import os
 
 def make_mock_model_and_tokenizer():
     """Returns a tuple of HF AutoModelForCausalLM and AutoTokenizer."""
+    import torch
+    torch.set_num_threads(1)
+
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
     # Can regenerate the sample pipe with this:
@@ -15,9 +18,15 @@ def make_mock_model_and_tokenizer():
         os.path.abspath(os.path.normpath(os.path.dirname(__file__))), "tiny-random-gpt2"
     )
 
-    model = AutoModelForCausalLM.from_pretrained(savedir, local_files_only=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        savedir,
+        local_files_only=True,
+    )
 
-    tokenizer = AutoTokenizer.from_pretrained(savedir, local_files_only=True)
+    tokenizer = AutoTokenizer.from_pretrained(
+        savedir,
+        local_files_only=True,
+    )
 
     return model, tokenizer
 


### PR DESCRIPTION
In short, HuggingFace (or, Torch, really) is running into an invalid access fault in OpenMP when allocating space for a buffer.

```
frame #0: 0x000000031fe6992c libomp.dylib`void __kmp_suspend_64<false, true>(int, kmp_flag_64<false, true>*) + 48
libomp.dylib`__kmp_suspend_64<false, true>:
```

To sidestep this issue we can force the thread count to 1 inside the tests.