### PR TITLE
add docs to message about prompt failures

### DIFF
--- a/guardrails/classes/llm/prompt_callable.py
+++ b/guardrails/classes/llm/prompt_callable.py
@@ -1,6 +1,12 @@
 from guardrails.classes.llm.llm_response import LLMResponse
 
 
+CALLABLE_FAILURE_SUFFIX = """Make sure that `fn` can be called as a function
+that accepts a prompt string, **kwargs, and returns a string.
+ If you're using a custom LLM callable, please see docs
+ here: https://go.guardrailsai.com/B1igEy3"""  # noqa
+
+
 class PromptCallableException(Exception):
     pass
 
@@ -29,17 +35,11 @@ class PromptCallableBase:
         except Exception as e:
             raise PromptCallableException(
                 "The callable `fn` passed to `Guard(fn, ...)` failed"
-                f" with the following error: `{e}`. "
-                "Make sure that `fn` can be called as a function that"
-                " takes in a single prompt string "
-                "and returns a string."
+                f" with the following error: `{e}`. {CALLABLE_FAILURE_SUFFIX}"
             )
         if not isinstance(result, LLMResponse):
             raise PromptCallableException(
                 "The callable `fn` passed to `Guard(fn, ...)` returned"
-                f" a non-string value: {result}. "
-                "Make sure that `fn` can be called as a function that"
-                " takes in a single prompt string "
-                "and returns a string."
+                f" a non-string value: {result}. {CALLABLE_FAILURE_SUFFIX}"
             )
         return result

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 from guardrails.errors import UserFacingException
 from guardrails.classes.llm.llm_response import LLMResponse
 from guardrails.classes.llm.prompt_callable import (
+    CALLABLE_FAILURE_SUFFIX,
     PromptCallableBase,
     PromptCallableException,
 )
@@ -903,18 +904,12 @@ class AsyncPromptCallableBase(PromptCallableBase):
         except Exception as e:
             raise PromptCallableException(
                 "The callable `fn` passed to `Guard(fn, ...)` failed"
-                f" with the following error: `{e}`. "
-                "Make sure that `fn` can be called as a function that"
-                " takes in a single prompt string "
-                "and returns a string."
+                f" with the following error: `{e}`. {CALLABLE_FAILURE_SUFFIX}"
             )
         if not isinstance(result, LLMResponse):
             raise PromptCallableException(
                 "The callable `fn` passed to `Guard(fn, ...)` returned"
-                f" a non-string value: {result}. "
-                "Make sure that `fn` can be called as a function that"
-                " takes in a single prompt string "
-                "and returns a string."
+                f" a non-string value: {result}. {CALLABLE_FAILURE_SUFFIX}"
             )
         return result
 


### PR DESCRIPTION
1. improve callable message to include **kwargs. This improves handling around `temperature`, `prompt`, `instructions`. Probably get-riddable or should be updated before 0.6.0 even
2. adds a link to the custom callable doc.