### PR TITLE
Corrected the model name in example for Cohere model

### DIFF
--- a/docs/llm_api_wrappers.md
+++ b/docs/llm_api_wrappers.md
@@ -49,7 +49,7 @@ raw_llm_output, guardrail_output, *rest = guard(
 
 ## Cohere
 
-### Generate (e.g. GPT-3)
+### Generate (e.g. command)
 
 ```python
 import cohere


### PR DESCRIPTION
Updated the model name from GPT-3 to command in case of cohere in the markdown file showing the examples of implementation of different llm api wrappers. 