### PR TITLE
update unauthorized hub errors to include instructions

### DIFF
--- a/guardrails/cli/server/hub_client.py
+++ b/guardrails/cli/server/hub_client.py
@@ -147,7 +147,10 @@ def get_validator_manifest(module_name: str):
             logger.error(f"Failed to install hub://{module_name}")
             sys.exit(1)
         return module_manifest
-    except HttpError:
+    except HttpError as e:
+        if e.message == "Unauthorized":
+            logger.error(TOKEN_INVALID_MESSAGE)
+            raise
         logger.error(f"Failed to install hub://{module_name}")
         sys.exit(1)
     except (ExpiredTokenError, InvalidTokenError) as e:

--- a/guardrails/validator_base.py
+++ b/guardrails/validator_base.py
@@ -280,7 +280,14 @@ class Validator:
         }
         req = requests.post(validation_endpoint, data=request_body, headers=headers)
         if not req.ok:
-            logging.error(req.status_code)
+            if req.status_code == 401:
+                raise Exception(
+                    "401: Remote Inference Unauthorized. Please run "
+                    "`guardrails configure`. You can find a new"
+                    " token at https://hub.guardrailsai.com/keys"
+                )
+            else:
+                logging.error(req.status_code)
 
         return req.json()
 


### PR DESCRIPTION
```
import guardrails as gr

from guardrails.hub import DetectPII

guard = gr.Guard()
guard.use_many(DetectPII(pii_entities=['PERSON', 'LOCATION']))

completion = guard(
    messages=[
        {
            "role": "user",
            "content": "Tell me about a city in california."
        }
    ],
    model="gpt-4o-mini"
)

print(completion)
```

should yield

```
Exception: 401: Remote Inference Unauthorized. Please run `guardrails configure`. You can find a new token at https://hub.guardrailsai.com/keys
```
and 
```
guardrails hub install hub://guardrails/profanity_free
```
returns
```
Installing hub://guardrails/profanity_free...
401
Unauthorized
Your token is invalid. Please run `guardrails configure`to update your token.
You can find a new token at https://hub.guardrailsai.com/keys
```