### PR TITLE
Add 'error_message' as an explicitly required parameter into the FailResult to avoid a footgun.

### DIFF
--- a/guardrails/classes/validation/validation_result.py
+++ b/guardrails/classes/validation/validation_result.py
@@ -7,7 +7,6 @@ from guardrails_api_client import (
     ErrorSpan as IErrorSpan,
 )
 from guardrails.classes.generic.arbitrary_model import ArbitraryModel
-from guardrails.logger import logger
 
 
 class ValidationResult(IValidationResult, ArbitraryModel):
@@ -116,19 +115,6 @@ class FailResult(ValidationResult, IFailResult):
     May not exist for non-streamed output.
     """
     error_spans: Optional[List["ErrorSpan"]] = None
-
-    def __init__(self, **kwargs) -> None:
-        # Prevent a footgun: message is not an expected parameter, error_message is.
-        # We accept kwargs, but that means a user can pass message by accident and not
-        # know that it's wrong until they get an exception.
-        if "error_message" not in kwargs and "message" in kwargs:
-            logger.warning(
-                "Parameter missing: FailResult was passed 'message' instead "
-                "of 'error_message' and 'error_messge' is unspecified."
-            )
-            kwargs["error_message"] = kwargs["message"]
-            del kwargs["message"]
-        super().__init__(**kwargs)
 
     @classmethod
     def from_interface(cls, i_fail_result: IFailResult) -> "FailResult":

--- a/guardrails/classes/validation/validation_result.py
+++ b/guardrails/classes/validation/validation_result.py
@@ -117,10 +117,10 @@ class FailResult(ValidationResult, IFailResult):
     error_spans: Optional[List["ErrorSpan"]] = None
 
     def __init__(self, error_message: str, **kwargs) -> None:
-        super().__init__(error_message=error_message, **kwargs)
         # This is a silly thing to force a friendly error message and to give type hints
         # to IDEs who have a hard time figuring out the constructor parameters.
-        self.error_message = error_message
+        kwargs["error_message"] = error_message
+        super().__init__(**kwargs)
 
     @classmethod
     def from_interface(cls, i_fail_result: IFailResult) -> "FailResult":

--- a/guardrails/classes/validation/validation_result.py
+++ b/guardrails/classes/validation/validation_result.py
@@ -116,6 +116,12 @@ class FailResult(ValidationResult, IFailResult):
     """
     error_spans: Optional[List["ErrorSpan"]] = None
 
+    def __init__(self, error_message: str, **kwargs) -> None:
+        super().__init__(error_message=error_message, **kwargs)
+        # This is a silly thing to force a friendly error message and to give type hints
+        # to IDEs who have a hard time figuring out the constructor parameters.
+        self.error_message = error_message
+
     @classmethod
     def from_interface(cls, i_fail_result: IFailResult) -> "FailResult":
         error_spans = None

--- a/guardrails/classes/validation/validation_result.py
+++ b/guardrails/classes/validation/validation_result.py
@@ -7,6 +7,7 @@ from guardrails_api_client import (
     ErrorSpan as IErrorSpan,
 )
 from guardrails.classes.generic.arbitrary_model import ArbitraryModel
+from guardrails.logger import logger
 
 
 class ValidationResult(IValidationResult, ArbitraryModel):
@@ -115,6 +116,19 @@ class FailResult(ValidationResult, IFailResult):
     May not exist for non-streamed output.
     """
     error_spans: Optional[List["ErrorSpan"]] = None
+
+    def __init__(self, **kwargs) -> None:
+        # Prevent a footgun: message is not an expected parameter, error_message is.
+        # We accept kwargs, but that means a user can pass message by accident and not
+        # know that it's wrong until they get an exception.
+        if "error_message" not in kwargs and "message" in kwargs:
+            logger.warning(
+                "Parameter missing: FailResult was passed 'message' instead "
+                "of 'error_message' and 'error_messge' is unspecified."
+            )
+            kwargs["error_message"] = kwargs["message"]
+            del kwargs["message"]
+        super().__init__(**kwargs)
 
     @classmethod
     def from_interface(cls, i_fail_result: IFailResult) -> "FailResult":


### PR DESCRIPTION
Possible fix for https://github.com/guardrails-ai/guardrails/issues/997

Before:

```
In [2]: FailResult(message="Heck")
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[2], line 1
----> 1 FailResult(message="Heck")

File ~/.virtualenvs/guardrails/lib/python3.10/site-packages/pydantic/main.py:176, in BaseModel.__init__(self, **data)
    174 # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
    175 __tracebackhide__ = True
--> 176 self.__pydantic_validator__.validate_python(data, self_instance=self)

ValidationError: 1 validation error for FailResult
error_message
  Field required [type=missing, input_value={'message': 'Heck'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/missing
```

After:

```
>>> FailResult("Heck")
FailResult(outcome='fail', error_message='Heck', fix_value=None, error_spans=None, metadata=None, validated_chunk=None)

>>> FailResult(error_message="Heck")
FailResult(outcome='fail', error_message='Heck', fix_value=None, error_spans=None, metadata=None, validated_chunk=None)

>>> FailResult(message="Heck")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 FailResult(message="Heck")

TypeError: FailResult.__init__() missing 1 required positional argument: 'error_message'
```

It feels like a bit of a hack to make error_message a required field, since that job really should fall to the BaseModel.  This change gives the IDE a type hint (that error_message is the value rather than 'message') and lets people pass a plain string as the first parameter, no named type required.  

At some point we should probably shuffle up the stack and remove `model_config = ConfigDict(arbitrary_types_allowed=True)` from ArbitraryModel, opting for BaseModel where we can.