### PR TITLE
Explicit file encoding to utf-8 for configuration file

### DIFF
--- a/guardrails/classes/credentials.py
+++ b/guardrails/classes/credentials.py
@@ -30,7 +30,7 @@ class Credentials(Serializeable):
                 logger = logging.getLogger()
             home = expanduser("~")
             guardrails_rc = os.path.join(home, ".guardrailsrc")
-            with open(guardrails_rc) as rc_file:
+            with open(guardrails_rc, encoding="utf-8") as rc_file:
                 lines = rc_file.readlines()
                 filtered_lines = list(filter(lambda l: l.strip(), lines))
                 creds = {}

--- a/guardrails/cli/configure.py
+++ b/guardrails/cli/configure.py
@@ -32,7 +32,7 @@ def save_configuration_file(
 
     home = expanduser("~")
     guardrails_rc = os.path.join(home, ".guardrailsrc")
-    with open(guardrails_rc, "w") as rc_file:
+    with open(guardrails_rc, "w", encoding="utf-8") as rc_file:
         lines = [
             f"id={str(uuid.uuid4())}{os.linesep}",
             f"token={token}{os.linesep}",


### PR DESCRIPTION
Updated:
- Saving/Writing `guardrailsrc` with explicit `utf-8` encoding (instead of reverting to system default)

Notes: `PYTHONUTF8=1` also accomplishes this globally 