### PR TITLE
Add -q as shortcut for hub quiet install

### DIFF
--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -203,7 +203,7 @@ Example: hub://guardrails/regex_match."
     ),
     quiet: bool = typer.Option(
         False,
-        "--quiet",
+        "-q", "--quiet",
         help="Run the command in quiet mode to reduce output verbosity.",
     ),
 ):

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -203,7 +203,8 @@ Example: hub://guardrails/regex_match."
     ),
     quiet: bool = typer.Option(
         False,
-        "-q", "--quiet",
+        "-q",
+        "--quiet",
         help="Run the command in quiet mode to reduce output verbosity.",
     ),
 ):


### PR DESCRIPTION
This PR addresses this [issue](https://github.com/guardrails-ai/guardrails/issues/929) and adds ```-q``` as a shortcut for installing validators from the hub: 

```
(gr) aaravnavani@Aaravs-MacBook-Pro guardrails % guardrails hub install hub://guardrails/toxic_language -q
Installing hub://guardrails/toxic_language...
✅Successfully installed guardrails/toxic_language!
```
