### PR TITLE
Make an explicit constructor for FailResult so that we don't get a footgun late in the game.

### DIFF
--- a/guardrails/classes/validation/validation_result.py
+++ b/guardrails/classes/validation/validation_result.py
@@ -117,10 +117,10 @@ class FailResult(ValidationResult, IFailResult):
     error_spans: Optional[List["ErrorSpan"]] = None
 
     def __init__(self, error_message: str, **kwargs) -> None:
-        super().__init__(error_message=error_message, **kwargs)
         # This is a silly thing to force a friendly error message and to give type hints
         # to IDEs who have a hard time figuring out the constructor parameters.
-        self.error_message = error_message
+        kwargs["error_message"] = error_message
+        super().__init__(**kwargs)
 
     @classmethod
     def from_interface(cls, i_fail_result: IFailResult) -> "FailResult":

--- a/guardrails/classes/validation/validation_result.py
+++ b/guardrails/classes/validation/validation_result.py
@@ -116,6 +116,12 @@ class FailResult(ValidationResult, IFailResult):
     """
     error_spans: Optional[List["ErrorSpan"]] = None
 
+    def __init__(self, error_message: str, **kwargs) -> None:
+        super().__init__(error_message=error_message, **kwargs)
+        # This is a silly thing to force a friendly error message and to give type hints
+        # to IDEs who have a hard time figuring out the constructor parameters.
+        self.error_message = error_message
+
     @classmethod
     def from_interface(cls, i_fail_result: IFailResult) -> "FailResult":
         error_spans = None


### PR DESCRIPTION
A candidate for https://github.com/guardrails-ai/guardrails/issues/997

See also https://github.com/guardrails-ai/guardrails/pull/1000/files

Before:

```
>>> FailResult(message="Heck")
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[2], line 1
----> 1 FailResult(message="Heck")

File ~/.virtualenvs/guardrails/lib/python3.10/site-packages/pydantic/main.py:176, in BaseModel.__init__(self, **data)
    174 # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
    175 __tracebackhide__ = True
--> 176 self.__pydantic_validator__.validate_python(data, self_instance=self)

ValidationError: 1 validation error for FailResult
error_message
  Field required [type=missing, input_value={'message': 'Heck'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/missing
```

After:

```
>>> FailResult("Heck")
FailResult(outcome='fail', error_message='Heck', fix_value=None, error_spans=None, metadata=None, validated_chunk=None)

>>> FailResult(error_message="Heck")
FailResult(outcome='fail', error_message='Heck', fix_value=None, error_spans=None, metadata=None, validated_chunk=None)

>>> FailResult(message="Heck")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 FailResult(message="Heck")

TypeError: FailResult.__init__() missing 1 required positional argument: 'error_message'
```