### PR TITLE
[feat] Add --clear option to the guardrails watch command.

### DIFF
--- a/guardrails/call_tracing/sqlite_trace_handler.py
+++ b/guardrails/call_tracing/sqlite_trace_handler.py
@@ -82,6 +82,8 @@ class SQLiteTraceHandler(TracerMixin):
     """
 
     def __init__(self, log_path: os.PathLike, read_mode: bool):
+        # super().__init__(log_path, read_mode)
+        # super(TracerMixin, self).__init__(log_path, read_mode)
         self._log_path = log_path  # Read-only value.
         self.last_cleanup = time.time()
         self.readonly = read_mode
@@ -89,10 +91,6 @@ class SQLiteTraceHandler(TracerMixin):
             self.db = SQLiteTraceHandler._get_read_connection(log_path)
         else:
             self.db = SQLiteTraceHandler._get_write_connection(log_path)
-
-    @property
-    def log_path(self):
-        return self._log_path
 
     @classmethod
     def _get_write_connection(cls, log_path: os.PathLike) -> sqlite3.Connection:
@@ -193,17 +191,20 @@ class SQLiteTraceHandler(TracerMixin):
             )
         self._truncate()
 
+    def clear_logs(self):
+        self.db.execute("DELETE FROM guard_logs;")
+
     def tail_logs(
         self, start_offset_idx: int = 0, follow: bool = False
     ) -> Iterator[GuardTraceEntry]:
-        """Returns an iterator to generate GuardLogEntries. @param
-        start_offset_idx : Start printing entries after this IDX. If.
+        """Returns an iterator to generate GuardLogEntries.
 
-        negative, this will instead start printing the LAST
-        start_offset_idx entries. @param follow : If follow is True,
-        will re-check the database for new entries after the first batch
-        is complete.  If False (default), will return when entries are
-        exhausted.
+        @param start_offset_idx : Start printing entries after this IDX. If negative,
+        this will instead start printing the LAST start_offset_idx entries.
+
+        @param follow : If follow is True, will re-check the database for new entries
+        after the first batch is complete.  If False (default), will return when entries
+        are exhausted.
         """
         last_idx = start_offset_idx
         cursor = self.db.cursor()

--- a/guardrails/call_tracing/sqlite_trace_handler.py
+++ b/guardrails/call_tracing/sqlite_trace_handler.py
@@ -82,8 +82,6 @@ class SQLiteTraceHandler(TracerMixin):
     """
 
     def __init__(self, log_path: os.PathLike, read_mode: bool):
-        # super().__init__(log_path, read_mode)
-        # super(TracerMixin, self).__init__(log_path, read_mode)
         self._log_path = log_path  # Read-only value.
         self.last_cleanup = time.time()
         self.readonly = read_mode

--- a/guardrails/call_tracing/trace_handler.py
+++ b/guardrails/call_tracing/trace_handler.py
@@ -61,11 +61,11 @@ class TraceHandler(TracerMixin):
         return cls._instance
 
     @classmethod
-    def _create(cls, path: os.PathLike = LOGFILE_PATH) -> TracerMixin:  # type: ignore
-        return SQLiteTraceHandler(path, read_mode=False)
+    def _create(cls) -> TracerMixin:  # type: ignore
+        return SQLiteTraceHandler(LOGFILE_PATH, read_mode=False)
         # To disable logging:
-        # return _BaseTraceHandler(path, read_mode=False)
+        # return _BaseTraceHandler(LOGFILE_PATH, read_mode=False)
 
     @classmethod
-    def get_reader(cls, path: os.PathLike = LOGFILE_PATH) -> TracerMixin:  # type: ignore
-        return SQLiteTraceHandler(path, read_mode=True)
+    def get_reader(cls) -> TracerMixin:  # type: ignore
+        return SQLiteTraceHandler(LOGFILE_PATH, read_mode=True)

--- a/guardrails/call_tracing/trace_handler.py
+++ b/guardrails/call_tracing/trace_handler.py
@@ -62,10 +62,10 @@ class TraceHandler(TracerMixin):
 
     @classmethod
     def _create(cls) -> TracerMixin:  # type: ignore
-        return SQLiteTraceHandler(LOGFILE_PATH, read_mode=False)
+        return SQLiteTraceHandler(LOGFILE_PATH, read_mode=False)  # type: ignore
         # To disable logging:
         # return _BaseTraceHandler(LOGFILE_PATH, read_mode=False)
 
     @classmethod
     def get_reader(cls) -> TracerMixin:  # type: ignore
-        return SQLiteTraceHandler(LOGFILE_PATH, read_mode=True)
+        return SQLiteTraceHandler(LOGFILE_PATH, read_mode=True)  # type: ignore

--- a/guardrails/call_tracing/tracer_mixin.py
+++ b/guardrails/call_tracing/tracer_mixin.py
@@ -14,8 +14,15 @@ from guardrails.classes.validation.validator_logs import ValidatorLogs
 class TracerMixin:
     """The pads out the methods but is otherwise a noop."""
 
+    _log_path: os.PathLike
+
     def __init__(self, log_path: os.PathLike, read_mode: bool):
         self.db = None
+        self._log_path = log_path
+
+    @property
+    def log_path(self) -> os.PathLike:
+        return self._log_path
 
     def log(self, *args, **kwargs):
         pass
@@ -26,9 +33,10 @@ class TracerMixin:
     def log_validator(self, vlog: ValidatorLogs):
         pass
 
+    def clear_logs(self):
+        pass
+
     def tail_logs(
-        self,
-        start_offset_idx: int = 0,
-        follow: bool = False,
+        self, start_offset_idx: int = 0, follow: bool = False, clear: bool = False
     ) -> Iterator[GuardTraceEntry]:
         yield from []

--- a/guardrails/cli/watch.py
+++ b/guardrails/cli/watch.py
@@ -1,8 +1,8 @@
 import json
 import sqlite3
+import sys
 import time
 from dataclasses import asdict
-from typing import Optional
 
 import rich
 import typer
@@ -26,21 +26,16 @@ def watch_command(
         default=True,
         help="Continuously read the last output commands",
     ),
-    log_path_override: Optional[str] = typer.Option(
-        default=None, help="Specify a path to the log output file."
+    clear: bool = typer.Option(
+        default=False, is_flag=True, help="Clear all log outputs and exit."
     ),
 ):
+    if clear:
+        _clear_and_quit()
+        return
+
     # Open a reader for the log path:
-    log_reader = None
-    while log_reader is None:
-        try:
-            if log_path_override is not None:
-                log_reader = TraceHandler.get_reader(log_path_override)  # type: ignore
-            else:
-                log_reader = TraceHandler.get_reader()
-        except sqlite3.OperationalError:
-            print("Logfile not found. Retrying.")
-            time.sleep(1)
+    log_reader = _wait_for_logfile()
 
     # If we are using fancy outputs, grab a console ref and prep a table.
     output_fn = _print_and_format_plain
@@ -52,9 +47,27 @@ def watch_command(
         output_fn(log_msg)
 
 
+def _wait_for_logfile():
+    log_reader = None
+    while log_reader is None:
+        try:
+            log_reader = TraceHandler.get_reader()
+        except sqlite3.OperationalError:
+            print("Logfile not found. Retrying.")
+            time.sleep(1)
+    print(f"Reading log from {log_reader.log_path}")
+    return log_reader
+
+
 def _print_fancy(log_msg: GuardTraceEntry):
     rich.print(log_msg)
 
 
 def _print_and_format_plain(log_msg: GuardTraceEntry) -> None:
     print(json.dumps(asdict(log_msg)))
+
+
+def _clear_and_quit():
+    log_reader = TraceHandler()
+    log_reader.clear_logs()
+    sys.exit(0)  # Force an exit here so we don't accidentally do something afterwards.


### PR DESCRIPTION
Adds --clear to the guardrails watch command to clear output logs.  Also cleaned up some unused code (default write path) and made a few other code paths cleaner.  Added unit tests for new feature.