### PR TITLE
Cli option to list hub validators 

### DIFF
--- a/guardrails/call_tracing/sqlite_trace_handler.py
+++ b/guardrails/call_tracing/sqlite_trace_handler.py
@@ -197,12 +197,13 @@ class SQLiteTraceHandler(TracerMixin):
     ) -> Iterator[GuardTraceEntry]:
         """Returns an iterator to generate GuardLogEntries.
 
-        @param start_offset_idx : Start printing entries after this IDX. If negative,
-        this will instead start printing the LAST start_offset_idx entries.
+        @param start_offset_idx : Start printing entries after this IDX.
+        If negative, this will instead start printing the LAST
+        start_offset_idx entries.
 
-        @param follow : If follow is True, will re-check the database for new entries
-        after the first batch is complete.  If False (default), will return when entries
-        are exhausted.
+        @param follow : If follow is True, will re-check the database
+        for new entries after the first batch is complete.  If False
+        (default), will return when entries are exhausted.
         """
         last_idx = start_offset_idx
         cursor = self.db.cursor()

--- a/guardrails/cli/hub/__init__.py
+++ b/guardrails/cli/hub/__init__.py
@@ -2,4 +2,5 @@ import guardrails.cli.hub.create_validator  # noqa
 import guardrails.cli.hub.install  # noqa
 import guardrails.cli.hub.uninstall  # noqa
 import guardrails.cli.hub.submit  # noqa
+import guardrails.cli.hub.list # noqa
 from guardrails.cli.hub.hub import hub_command  # noqa

--- a/guardrails/cli/hub/__init__.py
+++ b/guardrails/cli/hub/__init__.py
@@ -2,5 +2,5 @@ import guardrails.cli.hub.create_validator  # noqa
 import guardrails.cli.hub.install  # noqa
 import guardrails.cli.hub.uninstall  # noqa
 import guardrails.cli.hub.submit  # noqa
-import guardrails.cli.hub.list # noqa
+import guardrails.cli.hub.list  # noqa
 from guardrails.cli.hub.hub import hub_command  # noqa

--- a/guardrails/cli/hub/list.py
+++ b/guardrails/cli/hub/list.py
@@ -1,12 +1,10 @@
 import os
-import sys
-from contextlib import contextmanager
-import typer
 import re
 
 from guardrails.cli.hub.hub import hub_command
 from guardrails.cli.hub.utils import get_site_packages_location
 from .console import console
+
 
 @hub_command.command(name="list")
 def list():
@@ -17,9 +15,9 @@ def list():
     installed_validators = []
 
     if os.path.isfile(hub_init_file):
-        with open(hub_init_file, 'r') as file:
+        with open(hub_init_file, "r") as file:
             content = file.read()
-            matches = re.findall(r'from .* import (\w+)', content)
+            matches = re.findall(r"from .* import (\w+)", content)
             installed_validators.extend(matches)
 
     if installed_validators:
@@ -28,4 +26,3 @@ def list():
             console.print(f"- {validator}")
     else:
         console.print("No validators installed.")
-

--- a/guardrails/cli/hub/list.py
+++ b/guardrails/cli/hub/list.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from contextlib import contextmanager
+import typer
+import re
+
+from guardrails.cli.hub.hub import hub_command
+from guardrails.cli.hub.utils import get_site_packages_location
+from .console import console
+
+@hub_command.command(name="list")
+def list():
+    """List all installed validators."""
+    site_packages = get_site_packages_location()
+    hub_init_file = os.path.join(site_packages, "guardrails", "hub", "__init__.py")
+
+    installed_validators = []
+
+    if os.path.isfile(hub_init_file):
+        with open(hub_init_file, 'r') as file:
+            content = file.read()
+            matches = re.findall(r'from .* import (\w+)', content)
+            installed_validators.extend(matches)
+
+    if installed_validators:
+        console.print("Installed Validators:")
+        for validator in installed_validators:
+            console.print(f"- {validator}")
+    else:
+        console.print("No validators installed.")
+

--- a/tests/unit_tests/cli/hub/test_list.py
+++ b/tests/unit_tests/cli/hub/test_list.py
@@ -8,11 +8,12 @@ from guardrails.cli.hub.hub import hub_command
 
 runner = CliRunner()
 
+
 class TestListCommand:
     @pytest.fixture(autouse=True)
     def setup(self, mocker):
         mocker.patch(
-            "guardrails.cli.hub.utils.get_site_packages_location", 
+            "guardrails.cli.hub.utils.get_site_packages_location",
             return_value="/test/site-packages",
         )
 

--- a/tests/unit_tests/cli/hub/test_list.py
+++ b/tests/unit_tests/cli/hub/test_list.py
@@ -1,0 +1,52 @@
+import os
+import re
+from unittest.mock import mock_open, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from guardrails.cli.hub.hub import hub_command
+from guardrails.cli.hub.utils import get_site_packages_location
+
+from guardrails.cli.hub.list import hub_command, list
+
+runner = CliRunner()
+
+class TestListCommand:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        mocker.patch("guardrails.cli.hub.utils.get_site_packages_location", return_value="/test/site-packages")
+
+    def test_list_no_validators_installed(self, mocker):
+        mocker.patch("os.path.isfile", return_value=False)
+
+        result = runner.invoke(hub_command, ["list"])
+
+        assert result.exit_code == 0
+        assert "No validators installed." in result.output
+
+    def test_list_validators_installed(self, mocker):
+        mocker.patch("os.path.isfile", return_value=True)
+
+        init_file_content = """
+        from guardrails.hub.guardrails.toxic_language.validator import ToxicLanguage
+        from guardrails.hub.guardrails.competitor_check.validator import CompetitorCheck
+        """
+        mocker.patch("builtins.open", mock_open(read_data=init_file_content))
+
+        result = runner.invoke(hub_command, ["list"])
+
+        assert result.exit_code == 0
+        assert "Installed Validators:" in result.output
+        assert "- ToxicLanguage" in result.output
+        assert "- CompetitorCheck" in result.output
+
+    def test_list_handles_empty_init_file(self, mocker):
+        mocker.patch("os.path.isfile", return_value=True)
+
+        mocker.patch("builtins.open", mock_open(read_data=""))
+
+        result = runner.invoke(hub_command, ["list"])
+
+        assert result.exit_code == 0
+        assert "No validators installed." in result.output

--- a/tests/unit_tests/cli/hub/test_list.py
+++ b/tests/unit_tests/cli/hub/test_list.py
@@ -1,21 +1,20 @@
-import os
-import re
-from unittest.mock import mock_open, patch
+from unittest.mock import mock_open
 
 import pytest
 from typer.testing import CliRunner
 
 from guardrails.cli.hub.hub import hub_command
-from guardrails.cli.hub.utils import get_site_packages_location
 
-from guardrails.cli.hub.list import hub_command, list
 
 runner = CliRunner()
 
 class TestListCommand:
     @pytest.fixture(autouse=True)
     def setup(self, mocker):
-        mocker.patch("guardrails.cli.hub.utils.get_site_packages_location", return_value="/test/site-packages")
+        mocker.patch(
+            "guardrails.cli.hub.utils.get_site_packages_location", 
+            return_value="/test/site-packages",
+        )
 
     def test_list_no_validators_installed(self, mocker):
         mocker.patch("os.path.isfile", return_value=False)


### PR DESCRIPTION
Adds `list` cli option to `guardrails hub` that allows you to see a list of installed validators. 