### PR TITLE
Fix Hub Post Install

### DIFF
--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -270,7 +270,10 @@ Example: hub://guardrails/regex_match."
         pass
 
     # Post-install
-    if not use_remote_endpoint and install_local_models is not False:
+    install_local_models = (
+        install_local_models if install_local_models is not None else True
+    )
+    if not use_remote_endpoint and install_local_models is True:
         logger.log(
             level=LEVELS.get("SPAM"),  # type: ignore
             msg="Installing models locally!",

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from string import Template
-from typing import List, Literal
+from typing import List, Literal, Optional
 
 import typer
 
@@ -196,8 +196,8 @@ def install(
         help="URI to the package to install.\
 Example: hub://guardrails/regex_match."
     ),
-    local_models: bool = typer.Option(
-        False,
+    local_models: Optional[bool] = typer.Option(
+        None,
         "--install-local-models/--no-install-local-models",
         help="Install local models",
     ),
@@ -248,14 +248,19 @@ Example: hub://guardrails/regex_match."
         install_hub_module(module_manifest, site_packages, quiet=quiet)
 
     install_local_models = local_models
+    use_remote_endpoint = False
+    module_has_endpoint = (
+        module_manifest.tags and module_manifest.tags.has_guardrails_endpoint
+    )
 
     try:
         if has_rc_file:
             # if we do want to remote then we don't want to install local models
-            install_local_models = not Credentials.from_rc_file(
-                logger
-            ).use_remote_inferencing
-        elif module_manifest.tags and module_manifest.tags.has_guardrails_endpoint:
+            use_remote_endpoint = (
+                not Credentials.from_rc_file(logger).use_remote_inferencing
+                and module_has_endpoint
+            )
+        elif install_local_models is None and module_has_endpoint:
             install_local_models = typer.confirm(
                 "This validator has a Guardrails AI inference endpoint available. "
                 "Would you still like to install the"
@@ -265,7 +270,7 @@ Example: hub://guardrails/regex_match."
         pass
 
     # Post-install
-    if install_local_models:
+    if not use_remote_endpoint and install_local_models is not False:
         logger.log(
             level=LEVELS.get("SPAM"),  # type: ignore
             msg="Installing models locally!",

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -12,7 +12,7 @@ class TestInstall:
     def test_exits_early_if_uri_is_not_valid(self, mocker):
         mock_logger_error = mocker.patch("guardrails.cli.hub.install.logger.error")
 
-        from guardrails.cli.hub.install import install, sys
+        from guardrails.cli.hub.install import sys
 
         sys_exit_spy = mocker.spy(sys, "exit")
 
@@ -58,9 +58,12 @@ class TestInstall:
 
         monkeypatch.setattr("typer.confirm", lambda prompt, default=True: True)
 
-        from guardrails.cli.hub.install import install
+        runner = CliRunner()
 
-        install("hub://guardrails/test-validator", quiet=False, local_models=False)
+        runner.invoke(
+            hub_command,
+            ["install", "hub://guardrails/test-validator", "--no-install-local-models"],
+        )
 
         log_calls = [
             call(level=5, msg="Installing hub://guardrails/test-validator..."),
@@ -119,9 +122,12 @@ class TestInstall:
 
         monkeypatch.setattr("typer.confirm", lambda prompt, default=True: True)
 
-        from guardrails.cli.hub.install import install
+        runner = CliRunner()
 
-        install("hub://guardrails/test-validator", quiet=False, local_models=True)
+        runner.invoke(
+            hub_command,
+            ["install", "hub://guardrails/test-validator", "--install-local-models"],
+        )
 
         log_calls = [
             call(level=5, msg="Installing hub://guardrails/test-validator..."),
@@ -179,9 +185,9 @@ class TestInstall:
 
         monkeypatch.setattr("typer.confirm", lambda prompt, default=True: True)
 
-        from guardrails.cli.hub.install import install
+        runner = CliRunner()
 
-        install("hub://guardrails/test-validator", quiet=False)
+        runner.invoke(hub_command, ["install", "hub://guardrails/test-validator"])
 
         log_calls = [
             call(level=5, msg="Installing hub://guardrails/test-validator..."),
@@ -235,9 +241,9 @@ class TestInstall:
         mocker.patch("guardrails.cli.hub.install.run_post_install")
         mocker.patch("guardrails.cli.hub.install.add_to_hub_inits")
 
-        monkeypatch.setattr("typer.confirm", lambda _: False)
+        runner = CliRunner()
 
-        install("hub://guardrails/test-validator", quiet=False)
+        runner.invoke(hub_command, ["install", "hub://guardrails/test-validator"])
 
         log_calls = [
             call(level=5, msg="Installing hub://guardrails/test-validator..."),

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -22,7 +22,128 @@ class TestInstall:
         mock_logger_error.assert_called_once_with("Invalid URI!")
         sys_exit_spy.assert_called_once_with(1)
 
-    def test_install_local_models(self, mocker, monkeypatch):
+    def test_install_local_models__false(self, mocker, monkeypatch):
+        mock_logger_log = mocker.patch("guardrails.cli.hub.install.logger.log")
+
+        mock_get_validator_manifest = mocker.patch(
+            "guardrails.cli.hub.install.get_validator_manifest"
+        )
+        manifest = ModuleManifest.from_dict(
+            {
+                "id": "id",
+                "name": "name",
+                "author": {"name": "me", "email": "me@me.me"},
+                "maintainers": [],
+                "repository": {"url": "some-repo"},
+                "namespace": "guardrails",
+                "package_name": "test-validator",
+                "module_name": "test_validator",
+                "exports": ["TestValidator"],
+                "tags": {"has_guardrails_endpoint": False},
+            }
+        )
+        mock_get_validator_manifest.return_value = manifest
+
+        mock_get_site_packages_location = mocker.patch(
+            "guardrails.cli.hub.install.get_site_packages_location"
+        )
+        site_packages = "./.venv/lib/python3.X/site-packages"
+        mock_get_site_packages_location.return_value = site_packages
+
+        mocker.patch("guardrails.cli.hub.install.install_hub_module")
+
+        mock_add_to_hub_init = mocker.patch(
+            "guardrails.cli.hub.install.add_to_hub_inits"
+        )
+
+        monkeypatch.setattr("typer.confirm", lambda prompt, default=True: True)
+
+        from guardrails.cli.hub.install import install
+
+        install("hub://guardrails/test-validator", quiet=False, local_models=False)
+
+        log_calls = [
+            call(level=5, msg="Installing hub://guardrails/test-validator..."),
+            call(
+                level=5,
+                msg="Skipping post install, models will not be downloaded for local "
+                "inference.",
+            ),
+            call(
+                level=5,
+                msg="✅Successfully installed hub://guardrails/test-validator!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/id\n",  # noqa
+            ),  # noqa
+        ]
+        assert mock_logger_log.call_count == 3
+        mock_logger_log.assert_has_calls(log_calls)
+
+        mock_get_validator_manifest.assert_called_once_with("guardrails/test-validator")
+
+        assert mock_get_site_packages_location.call_count == 1
+
+        mock_add_to_hub_init.assert_called_once_with(manifest, site_packages)
+
+    def test_install_local_models__true(self, mocker, monkeypatch):
+        mock_logger_log = mocker.patch("guardrails.cli.hub.install.logger.log")
+
+        mock_get_validator_manifest = mocker.patch(
+            "guardrails.cli.hub.install.get_validator_manifest"
+        )
+        manifest = ModuleManifest.from_dict(
+            {
+                "id": "id",
+                "name": "name",
+                "author": {"name": "me", "email": "me@me.me"},
+                "maintainers": [],
+                "repository": {"url": "some-repo"},
+                "namespace": "guardrails",
+                "package_name": "test-validator",
+                "module_name": "test_validator",
+                "exports": ["TestValidator"],
+                "tags": {"has_guardrails_endpoint": False},
+            }
+        )
+        mock_get_validator_manifest.return_value = manifest
+
+        mock_get_site_packages_location = mocker.patch(
+            "guardrails.cli.hub.install.get_site_packages_location"
+        )
+        site_packages = "./.venv/lib/python3.X/site-packages"
+        mock_get_site_packages_location.return_value = site_packages
+
+        mocker.patch("guardrails.cli.hub.install.install_hub_module")
+
+        mock_add_to_hub_init = mocker.patch(
+            "guardrails.cli.hub.install.add_to_hub_inits"
+        )
+
+        monkeypatch.setattr("typer.confirm", lambda prompt, default=True: True)
+
+        from guardrails.cli.hub.install import install
+
+        install("hub://guardrails/test-validator", quiet=False, local_models=True)
+
+        log_calls = [
+            call(level=5, msg="Installing hub://guardrails/test-validator..."),
+            call(
+                level=5,
+                msg="Installing models locally!",
+            ),
+            call(
+                level=5,
+                msg="✅Successfully installed hub://guardrails/test-validator!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/id\n",  # noqa
+            ),  # noqa
+        ]
+        assert mock_logger_log.call_count == 3
+        mock_logger_log.assert_has_calls(log_calls)
+
+        mock_get_validator_manifest.assert_called_once_with("guardrails/test-validator")
+
+        assert mock_get_site_packages_location.call_count == 1
+
+        mock_add_to_hub_init.assert_called_once_with(manifest, site_packages)
+
+    def test_install_local_models__none(self, mocker, monkeypatch):
         mock_logger_log = mocker.patch("guardrails.cli.hub.install.logger.log")
 
         mock_get_validator_manifest = mocker.patch(
@@ -66,8 +187,7 @@ class TestInstall:
             call(level=5, msg="Installing hub://guardrails/test-validator..."),
             call(
                 level=5,
-                msg="Skipping post install, models will not be downloaded for local "
-                "inference.",
+                msg="Installing models locally!",
             ),
             call(
                 level=5,
@@ -123,7 +243,7 @@ class TestInstall:
             call(level=5, msg="Installing hub://guardrails/test-validator..."),
             call(
                 level=5,
-                msg="Skipping post install, models will not be downloaded for local inference.",  # noqa
+                msg="Installing models locally!",  # noqa
             ),  # noqa
         ]
 


### PR DESCRIPTION
In the recent release the concept of using remote inference with validators was introduced.  Along with this came the option to skip installing a validator's ML models with the intention of using said remote inference endpoints instead.  While there is a flag to control this behaviour, it was defaulted to skip model installation unless told otherwise.

First, this is a bad assumption since it can leave validators in an unusable state without knowing and referencing the docs for this feature.
Second, post-install is also currently where other hub validators that a particular validator depends on are installed.  See https://github.com/guardrails-ai/guardrails/issues/966 as an example of this.



This PR corrects this behaviour by implementing the following:

- The `local_models` option defaults to `None` instead of `False`
- We only auto-skip running the post-install if `use_remote_inferencing` is set to `true` in the `.guardrailsrc` _and_ the validator being installed is tagged as having a remote inference endpoint (i.e. `module_manifest.tags.has_guardrails_endpoint`).
- The `--install-local-models` flag always indicates the post-install should be run
- The `--no-install-local-models` flag always indicates the post-install should _not_ be run
- If no flag is passed, and remote inferencing is not to be used (either through settings or lack of support), the post install is run