### PR TITLE
add extra action permissions so close stale works

### DIFF
--- a/.github/workflows/autoclose_stale_issues_and_prs.yml
+++ b/.github/workflows/autoclose_stale_issues_and_prs.yml
@@ -3,6 +3,12 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+# modify permissions to allow writing to issues and PRs
+permissions:
+  contents: write # only for delete-branch option
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/marketplace/actions/close-stale-issues#recommended-permissions

see https://github.com/guardrails-ai/guardrails/blob/main/.github/workflows/deploy_docs.yml where we're doing similarly
