### PR TITLE
Add none checks

### DIFF
--- a/guardrails/run/async_runner.py
+++ b/guardrails/run/async_runner.py
@@ -179,7 +179,7 @@ class AsyncRunner(Runner):
 
         try:
             # Prepare: run pre-processing, and input validation.
-            if output:
+            if output is not None:
                 instructions = None
                 prompt = None
                 msg_history = None

--- a/guardrails/run/async_stream_runner.py
+++ b/guardrails/run/async_stream_runner.py
@@ -161,7 +161,7 @@ class AsyncStreamRunner(StreamRunner):
         outputs = Outputs()
         iteration = Iteration(inputs=inputs, outputs=outputs)
         call_log.iterations.push(iteration)
-        if output:
+        if output is not None:
             instructions = None
             prompt = None
             msg_history = None

--- a/guardrails/run/runner.py
+++ b/guardrails/run/runner.py
@@ -238,7 +238,7 @@ class Runner:
 
         try:
             # Prepare: run pre-processing, and input validation.
-            if output:
+            if output is not None:
                 instructions = None
                 prompt = None
                 msg_history = None

--- a/guardrails/run/stream_runner.py
+++ b/guardrails/run/stream_runner.py
@@ -116,7 +116,7 @@ class StreamRunner(Runner):
         call_log.iterations.push(iteration)
 
         # Prepare: run pre-processing, and input validation.
-        if output:
+        if output is not None:
             instructions = None
             prompt = None
             msg_history = None


### PR DESCRIPTION
Using falsy checks instead of None checks against output is vulnerable to cases where output is an empty string.