### PR TITLE
Fix Langchain Integration when using No-Op

### DIFF
--- a/guardrails/integrations/langchain/guard_runnable.py
+++ b/guardrails/integrations/langchain/guard_runnable.py
@@ -2,6 +2,7 @@ from guardrails.integrations.langchain.base_runnable import BaseRunnable
 from guardrails.guard import Guard
 from guardrails.errors import ValidationError
 from guardrails.classes.output_type import OT
+from guardrails.classes.validation_outcome import ValidationOutcome
 
 
 class GuardRunnable(BaseRunnable):
@@ -12,9 +13,9 @@ class GuardRunnable(BaseRunnable):
         self.guard = guard
 
     def _validate(self, input: str) -> OT:
-        response = self.guard.validate(input)
+        response: ValidationOutcome[OT] = self.guard.validate(input)
         validated_output = response.validated_output
-        if not validated_output:
+        if not validated_output or response.validation_passed is False:
             raise ValidationError(
                 (
                     "The response from the LLM failed validation!"

--- a/tests/integration_tests/integrations/langchain/test_guard_runnable.py
+++ b/tests/integration_tests/integrations/langchain/test_guard_runnable.py
@@ -20,7 +20,7 @@ def guard_runnable():
         .use(
             RegexMatch("Ice cream", match_type="search", on_fail="refrain"), on="output"
         )
-        .use(ReadingTime(0.05, on_fail="refrain"))
+        .use(ReadingTime(0.05, on_fail="noop"))
     )
 
 


### PR DESCRIPTION
Previously, if validation failed when the on_fail action was noop, the output that failed validation would be returned through the chain.

Now we raise an exception if validation fails with noop in guard runnable by inspecting `ValidationOutcome.validation_passed`.