### PR TITLE
Hub cli flag to upgrade validators

### DIFF
--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -25,6 +25,11 @@ Example: hub://guardrails/regex_match."
         "--quiet",
         help="Run the command in quiet mode to reduce output verbosity.",
     ),
+    upgrade: bool = typer.Option(
+        False,
+        "--upgrade",
+        help="Upgrade the package to the latest version."
+    ),
 ):
     try:
         trace_if_enabled("hub/install")
@@ -41,6 +46,7 @@ Example: hub://guardrails/regex_match."
             package_uri,
             install_local_models=local_models,
             quiet=quiet,
+            upgrade = upgrade,
             install_local_models_confirm=confirm,
         )
     except Exception as e:

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -26,9 +26,7 @@ Example: hub://guardrails/regex_match."
         help="Run the command in quiet mode to reduce output verbosity.",
     ),
     upgrade: bool = typer.Option(
-        False,
-        "--upgrade",
-        help="Upgrade the package to the latest version."
+        False, "--upgrade", help="Upgrade the package to the latest version."
     ),
 ):
     try:
@@ -46,7 +44,7 @@ Example: hub://guardrails/regex_match."
             package_uri,
             install_local_models=local_models,
             quiet=quiet,
-            upgrade = upgrade,
+            upgrade=upgrade,
             install_local_models_confirm=confirm,
         )
     except Exception as e:

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -31,6 +31,7 @@ def pip_process(
         if package:
             command.append(package)
 
+        print('pip command', command)
         env = dict(os.environ)
         if no_color:
             env["NO_COLOR"] = "true"

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -31,7 +31,6 @@ def pip_process(
         if package:
             command.append(package)
 
-        print('pip command', command)
         env = dict(os.environ)
         if no_color:
             env["NO_COLOR"] = "true"

--- a/guardrails/hub/install.py
+++ b/guardrails/hub/install.py
@@ -85,7 +85,11 @@ def install(
     dl_deps_msg = "Downloading dependencies"
     with loader(dl_deps_msg, spinner="bouncingBar"):
         ValidatorPackageService.install_hub_module(
-            module_manifest, site_packages, quiet=quiet, upgrade=upgrade, logger=cli_logger
+            module_manifest,
+            site_packages,
+            quiet=quiet,
+            upgrade=upgrade,
+            logger=cli_logger,
         )
 
     use_remote_endpoint = False

--- a/guardrails/hub/install.py
+++ b/guardrails/hub/install.py
@@ -35,6 +35,7 @@ def install(
     package_uri: str,
     install_local_models=None,
     quiet: bool = True,
+    upgrade: bool = False,
     install_local_models_confirm: Callable = default_local_models_confirm,
 ) -> ValidatorModuleType:
     """Install a validator package from a hub URI.
@@ -84,7 +85,7 @@ def install(
     dl_deps_msg = "Downloading dependencies"
     with loader(dl_deps_msg, spinner="bouncingBar"):
         ValidatorPackageService.install_hub_module(
-            module_manifest, site_packages, quiet=quiet, logger=cli_logger
+            module_manifest, site_packages, quiet=quiet, upgrade=upgrade, logger=cli_logger
         )
 
     use_remote_endpoint = False

--- a/guardrails/hub/validator_package_service.py
+++ b/guardrails/hub/validator_package_service.py
@@ -260,7 +260,7 @@ class ValidatorPackageService:
         module_manifest: Manifest,
         site_packages: str,
         quiet: bool = False,
-        upgrade: bool=False,
+        upgrade: bool = False,
         logger=guardrails_logger,
     ):
         install_url = ValidatorPackageService.get_install_url(module_manifest)
@@ -270,9 +270,9 @@ class ValidatorPackageService:
 
         pip_flags = [f"--target={install_directory}", "--no-deps"]
 
-        if upgrade: 
+        if upgrade:
             pip_flags.append("--upgrade")
-            
+
         if quiet:
             pip_flags.append("-q")
 

--- a/guardrails/hub/validator_package_service.py
+++ b/guardrails/hub/validator_package_service.py
@@ -260,6 +260,7 @@ class ValidatorPackageService:
         module_manifest: Manifest,
         site_packages: str,
         quiet: bool = False,
+        upgrade: bool=False,
         logger=guardrails_logger,
     ):
         install_url = ValidatorPackageService.get_install_url(module_manifest)
@@ -268,6 +269,10 @@ class ValidatorPackageService:
         )
 
         pip_flags = [f"--target={install_directory}", "--no-deps"]
+
+        if upgrade: 
+            pip_flags.append("--upgrade")
+            
         if quiet:
             pip_flags.append("-q")
 

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -204,7 +204,7 @@ class TestPipProcess:
             )
 
             sys_exit_spy.assert_called_once_with(1)
-        
+
     def test_install_with_upgrade_flag(self, mocker):
         mock_install = mocker.patch("guardrails.hub.install.install")
         runner = CliRunner()
@@ -221,6 +221,7 @@ class TestPipProcess:
         )
 
         assert result.exit_code == 0
+
 
 def test_get_site_packages_location(mocker):
     mock_pip_process = mocker.patch("guardrails.cli.hub.utils.pip_process")

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -204,7 +204,23 @@ class TestPipProcess:
             )
 
             sys_exit_spy.assert_called_once_with(1)
+        
+    def test_install_with_upgrade_flag(self, mocker):
+        mock_install = mocker.patch("guardrails.hub.install.install")
+        runner = CliRunner()
+        result = runner.invoke(
+            hub_command, ["install", "--upgrade", "hub://guardrails/test-validator"]
+        )
 
+        mock_install.assert_called_once_with(
+            "hub://guardrails/test-validator",
+            install_local_models=None,
+            quiet=False,
+            install_local_models_confirm=ANY,
+            upgrade=True,
+        )
+
+        assert result.exit_code == 0
 
 def test_get_site_packages_location(mocker):
     mock_pip_process = mocker.patch("guardrails.cli.hub.utils.pip_process")

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -205,6 +205,22 @@ class TestPipProcess:
 
             sys_exit_spy.assert_called_once_with(1)
 
+    def test_install_with_upgrade_flag(self, mocker):
+        mock_install = mocker.patch("guardrails.hub.install.install")
+        runner = CliRunner()
+        result = runner.invoke(
+            hub_command, ["install", "--upgrade", "hub://guardrails/test-validator"]
+        )
+
+        mock_install.assert_called_once_with(
+            "hub://guardrails/test-validator",
+            install_local_models=None,
+            quiet=False,
+            install_local_models_confirm=ANY,
+            upgrade=True,  
+        )
+
+        assert result.exit_code == 0
 
 def test_get_site_packages_location(mocker):
     mock_pip_process = mocker.patch("guardrails.cli.hub.utils.pip_process")

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -205,27 +205,6 @@ class TestPipProcess:
 
             sys_exit_spy.assert_called_once_with(1)
 
-    def test_install_with_upgrade_flag(self, mocker):
-        mock_install_hub_module = mocker.patch(
-            "guardrails.hub.validator_package_service.ValidatorPackageService.install_hub_module"
-        )
-        
-        runner = CliRunner()
-        result = runner.invoke(
-            hub_command, ["install", "--upgrade", "hub://guardrails/test-validator"]
-        )
-
-        mock_install_hub_module.assert_called_once_with(
-            ANY,  
-            ANY,  
-            quiet=False,
-            upgrade=True,
-            logger=ANY,
-        )
-
-        assert result.exit_code == 0
-
-
 
 def test_get_site_packages_location(mocker):
     mock_pip_process = mocker.patch("guardrails.cli.hub.utils.pip_process")

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -29,6 +29,7 @@ class TestInstall:
             "hub://guardrails/test-validator",
             install_local_models=False,
             quiet=False,
+            upgrade=False,
             install_local_models_confirm=ANY,
         )
 
@@ -45,6 +46,7 @@ class TestInstall:
             "hub://guardrails/test-validator",
             install_local_models=True,
             quiet=False,
+            upgrade=False,
             install_local_models_confirm=ANY,
         )
 
@@ -61,6 +63,7 @@ class TestInstall:
             "hub://guardrails/test-validator",
             install_local_models=None,
             quiet=False,
+            upgrade=False,
             install_local_models_confirm=ANY,
         )
 
@@ -77,6 +80,7 @@ class TestInstall:
             "hub://guardrails/test-validator",
             install_local_models=None,
             quiet=True,
+            upgrade=False,
             install_local_models_confirm=ANY,
         )
 

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -217,10 +217,11 @@ class TestPipProcess:
             install_local_models=None,
             quiet=False,
             install_local_models_confirm=ANY,
-            upgrade=True,  
+            upgrade=True,
         )
 
         assert result.exit_code == 0
+
 
 def test_get_site_packages_location(mocker):
     mock_pip_process = mocker.patch("guardrails.cli.hub.utils.pip_process")

--- a/tests/unit_tests/cli/hub/test_install.py
+++ b/tests/unit_tests/cli/hub/test_install.py
@@ -206,21 +206,25 @@ class TestPipProcess:
             sys_exit_spy.assert_called_once_with(1)
 
     def test_install_with_upgrade_flag(self, mocker):
-        mock_install = mocker.patch("guardrails.hub.install.install")
+        mock_install_hub_module = mocker.patch(
+            "guardrails.hub.validator_package_service.ValidatorPackageService.install_hub_module"
+        )
+        
         runner = CliRunner()
         result = runner.invoke(
             hub_command, ["install", "--upgrade", "hub://guardrails/test-validator"]
         )
 
-        mock_install.assert_called_once_with(
-            "hub://guardrails/test-validator",
-            install_local_models=None,
+        mock_install_hub_module.assert_called_once_with(
+            ANY,  
+            ANY,  
             quiet=False,
-            install_local_models_confirm=ANY,
             upgrade=True,
+            logger=ANY,
         )
 
         assert result.exit_code == 0
+
 
 
 def test_get_site_packages_location(mocker):

--- a/tests/unit_tests/hub/test_hub_install.py
+++ b/tests/unit_tests/hub/test_hub_install.py
@@ -99,7 +99,7 @@ class TestInstall:
         )
 
         mock_pip_install_hub_module.assert_called_once_with(
-            self.manifest, self.site_packages, quiet=ANY, logger=ANY
+            self.manifest, self.site_packages, quiet=ANY, upgrade=ANY, logger=ANY
         )
         mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
@@ -160,7 +160,7 @@ class TestInstall:
         )
 
         mock_pip_install_hub_module.assert_called_once_with(
-            self.manifest, self.site_packages, quiet=ANY, logger=ANY
+            self.manifest, self.site_packages, quiet=ANY, upgrade=ANY, logger=ANY
         )
         mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
@@ -221,7 +221,7 @@ class TestInstall:
         )
 
         mock_pip_install_hub_module.assert_called_once_with(
-            self.manifest, self.site_packages, quiet=ANY, logger=ANY
+            self.manifest, self.site_packages, quiet=ANY, upgrade=ANY, logger=ANY
         )
         mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
@@ -278,7 +278,7 @@ class TestInstall:
         )
 
         mock_pip_install_hub_module.assert_called_once_with(
-            self.manifest, self.site_packages, quiet=ANY, logger=ANY
+            self.manifest, self.site_packages, quiet=ANY, upgrade=ANY, logger=ANY
         )
         mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 


### PR DESCRIPTION
This PR adds functionality to the hub cli so that users can upgrade a validator to the latest version.

Now, doing `guardrails hub install --upgrade hub://guardrails/toxic_language` installs the latest version of the validator. If a user has an older version of a validator installed on their machine, they can now use the `--upgrade` flag instead of having to uninstall and install the validator again. 