### PR TITLE
Fix Behaviour when LLM is None 

### DIFF
--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -802,7 +802,10 @@ class Guard(IGuard, Generic[OT]):
         msg_history: Optional[List[Dict]] = None,
         **kwargs,
     ) -> Union[ValidationOutcome[OT], Iterable[ValidationOutcome[OT]]]:
-        api = get_llm_ask(llm_api, *args, **kwargs)
+        api = None
+
+        if llm_api is not None or kwargs.get("model") is not None:
+            api = get_llm_ask(llm_api, *args, **kwargs)
 
         if self._output_formatter is not None:
             # Type suppression here? ArbitraryCallable is a subclass of PromptCallable!?

--- a/guardrails/utils/openai_utils/v1.py
+++ b/guardrails/utils/openai_utils/v1.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, AsyncIterable, Dict, Iterable, List, cast
 
 import openai
@@ -14,14 +13,10 @@ from guardrails.utils.telemetry_utils import trace_llm_call, trace_operation
 
 
 def get_static_openai_create_func():
-    if "OPENAI_API_KEY" not in os.environ:
-        return None
     return openai.completions.create
 
 
 def get_static_openai_chat_create_func():
-    if "OPENAI_API_KEY" not in os.environ:
-        return None
     return openai.chat.completions.create
 
 


### PR DESCRIPTION
Previously, if the `llm_api` argument was `None` and `OPENAI_API_KEY` environment variable was not set, the llm_api would match the static openai completions create function because it was returning `None`.  This would cause issues as shown in https://github.com/guardrails-ai/guardrails/issues/979

We now avoid this issue by:
1. Not matching to an LLM if the `llm_api` argument is `None` and there is no `model` argument specified.
2. Not returning `None` from the static openai fetcher methods.  If auth is not properly set, let the OpenAI errors propagate up accordingly.