### PR TITLE
increase actions per run and move it later so we have a lower chance …

### DIFF
--- a/.github/workflows/autoclose_stale_issues_and_prs.yml
+++ b/.github/workflows/autoclose_stale_issues_and_prs.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '30 3 * * *'
 
 # modify permissions to allow writing to issues and PRs
 permissions:
@@ -24,3 +24,4 @@ jobs:
           days-before-issue-close: 14
           days-before-pr-close: 14
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 300


### PR DESCRIPTION
…of getting rate limited

- update cron to be 830 or 930 pm pacific depending on daylight savings. this gets us more actions and less disruption during the work day for most engineers
- update operations so we can get through the backlog faster

```
The rate limit for GITHUB_TOKEN is 1,000 requests per hour per repository. For requests to resources that belong to a GitHub Enterprise Cloud account, the limit is 15,000 requests per hour per repository.
```
per https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions
once we get caught up we can probably turn this back down