### PR TITLE
patches on message support on top of history

### DIFF
--- a/guardrails/async_guard.py
+++ b/guardrails/async_guard.py
@@ -458,7 +458,7 @@ class AsyncGuard(Guard, Generic[OT]):
 
         instructions = instructions or self._exec_opts.instructions
         prompt = prompt or self._exec_opts.prompt
-        msg_history = msg_history or []
+        msg_history = msg_history or kwargs.pop("messages", None) or []
         if prompt is None:
             if msg_history is not None and not len(msg_history):
                 raise RuntimeError(

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -867,7 +867,7 @@ class Guard(IGuard, Generic[OT]):
         """
         instructions = instructions or self._exec_opts.instructions
         prompt = prompt or self._exec_opts.prompt
-        msg_history = msg_history or kwargs.get("messages") or []
+        msg_history = msg_history or kwargs.get("messages", None) or []
         if prompt is None:
             if msg_history is not None and not len(msg_history):
                 raise RuntimeError(
@@ -964,6 +964,7 @@ class Guard(IGuard, Generic[OT]):
             "output",
             "prompt",
             "instructions",
+            "messages",
             "msg_history",
         ] and not on.startswith("$"):
             warnings.warn(

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -964,7 +964,6 @@ class Guard(IGuard, Generic[OT]):
             "output",
             "prompt",
             "instructions",
-            "messages",
             "msg_history",
         ] and not on.startswith("$"):
             warnings.warn(
@@ -1015,6 +1014,8 @@ class Guard(IGuard, Generic[OT]):
             on: The part of the LLM request to validate. Defaults to "output".
         """
         hydrated_validator = get_validator(validator, *args, **kwargs)
+        if on == "messages":
+            on = "msg_history"
         self.__add_validator(hydrated_validator, on=on)
         self._save()
         return self
@@ -1036,6 +1037,8 @@ class Guard(IGuard, Generic[OT]):
     ) -> "Guard":
         """Use multiple validators to validate results of an LLM request."""
         # Loop through the validators
+        if on == "messages":
+            on = "msg_history"
         for v in validators:
             hydrated_validator = get_validator(v)
             self.__add_validator(hydrated_validator, on=on)

--- a/guardrails/run/async_runner.py
+++ b/guardrails/run/async_runner.py
@@ -267,7 +267,6 @@ class AsyncRunner(Runner):
             supports_base_model = getattr(api, "supports_base_model", False)
             if supports_base_model:
                 api_fn = partial(api, base_model=self.base_model)
-
         if output is not None:
             llm_response = LLMResponse(
                 output=output,

--- a/guardrails/run/runner.py
+++ b/guardrails/run/runner.py
@@ -382,7 +382,7 @@ class Runner:
             formatted_msg_history.append(msg_copy)
 
         # validate msg_history
-        if "msg_history" in self.validation_map or "messages" in self.validation_map:
+        if "msg_history" in self.validation_map:
             self.validate_msg_history(call_log, formatted_msg_history, attempt_number)
 
         return formatted_msg_history

--- a/guardrails/run/runner.py
+++ b/guardrails/run/runner.py
@@ -382,7 +382,7 @@ class Runner:
             formatted_msg_history.append(msg_copy)
 
         # validate msg_history
-        if "msg_history" in self.validation_map:
+        if "msg_history" in self.validation_map or "messages" in self.validation_map:
             self.validate_msg_history(call_log, formatted_msg_history, attempt_number)
 
         return formatted_msg_history

--- a/tests/unit_tests/test_validator_base.py
+++ b/tests/unit_tests/test_validator_base.py
@@ -758,6 +758,24 @@ async def test_input_validation_fail_async(
     assert isinstance(guard.history.last.exception, ValidationError)
     assert guard.history.last.exception == excinfo.value
 
+    # with_messages_validation
+    guard = AsyncGuard.from_pydantic(output_class=Pet)
+    guard.use(TwoWords(on_fail=on_fail), on="messages")
+
+    with pytest.raises(ValidationError) as excinfo:
+        await guard(
+            custom_llm,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "What kind of pet should I get?",
+                }
+            ],
+        )
+    assert str(excinfo.value) == structured_message_history_error
+    assert isinstance(guard.history.last.exception, ValidationError)
+    assert guard.history.last.exception == excinfo.value
+
     # rail prompt validation
     guard = AsyncGuard.from_rail_string(
         f"""


### PR DESCRIPTION
short circuits on="messages" to on="msg_history" to add use and use many support for the 6x interface

to test
```
from pydantic import BaseModel, Field
from guardrails.async_guard import AsyncGuard

class Pet(BaseModel):
    name: str = Field(description="a unique pet name")

def custom_llm(*args, **kwargs):
    raise Exception(
        "LLM was called when it should not have been!"
        "Input Validation did not raise as expected!"
    )

guard = AsyncGuard.from_pydantic(output_class=Pet)
guard.use(TwoWords(on_fail=on_fail), on="messages")
    await guard(
        custom_llm,
        messages=[
            {
                "role": "user",
                "content": "What kind of pet should I get?",
            }
        ],
    )
```

should raise a validation error