### PR TITLE
Add OpenLIT as a Telemetry Integration

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -116,6 +116,11 @@ const sidebars = {
           label: "Iudex",
           href: "https://docs.iudex.ai/integrations/guardrails-integration",
         },
+        {
+          type: "link",
+          label: "OpenLIT",
+          href: "https://docs.openlit.io/latest/integrations/guardrails",
+        },
       ],
     },
     // "integrations/openai_functions",


### PR DESCRIPTION
Hello Team, Nice to meet you!

I am the maintainer of [OpenLIT](https://github.com/openlit) which is an LLM Observability tool. Although we do have our OTel native SDK that automatically generates traces and metrics for various tools in the LLM Stack, I noticed Guardrails SDK already has Otel Traces in built which works great as developers can use it directly to view traces in OpenLIT or any other OTel tool. 

THis PR just adds a reference integration link to OpenLIT as it works natively.

<img width="1512" alt="Screenshot 2024-08-24 at 12 15 37 PM" src="https://github.com/user-attachments/assets/b0f9b76a-f9f4-40a0-9c2c-506beefe2e7a">
<img width="1511" alt="Screenshot 2024-08-24 at 12 16 09 PM" src="https://github.com/user-attachments/assets/db219f39-dd07-42b3-baec-3b9c231c647d">
