### PR TITLE
[Fix] #1091. Prevent confusion between guardrails.cli.hub.install and guardrails.hub install.

### DIFF
--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -10,9 +10,14 @@ from guardrails.cli.hub.console import console
 from guardrails.cli.version import version_warnings_if_applicable
 
 
-@hub_command.command()
+# Quick note: This is the command for `guardrails hub install`.  We change the name of
+# the function def to prevent confusion, lest people import it directly and calling it
+# with a string for package_uris instead of a list, which behaves oddly. If you need to
+# call install from a script, please consider importing install from guardrails.hub,
+# not guardrails.cli.hub.install.
+@hub_command.command(name="install")
 @trace(name="guardrails-cli/hub/install")
-def install(
+def install_cli(
     package_uris: List[str] = typer.Argument(
         ...,
         help="URIs to the packages to install. Example: hub://guardrails/regex_match hub://guardrails/toxic_language",
@@ -33,6 +38,17 @@ def install(
     ),
 ):
     try:
+        if isinstance(package_uris, str):
+            logger.error(
+                f"`install` in {__file__} was called with a string instead of "
+                "a list! This can happen if it is invoked directly instead of "
+                "being run via the CLI. Did you mean to import `from "
+                "guardrails.hub import install` instead?  Recovering..."
+            )
+            package_uris = [
+                package_uris,
+            ]
+
         from guardrails.hub.install import install_multiple
 
         def confirm():

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -13,7 +13,7 @@ from guardrails.cli.version import version_warnings_if_applicable
 # Quick note: This is the command for `guardrails hub install`.  We change the name of
 # the function def to prevent confusion, lest people import it directly and calling it
 # with a string for package_uris instead of a list, which behaves oddly. If you need to
-# call install from a script, please consider importing install from guardrails.hub,
+# call install from a script, please consider importing install from guardrails,
 # not guardrails.cli.hub.install.
 @hub_command.command(name="install")
 @trace(name="guardrails-cli/hub/install")
@@ -42,8 +42,8 @@ def install_cli(
             logger.error(
                 f"`install` in {__file__} was called with a string instead of "
                 "a list! This can happen if it is invoked directly instead of "
-                "being run via the CLI. Did you mean to import `from "
-                "guardrails.hub import install` instead?  Recovering..."
+                "being run via the CLI. Did you mean to import `from guardrails import "
+                "install` instead?  Recovering..."
             )
             package_uris = [
                 package_uris,

--- a/guardrails/hub/install.py
+++ b/guardrails/hub/install.py
@@ -53,7 +53,7 @@ def install(
     Examples:
         >>> RegexMatch = install("hub://guardrails/regex_match").RegexMatch
 
-        >>> install("hub://guardrails/regex_match);
+        >>> install("hub://guardrails/regex_match")
         >>> import guardrails.hub.regex_match as regex_match
     """
 


### PR DESCRIPTION
Backstory in https://github.com/guardrails-ai/guardrails/issues/1091

We don't want people to try to import and run the command that defines the COMMAND LINE INTERFACE FOR INSTALL `guardrails hub install` instead of the actual install command.  If someone searches the code and doesn't pay attention they might (rather, they have) do `from guardrails.cli.hub.install import install` instead of `from guardrails.hub import install`.  The former will report that a guard is not found when invoked with a string because it breaks it into characters and attempts to install all of them individually.

We resolve this in two ways:
First, make the install CLI function named install_cli so people don't import it by mistake. (Keep the invocation as `guardrails hub install`)

Second, check if the parameter passed is a string instead of a list and add a warning for string passage.