### PR TITLE
Feature: `create` command

### DIFF
--- a/guardrails/cli/__init__.py
+++ b/guardrails/cli/__init__.py
@@ -1,6 +1,7 @@
 import guardrails.cli.configure  # noqa
 import guardrails.cli.start  # noqa
 import guardrails.cli.validate  # noqa
+from guardrails.cli.create import create_command
 from guardrails.cli.guardrails import guardrails as cli
 from guardrails.cli.hub import hub_command
 from guardrails.cli.watch import watch_command  # noqa: F401

--- a/guardrails/cli/__init__.py
+++ b/guardrails/cli/__init__.py
@@ -1,7 +1,7 @@
 import guardrails.cli.configure  # noqa
 import guardrails.cli.start  # noqa
 import guardrails.cli.validate  # noqa
-from guardrails.cli.create import create_command
+from guardrails.cli.create import create_command  # noqa: F401
 from guardrails.cli.guardrails import guardrails as cli
 from guardrails.cli.hub import hub_command
 from guardrails.cli.watch import watch_command  # noqa: F401

--- a/guardrails/cli/create.py
+++ b/guardrails/cli/create.py
@@ -1,0 +1,104 @@
+import importlib
+#import pkgutil
+import inspect
+import subprocess
+from typing import Optional
+
+import rich
+import typer
+
+from guardrails.cli.guardrails import guardrails as gr_cli
+
+
+template = """
+from guardrails import Guard
+from guardrails.hub import (
+    DetectPII,
+    CompetitorCheck
+)
+
+
+input_guards = Guard()
+
+output_guards = Guard()
+output_guards.name = "Output Guard"
+output_guards.use_many(
+    DetectPII(
+        pii_entities='pii'
+    ),
+    CompetitorCheck(
+        competitors=['OpenAI', 'Anthropic']
+    )
+)
+"""
+
+
+@gr_cli.command(name="create")
+def create_command(
+    validators: str = typer.Option(
+        help="A comma-separated list of validator hub URIs. ",
+    ),
+    name: Optional[str] = typer.Option(
+        default=None,
+        help="The name of the guard to define in the file."
+    ),
+    filepath: str = typer.Option(
+        default="config.py",
+        help="The path to which the configuration file should be saved."
+    ),
+    dry_run: bool = typer.Option(
+        default=False,
+        is_flag=True,
+        help="Print out the validators to be installed without making any changes."
+    )
+):
+    installed_validators = split_and_process_validators(validators, dry_run)
+    new_config_file = generate_config_file(installed_validators, name)
+    if dry_run:
+        rich.print(f"Not actually saving output to {filepath}")
+        rich.print(f"The following would have been written:\n{new_config_file}")
+    else:
+        with open(filepath, 'wt') as fout:
+            fout.write(new_config_file)
+        rich.print(f"Saved configuration to {filepath}")
+
+
+def split_and_process_validators(validators: str, dry_run: bool = False):
+    """Given a comma-separated list of validators, check the hub to make sure all of
+    them exist, then install each one via pip.  """
+    # Quick sanity check after split:
+    validators = validators.split(",")
+    checked_validators = list()
+    for v in validators:
+        if not v.strip().startswith("hub://"):
+            rich.print(f"WARNING: Validator {v} does not appear to be a valid URI.")
+        checked_validators.append(v.strip())
+    validators = checked_validators
+
+    # We should make sure they exist.
+    for v in validators:
+        rich.print(f"Installing {v}")
+        try:
+            if not dry_run:
+                # TODO: When we have the programmatic hub install tool, switch to that.
+                subprocess.run(
+                    ["guardrails", "hub", "install", v],
+                    capture_output=True,
+                    check=True
+                )
+        except subprocess.CalledProcessError as cpe:
+            rich.print(f"ERROR: Failed to install guard {v}.{cpe.stdout}\n{cpe.stderr}")
+            raise cpe
+
+    # Pull the hub information from each of the installed validators and return it.
+    return [v for v in validators]
+
+
+def generate_config_file(validators: str, name: Optional[str] = None) -> str:
+    return "asdf"
+
+
+def _reload_hub():
+    import guardrails.hub
+    importlib.invalidate_caches()
+    return importlib.reload(guardrails.hub)

--- a/guardrails/cli/create.py
+++ b/guardrails/cli/create.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import time
-from glob import glob
 from typing import List, Optional, Union
 
 import typer
@@ -29,10 +28,9 @@ def create_command(
     name: Optional[str] = typer.Option(
         default=None, help="The name of the guard to define in the file."
     ),
-    filepath: Optional[str] = typer.Option(
-        default=None,
-        help="The path to which the configuration file should be saved. Defaults to "
-        "config.py, but will use config-X.py if a config.py file already exists.",
+    filepath: str = typer.Option(
+        default="config.py",
+        help="The path to which the configuration file should be saved.",
     ),
     dry_run: bool = typer.Option(
         default=False,
@@ -59,26 +57,18 @@ def create_command(
     )
 
 
-def check_filename(filename: Optional[Union[str, os.PathLike]]) -> str:
-    """If 'filename' is unspecified, defaults to 'config.py', but will autoincrement to
-    config-1.py, config-2.py, etc.  If a filename is specified and already exists, will
-    prompt the user to confirm overwriting."""
-    if filename is None:
-        filename = "config.py"
-        num_config_py_files = len(glob("config*.py"))
-        while os.path.exists(filename):
-            filename = f"config-{num_config_py_files}.py"
-            num_config_py_files += 1
-    else:
-        if os.path.exists(filename):
-            # Alert the user and get confirmation of overwrite.
-            overwrite = typer.confirm(
-                f"The configuration file {filename} already exists. Overwrite?"
-            )
-            if not overwrite:
-                console.print("Aborting")
-                typer.Abort()
-                sys.exit(0)  # Force exit if we fall through.
+def check_filename(filename: Union[str, os.PathLike]) -> str:
+    """If a filename is specified and already exists, will prompt the user to confirm
+    overwriting.  Aborts if the user declines."""
+    if os.path.exists(filename):
+        # Alert the user and get confirmation of overwrite.
+        overwrite = typer.confirm(
+            f"The configuration file {filename} already exists. Overwrite?"
+        )
+        if not overwrite:
+            console.print("Aborting")
+            typer.Abort()
+            sys.exit(0)  # Force exit if we fall through.
     return filename  # type: ignore
 
 

--- a/guardrails/cli/create.py
+++ b/guardrails/cli/create.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 from glob import glob
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import typer
 from rich.console import Console
@@ -79,22 +79,22 @@ def check_filename(filename: Optional[Union[str, os.PathLike]]) -> str:
                 console.print("Aborting")
                 typer.Abort()
                 sys.exit(0)  # Force exit if we fall through.
-    return filename
+    return filename  # type: ignore
 
 
 def split_and_install_validators(validators: str, dry_run: bool = False):
     """Given a comma-separated list of validators, check the hub to make sure all of
     them exist, install them, and return a list of 'imports'."""
-    # Quick sanity check after split:
-    validators = validators.split(",")
     stripped_validators = list()
     manifests = list()
     site_packages = get_site_packages_location()
 
+    # Split by comma, strip start and end spaces, then make sure there's a hub prefix.
+    # If all that passes, download the manifest file so we know where to install.
     # hub://blah -> blah, then download the manifest.
     console.print("Checking validators...")
     with console.status("Checking validator manifests") as status:
-        for v in validators:
+        for v in validators.split(","):
             status.update(f"Prefetching {v}")
             if not v.strip().startswith("hub://"):
                 console.print(
@@ -124,7 +124,7 @@ def split_and_install_validators(validators: str, dry_run: bool = False):
     return [manifest.exports[0] for manifest in manifests]
 
 
-def generate_config_file(validators: str, name: Optional[str] = None) -> str:
+def generate_config_file(validators: List[str], name: Optional[str] = None) -> str:
     console.print("Generating config file...")
     config_lines = [
         "from guardrails import Guard",


### PR DESCRIPTION
Adds a command to create the guardrails config file.

Per specification: 
- Defaults to config.py and will prompt on overwrite.
- Fills installed guards with TODO for parameters and notifies user.

Departures from specification:
- It was nice to have `--dry-run` as an option to see what would be created and written.  This will not save a config file but will sanity check that the validators exist and will print the config file to the console.

Examples:

Simple Happy Path:

```
% guardrails create --validators hub://guardrails/valid_length,hub://guardrails/lowercase
Checking validators...
Success!
Installing...
Success!
Generating config file...
Saved configuration to config.py
Replace TODOs in config.py and run with `guardrails start --config config.py`

% cat config.py
from guardrails import Guard
from guardrails.hub import (
        ValidLength,
        LowerCase
)
guard = Guard()
guard.use_many(
        ValidLength( TODO Fill these parameters ),
        LowerCase( TODO Fill these parameters )
)
```

Dry Run:
```
% guardrails create --validators hub://guardrails/detect_pii --dry-run
Checking validators...
Success!
Installing...
Fake installing guardrails/detect_pii
Success!
Generating config file...
Not actually saving output to config.py
The following would have been written:

from guardrails import Guard
from guardrails.hub import DetectPII
guard = Guard()
guard.use(DetectPII( TODO Fill these parameters ))
```