### PR TITLE
Bug: Bandaid null validation result.

### DIFF
--- a/guardrails/classes/validation/validator_logs.py
+++ b/guardrails/classes/validation/validator_logs.py
@@ -40,16 +40,22 @@ class ValidatorLogs(IValidatorLog, ArbitraryModel):
     def to_interface(self) -> IValidatorLog:
         start_time = self.start_time.isoformat() if self.start_time else None
         end_time = self.end_time.isoformat() if self.end_time else None
+        validation_result = (
+            ValidatorLogValidationResult(self.validation_result)
+            if self.validation_result
+            else None
+        )
+        # pyright doesn't understand aliases so all type aliases are ignored.
         return IValidatorLog(
-            validator_name=self.validator_name,  # type: ignore - pyright doesn't understand aliases
-            registered_name=self.registered_name,  # type: ignore - pyright doesn't understand aliases
-            instance_id=ValidatorLogInstanceId(self.instance_id),  # type: ignore - pyright doesn't understand aliases
-            property_path=self.property_path,  # type: ignore - pyright doesn't understand aliases
-            value_before_validation=self.value_before_validation,  # type: ignore - pyright doesn't understand aliases
-            value_after_validation=self.value_after_validation,  # type: ignore - pyright doesn't understand aliases
-            validation_result=ValidatorLogValidationResult(self.validation_result),  # type: ignore - pyright doesn't understand aliases
-            start_time=start_time,  # type: ignore - pyright doesn't understand aliases
-            end_time=end_time,  # type: ignore - pyright doesn't understand aliases
+            validator_name=self.validator_name,  # type: ignore
+            registered_name=self.registered_name,  # type: ignore
+            instance_id=ValidatorLogInstanceId(self.instance_id),  # type: ignore
+            property_path=self.property_path,  # type: ignore
+            value_before_validation=self.value_before_validation,  # type: ignore
+            value_after_validation=self.value_after_validation,  # type: ignore
+            validation_result=validation_result,  # type: ignore
+            start_time=start_time,  # type: ignore
+            end_time=end_time,  # type: ignore
         )
 
     def to_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
Not a real fix as far as I'm concerned, but perhaps the only one we can get.

Before:

```bash
% opentelemetry-instrument gunicorn --bind 0.0.0.0:8000 --timeout=30 --threads=2 --workers=2 'guardrails_api.app:create_app("sample.env", "sample_config.py")'
% ab -p ab-post-body.txt -T application/json -s 120 -c 2 -n 100 http://127.0.0.1:8000/guards/name-case/validate
Benchmarking 127.0.0.1 (be patient).....done

Server Software:        gunicorn
Server Hostname:        127.0.0.1
Server Port:            8000

Document Path:          /guards/name-case/validate
Document Length:        103 bytes

Concurrency Level:      2
Time taken for tests:   1.981 seconds
Complete requests:      100
Failed requests:        12
   (Connect: 0, Receive: 0, Length: 12, Exceptions: 0)
Non-2xx responses:      12
```

After:

```bash
opentelemetry-instrument gunicorn --bind 0.0.0.0:8000 --timeout=30 --workers=2 --threads=2 'guardrails_api.app:create_app("sample.env", "sample_config.py")'
% ab -p ab-post-body.txt -T application/json -s 120 -c 2 -n 100 http://127.0.0.1:8000/guards/name-case/validate
Benchmarking 127.0.0.1 (be patient).....done

Server Software:        gunicorn
Server Hostname:        127.0.0.1
Server Port:            8000

Document Path:          /guards/name-case/validate
Document Length:        103 bytes

Concurrency Level:      2
Time taken for tests:   1.970 seconds
Complete requests:      100
Failed requests:        0
```

## Way Too Much Information:

When running concurrently with multiple threads in guardrails-api, there seems to be a concurrent modification of history across two threads.  Evidence: Some of the validation_outputs are becoming None between steps of the stack trace.  This scales linearly with the number of threads.  The same behavior for the same code does not appear if num-threads is set to 1 and the number of workers is increased.  (`gunicorn --bind 0.0.0.0:8000 --timeout=30 --workers=2 --threads=1 'guardrails_api.app:create_app("sample.env", "sample_config.py")'`)  

## A Better Option:

Since we want Guards to be able to be used seamlessly across threads, we should make it possible to modify history and use it in a way that's thread-safe.  We could do this by protecting the history object with a mutex or some other kind of thread-safe structure.  Unfortunately, the base class is autogenerated and while it's possible that the modification to the subclass will remain compatible, if another type of Guard decides to inherit the interface guard instead of our base guard then we might end up in a place with really troublesome and subtle errors.  (Also, we don't want to have to worry about the ordering of the parent classes, though it does potentially make our lives easier: https://docs.python.org/3/tutorial/classes.html#multiple-inheritance)