### PR TITLE
fix(litellm): call LiteLLMCallable instead of OpenAIChatCallable when…

### DIFF
--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -596,6 +596,15 @@ def get_llm_ask(
 ) -> Optional[PromptCallableBase]:
     if "temperature" not in kwargs:
         kwargs.update({"temperature": 0})
+
+    try:
+        from litellm import completion
+
+        if llm_api == completion or (llm_api is None and kwargs.get("model")):
+            return LiteLLMCallable(*args, **kwargs)
+    except ImportError:
+        pass
+
     if llm_api == get_static_openai_create_func():
         return OpenAICallable(*args, **kwargs)
     if llm_api == get_static_openai_chat_create_func():
@@ -665,14 +674,6 @@ def get_llm_ask(
             raise ValueError(
                 "Only text generation pipelines are supported at this time."
             )
-    except ImportError:
-        pass
-
-    try:
-        from litellm import completion  # noqa: F401 # type: ignore
-
-        if llm_api == completion or (llm_api is None and kwargs.get("model")):
-            return LiteLLMCallable(*args, **kwargs)
     except ImportError:
         pass
 

--- a/tests/integration_tests/test_litellm.py
+++ b/tests/integration_tests/test_litellm.py
@@ -12,6 +12,12 @@ import guardrails as gd
 
 from typing import List
 from pydantic import BaseModel
+from guardrails.llm_providers import (
+    get_llm_ask,
+    LiteLLMCallable,
+    get_async_llm_ask,
+    AsyncLiteLLMCallable,
+)
 
 
 @pytest.mark.skipif(
@@ -145,3 +151,21 @@ def test_litellm_openai_async_messages():
     assert res.validated_output
     assert res.validated_output == res.raw_llm_output
     assert len(res.validated_output.split("\n")) == 10
+
+
+@pytest.mark.skipif(
+    not importlib.util.find_spec("litellm"),
+    reason="`litellm` is not installed",
+)
+def test_get_llm_ask_returns_litellm_callable_without_llm_api():
+    result = get_llm_ask(llm_api=None, model="azure/gpt-4")
+    assert isinstance(result, LiteLLMCallable)
+
+
+@pytest.mark.skipif(
+    not importlib.util.find_spec("litellm"),
+    reason="`litellm` is not installed",
+)
+def test_get_async_llm_ask_returns_async_litellm_callable_without_llm_api():
+    result = get_async_llm_ask(llm_api=None, model="azure/gpt-4")
+    assert isinstance(result, AsyncLiteLLMCallable)


### PR DESCRIPTION
… llm_api is not passed


- [x] Update get_llm_ask to check for LiteLLM first
- [x] Allow LiteLLM usage without explicitly passing litellm.completion
- [x] Maintain compatibility with other LLM providers
- [x] Update relevant tests to reflect new LiteLLM usage


### Script to reproduce the issue

```python
from guardrails import Guard
import os
os.environ["AZURE_API_KEY"] = "" # "my-azure-api-key"
os.environ["AZURE_API_BASE"] = "" # "https://example-endpoint.openai.azure.com/"
os.environ["AZURE_API_VERSION"] = "" # "2023-05-15"

guard = Guard()

result = guard(
    model="azure/<your_deployment_name>",
    messages=[{"role":"user", "content":"How many moons does Jupiter have?"}],
)

print(f"{result.validated_output}")
```