### PR TITLE
Default Validator Hub Service URL to point to Cloudfront Distribution

### DIFF
--- a/guardrails/cli/server/hub_client.py
+++ b/guardrails/cli/server/hub_client.py
@@ -24,7 +24,7 @@ to update your token.
 GUARDRAILS_VERSION = version("guardrails-ai")
 
 VALIDATOR_HUB_SERVICE = os.getenv(
-    "GR_VALIDATOR_HUB_SERVICE", "https://so4sg4q4pb.execute-api.us-east-1.amazonaws.com"
+    "GR_VALIDATOR_HUB_SERVICE", "https://hub.api.guardrailsai.com"
 )
 validator_manifest_endpoint = Template(
     "validator-manifests/${namespace}/${validator_name}"

--- a/guardrails/hub_token/token.py
+++ b/guardrails/hub_token/token.py
@@ -32,7 +32,7 @@ class HttpError(Exception):
 
 
 VALIDATOR_HUB_SERVICE = os.getenv(
-    "GR_VALIDATOR_HUB_SERVICE", "https://so4sg4q4pb.execute-api.us-east-1.amazonaws.com"
+    "GR_VALIDATOR_HUB_SERVICE", "https://hub.api.guardrailsai.com"
 )
 
 


### PR DESCRIPTION
Changed:
- The Validator Hub Service URL (which can be configured with `GR_VALIDATOR_HUB_SERVICE`) currently points to API GW, now it will point to our Cloudfront Distribution (with custom DNS)

Tested with: `guardrails configure` and successfully logs in using new URL ✅ 