### PR TITLE
Guardrails Top Level Settings

### DIFF
--- a/guardrails/__init__.py
+++ b/guardrails/__init__.py
@@ -8,6 +8,7 @@ from guardrails.prompt import Instructions, Prompt
 from guardrails.utils import constants, docs_utils
 from guardrails.types.on_fail import OnFailAction
 from guardrails.validator_base import Validator, register_validator
+from guardrails.settings import settings
 
 __all__ = [
     "Guard",
@@ -21,4 +22,5 @@ __all__ = [
     "configure_logging",
     "Prompt",
     "Instructions",
+    "settings",
 ]

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -84,6 +84,7 @@ from guardrails.utils.tools_utils import (
     # Prevent duplicate declaration in the docs
     json_function_calling_tool as json_function_calling_tool_util,
 )
+from guardrails.settings import settings
 
 
 class Guard(IGuard, Generic[OT]):
@@ -186,8 +187,8 @@ class Guard(IGuard, Generic[OT]):
         self._output_formatter: Optional[BaseFormatter] = None
 
         # Gaurdrails As A Service Initialization
-        api_key = os.environ.get("GUARDRAILS_API_KEY")
-        if api_key is not None:
+        if settings.use_server:
+            api_key = os.environ.get("GUARDRAILS_API_KEY")
             self._api_client = GuardrailsApiClient(api_key=api_key)
             _loaded = False
             if _try_to_load:
@@ -272,7 +273,7 @@ class Guard(IGuard, Generic[OT]):
 
     def _fill_validator_map(self):
         # dont init validators if were going to call the server
-        if self._api_client is not None:
+        if settings.use_server:
             return
         for ref in self.validators:
             entry: List[Validator] = self._validator_map.get(ref.on, [])  # type: ignore
@@ -724,7 +725,7 @@ class Guard(IGuard, Generic[OT]):
                 kwargs=kwargs,
             )
 
-            if self._api_client is not None and model_is_supported_server_side(
+            if settings.use_server and model_is_supported_server_side(
                 llm_api, *args, **kwargs
             ):
                 return self._call_server(
@@ -1076,13 +1077,13 @@ class Guard(IGuard, Generic[OT]):
     #     pass
 
     def upsert_guard(self):
-        if self._api_client:
+        if settings.use_server and self._api_client:
             self._api_client.upsert_guard(self)
         else:
-            raise ValueError("Guard does not have an api client!")
+            raise ValueError("Using the Guardrails server is not enabled!")
 
     def _single_server_call(self, *, payload: Dict[str, Any]) -> ValidationOutcome[OT]:
-        if self._api_client:
+        if settings.use_server and self._api_client:
             validation_output: IValidationOutcome = self._api_client.validate(
                 guard=self,  # type: ignore
                 payload=ValidatePayload.from_dict(payload),  # type: ignore
@@ -1126,7 +1127,7 @@ class Guard(IGuard, Generic[OT]):
         *,
         payload: Dict[str, Any],
     ) -> Iterable[ValidationOutcome[OT]]:
-        if self._api_client:
+        if settings.use_server and self._api_client:
             validation_output: Optional[IValidationOutcome] = None
             response = self._api_client.stream_validate(
                 guard=self,  # type: ignore
@@ -1176,7 +1177,7 @@ class Guard(IGuard, Generic[OT]):
         full_schema_reask: Optional[bool] = True,
         **kwargs,
     ) -> Union[ValidationOutcome[OT], Iterable[ValidationOutcome[OT]]]:
-        if self._api_client:
+        if settings.use_server and self._api_client:
             payload: Dict[str, Any] = {
                 "args": list(args),
                 "full_schema_reask": full_schema_reask,
@@ -1216,7 +1217,7 @@ class Guard(IGuard, Generic[OT]):
 
     def _save(self):
         api_key = os.environ.get("GUARDRAILS_API_KEY")
-        if api_key is not None:
+        if settings.use_server:
             if self.name is None:
                 self.name = f"gr-{str(self.id)}"
                 logger.warn("Warning: No name passed to guard!")

--- a/guardrails/settings.py
+++ b/guardrails/settings.py
@@ -1,16 +1,22 @@
-from typing import Self
+import threading
+from typing import Optional, Self
 
 
 class Settings:
     _instance = None
+    _lock = threading.Lock()
+    """Whether to use a local server for running Guardrails."""
+    use_server: Optional[bool]
 
     def __new__(cls) -> Self:
         if cls._instance is None:
-            cls._instance = super(Settings, cls).__new__(cls)
-            cls._instance.initialize()
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super(Settings, cls).__new__(cls)
+                    cls._instance._initialize()
         return cls._instance
 
-    def initialize(self):
+    def _initialize(self):
         self.use_server = None
 
 

--- a/guardrails/settings.py
+++ b/guardrails/settings.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Optional, Self
+from typing import Optional
 
 
 class Settings:
@@ -8,7 +8,7 @@ class Settings:
     """Whether to use a local server for running Guardrails."""
     use_server: Optional[bool]
 
-    def __new__(cls) -> Self:
+    def __new__(cls) -> "Settings":
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:

--- a/guardrails/settings.py
+++ b/guardrails/settings.py
@@ -1,0 +1,17 @@
+from typing import Self
+
+
+class Settings:
+    _instance = None
+
+    def __new__(cls) -> Self:
+        if cls._instance is None:
+            cls._instance = super(Settings, cls).__new__(cls)
+            cls._instance.initialize()
+        return cls._instance
+
+    def initialize(self):
+        self.use_server = None
+
+
+settings = Settings()


### PR DESCRIPTION
Adds a settings singleton to the guardrails package.  Currently only supports one setting `use_server` that allows users to specify when to run guards on the guardrails-api vs on the client.

Tested with the following:
### config.py
```py
from guardrails import Guard
from guardrails.hub import RegexMatch

name_case = Guard(
    name='name-case',
    description='Checks that a string is in Name Case format.'
).use(
    RegexMatch(regex="^[A-Z][a-z\\s]*$")
)
```

### start command
```sh
guardrails start --config=config.py
```

### client side script
```py
import os
import logging
from rich import print
from guardrails import configure_logging
from guardrails import Guard, settings

os.environ["GUARDRAILS_BASE_URL"] = "http://localhost:8000"

print(os.environ.get("GUARDRAILS_API_KEY", "No API key found"))
print(os.environ.get("GUARDRAILS_BASE_URL"))

settings.use_server = True
# settings.use_server = False
configure_logging(None, log_level=logging.DEBUG)


name_case = Guard(name='name-case')


result = name_case.parse(
    llm_output="z-dawg"
)

print("result: ", result)
print("number of validators run: ", len(name_case.history.last.validator_logs))
```