### PR TITLE
Validator Versioning

### DIFF
--- a/docs/concepts/remote_validation_inference.ipynb
+++ b/docs/concepts/remote_validation_inference.ipynb
@@ -19,6 +19,10 @@
     "\n",
     ":::note\n",
     "Remote validation inferencing is only available in Guardrails versions 0.5.0 and above.\n",
+    ":::\n",
+    "\n",
+    "::note\n",
+    "To enable/disable, you can run the cli command `guardrails configure` or modify your `~/.guardrailsrc`. For example, to disable remote inference use: `use_remote_inferencing=false`.\n",
     ":::"
    ]
   },
@@ -147,7 +151,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -161,9 +165,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/how_to_guides/continuous_integration_continuous_deployment.md
+++ b/docs/how_to_guides/continuous_integration_continuous_deployment.md
@@ -465,7 +465,6 @@ graph TD
     
     %% Public Subnet Group
     subgraph PublicSubnets["Public Subnets x3"]
-        NATGateway[NAT Gateway x2]
         NLB[Network Load Balancer]
         TG[Target Group<br/>TCP:80]
         SG[Security Group<br/>Ingress: 8000<br/>Egress: All]

--- a/docs/how_to_guides/continuous_integration_continuous_deployment.md
+++ b/docs/how_to_guides/continuous_integration_continuous_deployment.md
@@ -255,7 +255,7 @@ terraform apply -var="aws_region=us-east-1" -var="backend_memory=2048" -var="bac
 Once the deployment has succeeded you should see some output values (which will be required if you wish to set up CI).
 
 
-## Step4: Deploying Guardrails API
+## Step 4: Deploying Guardrails API
 ### Manual
 
 Firstly, create or use your existing guardrails token and export it to your current shell `export GUARDRAILS_TOKEN="..."`
@@ -444,7 +444,68 @@ By setting the above environment variable `GUARDRAILS_BASE_URL` the SDK will be 
 
 ## Quick Start Repository Template
 
-We've conveniently packaged all the artifacts from this document in a github repository that can be used as a template for your own verification and deployment [here](https://github.com/guardrails-ai/continuous_integration_and_deployment_aws_template). 
+We've conveniently packaged all the artifacts from this document in a github repository that can be used as a template for your own verification and deployment [here](https://github.com/guardrails-ai/continuous_integration_and_deployment_aws_template).
+
+## Diagram
+
+```mermaid
+graph TD
+    %% Internet and IGW
+    Internet((Internet)) --> IGW[Internet Gateway]
+    IGW --> RouteTable[Public Route Table]
+
+    %% VPC Container
+    VPC[VPC<br/>10.0.0.0/16] --> IGW
+    
+    %% IAM Permissions Group
+    subgraph ECSIAMPermissions["ECS IAM Permissions"]
+        ExecutionRole[ECS Execution Role]
+        TaskRole[ECS Task Role]
+    end
+    
+    %% Public Subnet Group
+    subgraph PublicSubnets["Public Subnets x3"]
+        NATGateway[NAT Gateway x2]
+        NLB[Network Load Balancer]
+        TG[Target Group<br/>TCP:80]
+        SG[Security Group<br/>Ingress: 8000<br/>Egress: All]
+        ECSCluster[ECS Cluster]
+        
+        %% ECS Components
+        ECSService[ECS Service]
+        TaskDef[Task Definition<br/>CPU: 1024<br/>Memory: 2048]
+        Container[Container<br/>Port: 8000]
+        
+        %% Internal Connections
+        NLB --> |Port 80| TG
+        TG --> ECSService
+        ECSCluster --> ECSService
+        SG --> ECSService
+        ECSService --> TaskDef
+        TaskDef --> Container
+    end
+    
+    %% IAM Connections
+    ECSIAMPermissions --> TaskDef
+    
+    %% Route Table Connection
+    RouteTable --> PublicSubnets
+    
+    %% External Service Connections
+    CloudWatchLogs[CloudWatch Log Group] --> Container
+    ECR[ECR Repository] --> |Image| Container
+    
+    %% Internet Access
+    Internet --> NLB
+
+    %% Styling
+    classDef aws fill:#FF9900,stroke:#232F3E,stroke-width:2px,color:black
+    classDef subnet fill:#FFD700,stroke:#232F3E,stroke-width:2px,color:black
+    classDef iam fill:#FF6B6B,stroke:#232F3E,stroke-width:2px,color:black
+    class VPC,IGW,NATGateway,RouteTable,NLB,TG,ECSCluster,ECSService,TaskDef,Container,SG,CloudWatchLogs,ECR aws
+    class PublicSubnets subnet
+    class ECSIAMPermissions,ExecutionRole,TaskRole iam
+```
 
 ## Terraform
 

--- a/docs/migration_guides/0-6-alpha-migration.md
+++ b/docs/migration_guides/0-6-alpha-migration.md
@@ -1,0 +1,133 @@
+# Migrating to 0.6.0-alpha
+
+## Summary
+This guide will help you migrate your codebase from 0.5.X to 0.6.0-alpha.
+
+## Installation
+```bash
+pip install --pre guardrails-ai
+```
+
+## List of backwards incompatible changes
+
+1. All validators will require authentication with a guardrails token. This will also apply to all versions >=0.4.x of the guardrails-ai package.
+1. prompt, msg_history, instructions, reask_messages, reask_instructions, and will be removed from the `Guard.__call__` function and will instead be supported by a single messages argument, and a reask_messages argument for reasks.
+1. Custom callables now need to expect `messages`, as opposed to `prompt` to come in as a keyword argument.
+1. The default on_fail action for validators will change from noop to exception.
+1. In cases where we try and generate structured data, Guardrails will no longer automatically attempt to try and coerce the LLM into giving correctly formatted information.
+1. Guardrails will no longer automatically set a tool selection in the OpenAI callable when initialized using pydantic for initial prompts or reasks
+1. Guard.from_stringis being removed in favor of Guard()
+1. Guard.from_pydantic is renamed to Guard.for_pydantic
+1. Guard.from_rail is renamed to Guard.for_rail
+1. Guard.from_rail_string is renamed to guard.for_rail_string
+1. The guardrails server will change from using Flask to FastAPI. We recommend serving uvicorn runners via a gunicorn WSGI.
+1. OpenAI, Cohere and Anthropic **callables are being removed in favor of support through passing no callable and setting the appropriate api key and model argument.
+
+
+## How to migrate
+
+### Messages support for reask and RAILS
+`Guard.__call` and rails now fully support `reask_messages` as an argument.
+
+### For `Guard.__call`
+```py
+response = guard(
+    messages=[{
+        "role":"user",
+        "content":"tell me a joke"
+    }],
+    reask_messages=[{
+        "role":"system"
+        "content":"your previous joke failed validation can you tell me another joke?"
+    }]
+)
+```
+
+#### For Rail
+```
+<rail version="0.1">
+<messages>
+    <message role="system">
+        Given the following document, answer the following questions. If the answer doesn't exist in the document, enter 'None'.
+        ${document}
+        ${gr.xml_prefix_prompt}
+    </message>
+    <message role="user">
+        ${question}
+    </message>
+</messages>
+<reask_messages>
+    <message="system">
+        You were asked ${question} and it was not correct can you try again?
+    </message>
+</reask_messages>
+</rail>
+```
+
+## Improvements
+
+### Per message validation and fix support
+Message validation is now more granular and executed on a per message content basis.
+This allows for on_fix behavior to be fully supported.
+
+## Backwards-incompatible changes
+### Validator onFail default behavior is now exception
+Previously the default behavior for validation failure was noop. This meant developers were required to set it on_fail to exception or check validation_failed
+to know if validation failed. This was unintuitive for new users and led to confusion around if validators were working or not. This new behavior will require 
+exception handling be added or configurations manually to be set to noop if desired. 
+
+### Simplified schema injection behavior
+Previously prompt and instruction suffixes and formatting hints were sometimes automatically injected
+into prompt and instructions if guardrails detected xml or a structured schema being used for output. 
+This caused confusion and unexpected behavior when arguments to llms were being mutated without a developer asking for it.
+Developers will now need to intentionally include Guardrails template variables such as `${gr.complete_xml_suffix_v2}`
+
+### Guardrails Server migration from Flask to FastAPI
+In 0.5.X guard.__call and guard.validate async streaming received support for on_fail="fix" merge and parallelized async validation.
+We have updated the server to use FastAPI which is build on ASGI to be able to fully take advantage of these improvements.
+config.py now fully supports the definition of AsyncGuards and streaming=true as a request argument.
+We recommend the combination of `gunicorn` and `uvicorn.workers.UvicornWorker`s
+
+### Streamlined prompt, instructions and msg_history arguments into messages
+`Guard.__call` prompt, instruction, reask_prompt and reask_instruction arguments have been streamlined into messages and reask_messages
+Instructions should be specified with the role system and prompts with the role user. Any of the out of the box supported llms that require only one text prompt will automatically have the messages converted to one unless a custom callable is being used.
+```
+# version < 0.6.0
+guard(
+    instructions="you are a funny assistant",
+    prompt="tell me a joke"
+)
+# version >= 0.6.0
+guard(
+    messages=[
+        {"role":"system", "content":"you are a funny assistant"},
+        {"role":"user", "content":"tell me a joke"}
+    ]
+)
+```
+
+### Removal of guardrails OpenAI, Cohere, Anthropic Callables
+These callables are being removed in favor of support through passing no callable and setting the appropriate api key and model argument.
+
+### Prompt no longer a required positional argument on custom callables
+Custom callables will no longer throw an error if the prompt arg is missing in their declaration and guardrails will no longer pass prompt as the first argument. They need to be updated to the messages kwarg to get text input. If a custom callables underlying llm only accepts a single string a helper exists that can compose messages into one otherwise some code to adapt them will be required. 
+
+```py
+from guardrails import messages_to_prompt_string
+
+class CustomCallableCallable(PromptCallableBase):
+    def llm_api(
+        self,
+        *args,
+        **kwargs,
+    ) -> str:
+        messages = kwargs.pop("messages", [])
+        prompt = messages_to_prompt_string(messages)
+
+        llm_string_output = some_llm_call_requiring_prompt(
+            prompt,
+            *args,
+            **kwargs,
+        )
+        return llm_string_output
+```

--- a/docs/migration_guides/0-6-alpha-migration.md
+++ b/docs/migration_guides/0-6-alpha-migration.md
@@ -16,7 +16,7 @@ pip install --pre guardrails-ai
 1. The default on_fail action for validators will change from noop to exception.
 1. In cases where we try and generate structured data, Guardrails will no longer automatically attempt to try and coerce the LLM into giving correctly formatted information.
 1. Guardrails will no longer automatically set a tool selection in the OpenAI callable when initialized using pydantic for initial prompts or reasks
-1. Guard.from_stringis being removed in favor of Guard()
+1. Guard.from_string is being removed in favor of Guard()
 1. Guard.from_pydantic is renamed to Guard.for_pydantic
 1. Guard.from_rail is renamed to Guard.for_rail
 1. Guard.from_rail_string is renamed to guard.for_rail_string

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -29,7 +29,7 @@ const config = {
   markdown: {
     mermaid: true
   },
-  // themes: ['@docusaurus/theme-mermaid', '@docusaurus/theme-classic'],
+  themes: ['@docusaurus/theme-mermaid'],
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
   // to replace "en" with "zh-Hans".

--- a/guardrails/cli/hub/list.py
+++ b/guardrails/cli/hub/list.py
@@ -2,7 +2,6 @@ import os
 import re
 
 from guardrails.cli.hub.hub import hub_command
-from guardrails.cli.hub.utils import get_site_packages_location
 from guardrails.hub_telemetry.hub_tracing import trace
 from .console import console
 
@@ -11,7 +10,9 @@ from .console import console
 @trace(name="guardrails-cli/hub/list")
 def list():
     """List all installed validators."""
-    site_packages = get_site_packages_location()
+    from guardrails.hub.validator_package_service import ValidatorPackageService
+
+    site_packages = ValidatorPackageService.get_site_packages_location()
     hub_init_file = os.path.join(site_packages, "guardrails", "hub", "__init__.py")
 
     installed_validators = []

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -63,7 +63,6 @@ def uninstall(
     """Uninstall a validator from the Hub."""
     from guardrails.hub.validator_package_service import ValidatorPackageService
 
-    print(f"ValidatorPackageService: {ValidatorPackageService}")
     if not package_uri.startswith("hub://"):
         logger.error("Invalid URI!")
         sys.exit(1)

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -9,9 +9,7 @@ import logging
 
 from email.parser import BytesHeaderParser
 from typing import List, Union
-from pydash.strings import snake_case
 
-from guardrails_hub_types import Manifest
 
 json_format: Literal["json"] = "json"
 string_format: Literal["string"] = "string"
@@ -84,16 +82,3 @@ def pip_process(
             e,
         )
         sys.exit(1)
-
-
-def get_org_and_package_dirs(manifest: Manifest) -> List[str]:
-    org_name = manifest.namespace
-    package_name = manifest.package_name
-    org = snake_case(org_name if len(org_name) > 1 else "")
-    package = snake_case(package_name if len(package_name) > 1 else package_name)
-    return list(filter(None, [org, package]))
-
-
-def get_hub_directory(manifest: Manifest, site_packages: str) -> str:
-    org_package = get_org_and_package_dirs(manifest)
-    return os.path.join(site_packages, "guardrails", "hub", *org_package)

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -73,8 +73,8 @@ def pip_process(
             (
                 f"Failed to {action} {package}\n"
                 f"Exit code: {exc.returncode}\n"
-                f"stderr: {(exc.stderr or "").strip()}\n"
-                f"stdout: {(exc.stdout or "").strip()}"
+                f"stderr: {(exc.stderr or '').strip()}\n"
+                f"stdout: {(exc.stdout or '').strip()}"
             )
         )
         # Re-raise the error or handle it accordingly

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -58,7 +58,7 @@ def pip_process(
             except Exception:
                 logger.debug(
                     f"JSON parse exception in decoding output from pip {action}"
-                    f"{package}. Falling back to accumulating the byte stream",
+                    f" {package}. Falling back to accumulating the byte stream",
                 )
             accumulator = {}
             parsed = BytesHeaderParser().parsebytes(result.stdout.encode())
@@ -77,20 +77,13 @@ def pip_process(
                 f"stdout: {(exc.stdout or '').strip()}"
             )
         )
-        # Re-raise the error or handle it accordingly
-        raise
+        sys.exit(1)
     except Exception as e:
         logger.error(
             f"An unexpected exception occurred while trying to {action} {package}!",
             e,
         )
-        raise
-
-
-def get_site_packages_location() -> str:
-    output = pip_process("show", "pip", format=json_format)
-    pip_location = output["Location"]  # type: ignore
-    return pip_location
+        sys.exit(1)
 
 
 def get_org_and_package_dirs(manifest: Manifest) -> List[str]:

--- a/guardrails/cli/hub/utils.py
+++ b/guardrails/cli/hub/utils.py
@@ -58,7 +58,7 @@ def pip_process(
             except Exception:
                 logger.debug(
                     f"JSON parse exception in decoding output from pip {action}"
-                    "{package}. Falling back to accumulating the byte stream",
+                    f"{package}. Falling back to accumulating the byte stream",
                 )
             accumulator = {}
             parsed = BytesHeaderParser().parsebytes(result.stdout.encode())

--- a/guardrails/hub/validator_package_service.py
+++ b/guardrails/hub/validator_package_service.py
@@ -1,20 +1,22 @@
 import importlib
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 
-from typing import List, Literal
+from typing import List, Literal, Optional
 from types import ModuleType
 from pydash.strings import snake_case
+from packaging.utils import canonicalize_name  # PEP 503
 
-from guardrails.classes.generic.stack import Stack
 from guardrails.logger import logger as guardrails_logger
 
 
 from guardrails.cli.hub.utils import pip_process
 from guardrails_hub_types import Manifest
 from guardrails.cli.server.hub_client import get_validator_manifest
+from guardrails.settings import settings
 
 
 json_format: Literal["json"] = "json"
@@ -91,11 +93,13 @@ class ValidatorPackageService:
         Returns:
             Any: The Validator class from the installed module
         """
-        org_package = ValidatorPackageService.get_org_and_package_dirs(manifest)
-        module_name = manifest.module_name
 
-        _relative_path = ".".join([*org_package, module_name])
-        import_line = f"guardrails.hub.{_relative_path}"
+        validator_id = manifest.id
+        import_path = ValidatorPackageService.get_import_path_from_validator_id(
+            validator_id
+        )
+
+        import_line = f"{import_path}"
 
         # Reload or import the module
         return ValidatorPackageService.reload_module(import_line)
@@ -112,14 +116,15 @@ class ValidatorPackageService:
 
     @staticmethod
     def add_to_hub_inits(manifest: Manifest, site_packages: str):
+        validator_id = manifest.id
         org_package = ValidatorPackageService.get_org_and_package_dirs(manifest)
         exports: List[str] = manifest.exports or []
         sorted_exports = sorted(exports, reverse=True)
-        module_name = manifest.module_name
-        relative_path = ".".join([*org_package, module_name])
-        import_line = (
-            f"from guardrails.hub.{relative_path} import {', '.join(sorted_exports)}"
+
+        import_path = ValidatorPackageService.get_import_path_from_validator_id(
+            validator_id
         )
+        import_line = f"from {import_path} import {', '.join(sorted_exports)}"
 
         hub_init_location = os.path.join(
             site_packages, "guardrails", "hub", "__init__.py"
@@ -179,14 +184,29 @@ class ValidatorPackageService:
         return package_path
 
     @staticmethod
-    def get_module_name(package_uri: str):
-        if not package_uri.startswith("hub://"):
+    def get_validator_id(validator_uri: str):
+        if not validator_uri.startswith("hub://"):
             raise InvalidHubInstallURL(
                 "Invalid URI! The package URI must start with 'hub://'"
             )
 
-        module_name = package_uri.replace("hub://", "")
-        return module_name
+        validator_uri_with_version = validator_uri.replace("hub://", "")
+
+        validator_id_version_regex = (
+            r"(?P<validator_id>[\/a-zA-Z0-9\-_]+)(?P<version>.*)"
+        )
+        match = re.match(validator_id_version_regex, validator_uri_with_version)
+        validator_version = None
+
+        if match:
+            validator_id = match.group("validator_id")
+            validator_version = (
+                match.group("version").strip() if match.group("version") else None
+            )
+        else:
+            validator_id = validator_uri_with_version
+
+        return (validator_id, validator_version)
 
     @staticmethod
     def get_install_url(manifest: Manifest) -> str:
@@ -207,18 +227,19 @@ class ValidatorPackageService:
     def run_post_install(
         manifest: Manifest, site_packages: str, logger=guardrails_logger
     ):
-        org_package = ValidatorPackageService.get_org_and_package_dirs(manifest)
+        validator_id = manifest.id
         post_install_script = manifest.post_install
+
         if not post_install_script:
             return
 
-        module_name = manifest.module_name
+        import_path = ValidatorPackageService.get_import_path_from_validator_id(
+            validator_id
+        )
+
         relative_path = os.path.join(
             site_packages,
-            "guardrails",
-            "hub",
-            *org_package,
-            module_name,
+            import_path,
             post_install_script,
         )
 
@@ -256,19 +277,41 @@ class ValidatorPackageService:
         return os.path.join(site_packages, "guardrails", "hub", *org_package)
 
     @staticmethod
+    def get_normalized_package_name(validator_id: str):
+        validator_id_parts = validator_id.split("/")
+        concatanated_package_name = (
+            f"{validator_id_parts[0]}-grhub-{validator_id_parts[1]}"
+        )
+        pep_503_package_name = canonicalize_name(concatanated_package_name)
+        return pep_503_package_name
+
+    @staticmethod
+    def get_import_path_from_validator_id(validator_id):
+        pep_503_package_name = ValidatorPackageService.get_normalized_package_name(
+            validator_id
+        )
+        return pep_503_package_name.replace("-", "_")
+
+    @staticmethod
     def install_hub_module(
-        module_manifest: Manifest,
-        site_packages: str,
+        validator_id: str,
+        validator_version: Optional[str] = "",
         quiet: bool = False,
         upgrade: bool = False,
         logger=guardrails_logger,
     ):
-        install_url = ValidatorPackageService.get_install_url(module_manifest)
-        install_directory = ValidatorPackageService.get_hub_directory(
-            module_manifest, site_packages
+        pep_503_package_name = ValidatorPackageService.get_normalized_package_name(
+            validator_id
         )
+        validator_version = validator_version if validator_version else ""
+        full_package_name = f"{pep_503_package_name}{validator_version}"
 
-        pip_flags = [f"--target={install_directory}", "--no-deps"]
+        guardrails_token = settings.rc.token
+
+        pip_flags = [
+            f"--index-url=https://__token__:{guardrails_token}@e4c4zula06.execute-api.us-east-1.amazonaws.com/simple",
+            "--extra-index-url=https://pypi.org/simple",
+        ]
 
         if upgrade:
             pip_flags.append("--upgrade")
@@ -276,46 +319,9 @@ class ValidatorPackageService:
         if quiet:
             pip_flags.append("-q")
 
-        # Install validator module in namespaced directory under guardrails.hub
-        download_output = pip_process("install", install_url, pip_flags, quiet=quiet)
+        # Install from guardrails hub pypi server with public pypi index as fallback
+        download_output = pip_process(
+            "install", full_package_name, pip_flags, quiet=quiet
+        )
         if not quiet:
             logger.info(download_output)
-
-        # Install validator module's dependencies in normal site-packages directory
-        inspect_output = pip_process(
-            "inspect",
-            flags=[f"--path={install_directory}"],
-            format=json_format,
-            quiet=quiet,
-            no_color=True,
-        )
-
-        # throw if inspect_output is a string. Mostly for pyright
-        if isinstance(inspect_output, str):
-            logger.error("Failed to inspect the installed package!")
-            raise FailedPackageInspection
-
-        dependencies = (
-            Stack(*inspect_output.get("installed", []))
-            .at(0, {})
-            .get("metadata", {})  # type: ignore
-            .get("requires_dist", [])  # type: ignore
-        )
-        requirements = list(filter(lambda dep: "extra" not in dep, dependencies))
-        for req in requirements:
-            if "git+" in req:
-                install_spec = req.replace(" ", "")
-                dep_install_output = pip_process("install", install_spec, quiet=quiet)
-                if not quiet:
-                    logger.info(dep_install_output)
-            else:
-                req_info = Stack(*req.split(" "))
-                name = req_info.at(0, "").strip()  # type: ignore
-                versions = req_info.at(1, "").strip("()")  # type: ignore
-                if name:
-                    install_spec = name if not versions else f"{name}{versions}"
-                    dep_install_output = pip_process(
-                        "install", install_spec, quiet=quiet
-                    )
-                    if not quiet:
-                        logger.info(dep_install_output)

--- a/guardrails/hub/validator_package_service.py
+++ b/guardrails/hub/validator_package_service.py
@@ -289,7 +289,7 @@ class ValidatorPackageService:
         guardrails_token = settings.rc.token
 
         pip_flags = [
-            f"--index-url=https://__token__:{guardrails_token}@e4c4zula06.execute-api.us-east-1.amazonaws.com/simple",
+            f"--index-url=https://__token__:{guardrails_token}@pypi.guardrailsai.com/simple",
             "--extra-index-url=https://pypi.org/simple",
         ]
 

--- a/guardrails/hub/validator_package_service.py
+++ b/guardrails/hub/validator_package_service.py
@@ -209,21 +209,6 @@ class ValidatorPackageService:
         return (validator_id, validator_version)
 
     @staticmethod
-    def get_install_url(manifest: Manifest) -> str:
-        repo = manifest.repository
-        repo_url = repo.url
-        branch = repo.branch
-
-        git_url = repo_url
-        if not repo_url.startswith("git+"):
-            git_url = f"git+{repo_url}"
-
-        if branch is not None:
-            git_url = f"{git_url}@{branch}"
-
-        return git_url
-
-    @staticmethod
     def run_post_install(
         manifest: Manifest, site_packages: str, logger=guardrails_logger
     ):
@@ -270,11 +255,6 @@ class ValidatorPackageService:
                     script for {manifest.id}!
                     """
                 )
-
-    @staticmethod
-    def get_hub_directory(manifest: Manifest, site_packages: str) -> str:
-        org_package = ValidatorPackageService.get_org_and_package_dirs(manifest)
-        return os.path.join(site_packages, "guardrails", "hub", *org_package)
 
     @staticmethod
     def get_normalized_package_name(validator_id: str):

--- a/tests/unit_tests/cli/hub/test_list.py
+++ b/tests/unit_tests/cli/hub/test_list.py
@@ -13,7 +13,7 @@ class TestListCommand:
     @pytest.fixture(autouse=True)
     def setup(self, mocker):
         mocker.patch(
-            "guardrails.cli.hub.utils.get_site_packages_location",
+            "guardrails.hub.validator_package_service.ValidatorPackageService.get_manifest_and_site_packages",
             return_value="/test/site-packages",
         )
 

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -5,46 +5,35 @@ import pytest
 from guardrails_hub_types import Manifest
 from guardrails.cli.hub.uninstall import remove_from_hub_inits
 
-manifest_mock = Manifest(
-    encoder="some_encoder",
-    id="module_id",
-    name="test_module",
-    author={"name": "Author Name", "email": "author@example.com"},
-    maintainers=[{"name": "Maintainer Name", "email": "maintainer@example.com"}],
-    repository={"url": "https://github.com/example/repo"},
-    namespace="guardrails",
-    package_name="test_package",
-    description="Test module",
-    module_name="test_module",
-    exports=["Validator", "Helper"],
+manifest_mock = Manifest.from_dict(
+    {
+        "id": "guardrails/test_package",
+        "name": "test_module",
+        "author": {"name": "Author Name", "email": "author@example.com"},
+        "maintainers": [{"name": "Maintainer Name", "email": "maintainer@example.com"}],
+        "repository": {"url": "https://github.com/example/repo"},
+        "packageName": "test_package",
+        "moduleName": "test_module",
+        "namespace": "guardrails",
+        "description": "Test module",
+        "exports": ["Validator", "Helper"],
+    }
 )
 
 
 def test_remove_from_hub_inits(mocker):
-    mocker.patch(
-        "guardrails.cli.hub.uninstall.get_org_and_package_dirs",
-        return_value=["guardrails", "test_package"],
-    )
     mock_remove_line = mocker.patch("guardrails.cli.hub.uninstall.remove_line")
-    mock_remove_dirs = mocker.patch("shutil.rmtree")
 
     remove_from_hub_inits(manifest_mock, "/site-packages")
 
     expected_calls = [
         call(
             "/site-packages/guardrails/hub/__init__.py",
-            "from guardrails.hub.guardrails.test_package.test_module import "
-            "Validator, Helper",
-        ),
-        call(
-            "/site-packages/guardrails/hub/guardrails/__init__.py",
-            "from guardrails.hub.guardrails.test_package.test_module import "
-            "Validator, Helper",
+            "from guardrails_grhub_test_package import " "Validator, Helper",
         ),
     ]
 
     mock_remove_line.assert_has_calls(expected_calls, any_order=True)
-    mock_remove_dirs.assert_called_once_with("/site-packages/guardrails/hub/guardrails")
 
 
 def test_uninstall_invalid_uri(mocker):
@@ -81,10 +70,7 @@ def test_uninstall_valid_uri(mocker):
         "guardrails.cli.hub.uninstall.get_validator_manifest",
         return_value=manifest_mock,
     )
-    mocker.patch(
-        "guardrails.cli.hub.uninstall.get_site_packages_location",
-        return_value="/site-packages",
-    )
+
     mock_uninstall_hub_module = mocker.patch(
         "guardrails.cli.hub.uninstall.uninstall_hub_module"
     )
@@ -93,9 +79,27 @@ def test_uninstall_valid_uri(mocker):
     )
     mocker.patch("guardrails.cli.hub.uninstall.console")
 
+    validator_package_service_mock = mocker.patch(
+        "guardrails.hub.validator_package_service.ValidatorPackageService",
+    )
+    validator_package_service_mock.get_site_packages_location.return_value = (
+        "/site-packages"
+    )
+
     from guardrails.cli.hub.uninstall import uninstall
 
     uninstall("hub://guardrails/test-validator")
 
-    mock_uninstall_hub_module.assert_called_once_with(manifest_mock, "/site-packages")
+    mock_uninstall_hub_module.assert_called_once_with(manifest_mock)
     mock_remove_from_hub_inits.assert_called_once_with(manifest_mock, "/site-packages")
+
+
+def test_uninstall_hub_module(mocker):
+    mock_pip_process = mocker.patch("guardrails.cli.hub.uninstall.pip_process")
+    from guardrails.cli.hub.uninstall import uninstall_hub_module
+
+    uninstall_hub_module(manifest_mock)
+
+    mock_pip_process.assert_called_once_with(
+        "uninstall", "guardrails-grhub-test-package", flags=["-y"], quiet=True
+    )

--- a/tests/unit_tests/hub/test_hub_install.py
+++ b/tests/unit_tests/hub/test_hub_install.py
@@ -18,7 +18,7 @@ class TestInstall:
     def setup_method(self):
         self.manifest = Manifest.from_dict(
             {
-                "id": "id",
+                "id": "guardrails/id",
                 "name": "name",
                 "author": {"name": "me", "email": "me@me.me"},
                 "maintainers": [],
@@ -74,13 +74,13 @@ class TestInstall:
         )
 
         install(
-            "hub://guardrails/test-validator",
+            "hub://guardrails/id",
             install_local_models=False,
             install_local_models_confirm=lambda: False,
         )
 
         log_calls = [
-            call(level=5, msg="Installing hub://guardrails/test-validator..."),
+            call(level=5, msg="Installing hub://guardrails/id..."),
             call(
                 level=5,
                 msg="Skipping post install, models will not be downloaded for local "
@@ -88,18 +88,16 @@ class TestInstall:
             ),
             call(
                 level=5,
-                msg="✅Successfully installed hub://guardrails/test-validator!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/id\n",  # noqa
+                msg="✅Successfully installed hub://guardrails/id!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/guardrails/id\n",  # noqa
             ),  # noqa
         ]
         assert mock_logger_log.call_count == 3
         mock_logger_log.assert_has_calls(log_calls)
 
-        get_manifest_and_site_packages_mock.assert_called_once_with(
-            "guardrails/test-validator"
-        )
+        get_manifest_and_site_packages_mock.assert_called_once_with("guardrails/id")
 
         mock_pip_install_hub_module.assert_called_once_with(
-            self.manifest, self.site_packages, quiet=ANY, upgrade=ANY, logger=ANY
+            self.manifest.id, validator_version=None, quiet=ANY, upgrade=ANY, logger=ANY
         )
         mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
@@ -116,6 +114,9 @@ class TestInstall:
         )
 
         mock_logger_log = mocker.patch("guardrails.hub.install.cli_logger.log")
+
+        pkg_resources = mocker.patch("guardrails.hub.install.pkg_resources")
+        pkg_resources.get_distribution.return_value.version = "1.0.0"
 
         get_manifest_and_site_packages_mock = mocker.patch(
             "guardrails.hub.validator_package_service.ValidatorPackageService.get_manifest_and_site_packages"
@@ -136,31 +137,29 @@ class TestInstall:
         )
 
         install(
-            "hub://guardrails/test-validator",
+            "hub://guardrails/id",
             install_local_models=True,
             install_local_models_confirm=lambda: True,
         )
 
         log_calls = [
-            call(level=5, msg="Installing hub://guardrails/test-validator..."),
+            call(level=5, msg="Installing hub://guardrails/id..."),
             call(
                 level=5,
                 msg="Installing models locally!",
             ),
             call(
                 level=5,
-                msg="✅Successfully installed hub://guardrails/test-validator!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/id\n",  # noqa
+                msg="✅Successfully installed hub://guardrails/id!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/guardrails/id\n",  # noqa
             ),  # noqa
         ]
         assert mock_logger_log.call_count == 3
         mock_logger_log.assert_has_calls(log_calls)
 
-        get_manifest_and_site_packages_mock.assert_called_once_with(
-            "guardrails/test-validator"
-        )
+        get_manifest_and_site_packages_mock.assert_called_once_with("guardrails/id")
 
         mock_pip_install_hub_module.assert_called_once_with(
-            self.manifest, self.site_packages, quiet=ANY, upgrade=ANY, logger=ANY
+            self.manifest.id, validator_version=None, quiet=ANY, upgrade=ANY, logger=ANY
         )
         mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
@@ -197,31 +196,29 @@ class TestInstall:
         )
 
         install(
-            "hub://guardrails/test-validator",
+            "hub://guardrails/id",
             install_local_models=None,
             install_local_models_confirm=lambda: True,
         )
 
         log_calls = [
-            call(level=5, msg="Installing hub://guardrails/test-validator..."),
+            call(level=5, msg="Installing hub://guardrails/id..."),
             call(
                 level=5,
                 msg="Installing models locally!",
             ),
             call(
                 level=5,
-                msg="✅Successfully installed hub://guardrails/test-validator!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/id\n",  # noqa
+                msg="✅Successfully installed hub://guardrails/id!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://hub.guardrailsai.com/validator/guardrails/id\n",  # noqa
             ),  # noqa
         ]
         assert mock_logger_log.call_count == 3
         mock_logger_log.assert_has_calls(log_calls)
 
-        get_manifest_and_site_packages_mock.assert_called_once_with(
-            "guardrails/test-validator"
-        )
+        get_manifest_and_site_packages_mock.assert_called_once_with("guardrails/id")
 
         mock_pip_install_hub_module.assert_called_once_with(
-            self.manifest, self.site_packages, quiet=ANY, upgrade=ANY, logger=ANY
+            self.manifest.id, validator_version=None, quiet=ANY, upgrade=ANY, logger=ANY
         )
         mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
@@ -258,12 +255,12 @@ class TestInstall:
         )
 
         install(
-            "hub://guardrails/test-validator",
+            "hub://guardrails/id",
             install_local_models_confirm=lambda: True,
         )
 
         log_calls = [
-            call(level=5, msg="Installing hub://guardrails/test-validator..."),
+            call(level=5, msg="Installing hub://guardrails/id..."),
             call(
                 level=5,
                 msg="Installing models locally!",  # noqa
@@ -273,12 +270,10 @@ class TestInstall:
         assert mock_logger_log.call_count == 3
         mock_logger_log.assert_has_calls(log_calls)
 
-        get_manifest_and_site_packages_mock.assert_called_once_with(
-            "guardrails/test-validator"
-        )
+        get_manifest_and_site_packages_mock.assert_called_once_with("guardrails/id")
 
         mock_pip_install_hub_module.assert_called_once_with(
-            self.manifest, self.site_packages, quiet=ANY, upgrade=ANY, logger=ANY
+            self.manifest.id, validator_version=None, quiet=ANY, upgrade=ANY, logger=ANY
         )
         mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
@@ -408,7 +403,7 @@ class TestInstall:
 
         manifest = Manifest.from_dict(
             {
-                "id": "id",
+                "id": "guardrails/test-validator",
                 "name": "name",
                 "author": {"name": "me", "email": "me@me.me"},
                 "maintainers": [],

--- a/tests/unit_tests/hub/test_validator_package_service.py
+++ b/tests/unit_tests/hub/test_validator_package_service.py
@@ -64,9 +64,8 @@ class TestAddToHubInits:
         site_packages = "./site-packages"
 
         hub_init_file = MockFile()
-        ns_init_file = MockFile()
         mock_open = mocker.patch("guardrails.hub.validator_package_service.open")
-        mock_open.side_effect = [hub_init_file, ns_init_file]
+        mock_open.side_effect = [hub_init_file]
 
         mock_hub_read = mocker.patch.object(hub_init_file, "read")
         mock_hub_read.return_value = (
@@ -77,29 +76,14 @@ class TestAddToHubInits:
         hub_write_spy = mocker.spy(hub_init_file, "write")
         hub_close_spy = mocker.spy(hub_init_file, "close")
 
-        mock_ns_read = mocker.patch.object(ns_init_file, "read")
-        mock_ns_read.return_value = (
-            "from guardrails_ai_grhub_id import helper, TestValidator"  # noqa
-        )
-
-        ns_seek_spy = mocker.spy(ns_init_file, "seek")
-        ns_write_spy = mocker.spy(ns_init_file, "write")
-        ns_close_spy = mocker.spy(ns_init_file, "close")
-
-        mock_is_file = mocker.patch(
-            "guardrails.hub.validator_package_service.os.path.isfile"
-        )
-        mock_is_file.return_value = True
-
         from guardrails.hub.validator_package_service import ValidatorPackageService
 
         manifest = cast(Manifest, manifest)
         ValidatorPackageService.add_to_hub_inits(manifest, site_packages)
 
-        assert mock_open.call_count == 2
+        assert mock_open.call_count == 1
         open_calls = [
             call("./site-packages/guardrails/hub/__init__.py", "a+"),
-            call("./site-packages/guardrails/hub/guardrails_ai/__init__.py", "a+"),
         ]
         mock_open.assert_has_calls(open_calls)
 
@@ -107,14 +91,6 @@ class TestAddToHubInits:
         assert mock_hub_read.call_count == 1
         assert hub_write_spy.call_count == 0
         assert hub_close_spy.call_count == 1
-
-        mock_is_file.assert_called_once_with(
-            "./site-packages/guardrails/hub/guardrails_ai/__init__.py"
-        )
-        assert ns_seek_spy.call_count == 1
-        assert mock_ns_read.call_count == 1
-        assert ns_write_spy.call_count == 0
-        assert ns_close_spy.call_count == 1
 
     def test_appends_import_line_if_not_present(self, mocker):
         manifest = Manifest.from_dict(
@@ -135,9 +111,8 @@ class TestAddToHubInits:
         site_packages = "./site-packages"
 
         hub_init_file = MockFile()
-        ns_init_file = MockFile()
         mock_open = mocker.patch("guardrails.hub.validator_package_service.open")
-        mock_open.side_effect = [hub_init_file, ns_init_file]
+        mock_open.side_effect = [hub_init_file]
 
         mock_hub_read = mocker.patch.object(hub_init_file, "read")
         mock_hub_read.return_value = "from guardrails.hub.other_org.other_validator.validator import OtherValidator"  # noqa
@@ -146,27 +121,14 @@ class TestAddToHubInits:
         hub_write_spy = mocker.spy(hub_init_file, "write")
         hub_close_spy = mocker.spy(hub_init_file, "close")
 
-        mock_ns_read = mocker.patch.object(ns_init_file, "read")
-        mock_ns_read.return_value = ""
-
-        ns_seek_spy = mocker.spy(ns_init_file, "seek")
-        ns_write_spy = mocker.spy(ns_init_file, "write")
-        ns_close_spy = mocker.spy(ns_init_file, "close")
-
-        mock_is_file = mocker.patch(
-            "guardrails.hub.validator_package_service.os.path.isfile"
-        )
-        mock_is_file.return_value = True
-
         from guardrails.hub.validator_package_service import ValidatorPackageService
 
         manifest = cast(Manifest, manifest)
         ValidatorPackageService.add_to_hub_inits(manifest, site_packages)
 
-        assert mock_open.call_count == 2
+        assert mock_open.call_count == 1
         open_calls = [
             call("./site-packages/guardrails/hub/__init__.py", "a+"),
-            call("./site-packages/guardrails/hub/guardrails_ai/__init__.py", "a+"),
         ]
         mock_open.assert_has_calls(open_calls)
 
@@ -187,21 +149,6 @@ class TestAddToHubInits:
 
         assert hub_close_spy.call_count == 1
 
-        mock_is_file.assert_called_once_with(
-            "./site-packages/guardrails/hub/guardrails_ai/__init__.py"
-        )
-
-        assert ns_seek_spy.call_count == 2
-        ns_seek_calls = [call(0, 0), call(0, 2)]
-        ns_seek_spy.assert_has_calls(ns_seek_calls)
-
-        assert mock_ns_read.call_count == 1
-        assert ns_write_spy.call_count == 1
-        ns_write_spy.assert_called_once_with(
-            "from guardrails_ai_grhub_id import TestValidator"  # noqa
-        )
-        assert ns_close_spy.call_count == 1
-
     def test_creates_namespace_init_if_not_exists(self, mocker):
         manifest = Manifest.from_dict(
             {
@@ -221,19 +168,11 @@ class TestAddToHubInits:
         site_packages = "./site-packages"
 
         hub_init_file = MockFile()
-        ns_init_file = MockFile()
         mock_open = mocker.patch("guardrails.hub.validator_package_service.open")
-        mock_open.side_effect = [hub_init_file, ns_init_file]
+        mock_open.side_effect = [hub_init_file]
 
         mock_hub_read = mocker.patch.object(hub_init_file, "read")
         mock_hub_read.return_value = "from guardrails_ai_grhub_id import TestValidator"  # noqa
-
-        mock_ns_read = mocker.patch.object(ns_init_file, "read")
-        mock_ns_read.return_value = ""
-
-        ns_seek_spy = mocker.spy(ns_init_file, "seek")
-        ns_write_spy = mocker.spy(ns_init_file, "write")
-        ns_close_spy = mocker.spy(ns_init_file, "close")
 
         mock_is_file = mocker.patch(
             "guardrails.hub.validator_package_service.os.path.isfile"
@@ -245,24 +184,11 @@ class TestAddToHubInits:
         manifest = cast(Manifest, manifest)
         ValidatorPackageService.add_to_hub_inits(manifest, site_packages)
 
-        assert mock_open.call_count == 2
+        assert mock_open.call_count == 1
         open_calls = [
             call("./site-packages/guardrails/hub/__init__.py", "a+"),
-            call("./site-packages/guardrails/hub/guardrails_ai/__init__.py", "w"),
         ]
         mock_open.assert_has_calls(open_calls)
-
-        mock_is_file.assert_called_once_with(
-            "./site-packages/guardrails/hub/guardrails_ai/__init__.py"
-        )
-
-        assert ns_seek_spy.call_count == 0
-        assert mock_ns_read.call_count == 0
-        assert ns_write_spy.call_count == 1
-        ns_write_spy.assert_called_once_with(
-            "from guardrails_ai_grhub_id import TestValidator"  # noqa
-        )
-        assert ns_close_spy.call_count == 1
 
 
 class TestReloadModule:

--- a/tests/unit_tests/hub/test_validator_package_service.py
+++ b/tests/unit_tests/hub/test_validator_package_service.py
@@ -487,53 +487,6 @@ class TestValidatorPackageService:
 
         mock_reload_module.assert_called_once_with("guardrails_grhub_id")
 
-    @pytest.mark.parametrize(
-        "manifest,expected",
-        [
-            (
-                Manifest.from_dict(
-                    {
-                        "id": "guardrails-ai/id",
-                        "name": "name",
-                        "author": {"name": "me", "email": "me@me.me"},
-                        "maintainers": [],
-                        "repository": {"url": "some-repo"},
-                        "namespace": "guardrails-ai",
-                        "packageName": "test-validator",
-                        "moduleName": "test_validator",
-                        "description": "description",
-                        "exports": ["TestValidator"],
-                        "tags": {},
-                    }
-                ),
-                ["guardrails_ai", "test_validator"],
-            ),
-            (
-                Manifest.from_dict(
-                    {
-                        "id": "guardrails-ai/id",
-                        "name": "name",
-                        "author": {"name": "me", "email": "me@me.me"},
-                        "maintainers": [],
-                        "repository": {"url": "some-repo"},
-                        "namespace": "",
-                        "packageName": "test-validator",
-                        "moduleName": "test_validator",
-                        "description": "description",
-                        "exports": ["TestValidator"],
-                        "tags": {},
-                    }
-                ),
-                ["test_validator"],
-            ),
-        ],
-    )
-    def test_get_org_and_package_dirs(self, manifest, expected):
-        from guardrails.hub.validator_package_service import ValidatorPackageService
-
-        actual = ValidatorPackageService.get_org_and_package_dirs(manifest)
-        assert actual == expected
-
     def test_get_module_name_valid(self):
         module_name, module_version = ValidatorPackageService.get_validator_id(
             "hub://test-module>=1.0.0"

--- a/tests/unit_tests/hub/test_validator_package_service.py
+++ b/tests/unit_tests/hub/test_validator_package_service.py
@@ -48,7 +48,7 @@ class TestAddToHubInits:
     def test_closes_early_if_already_added(self, mocker):
         manifest = Manifest.from_dict(
             {
-                "id": "id",
+                "id": "guardrails-ai/id",
                 "name": "name",
                 "author": {"name": "me", "email": "me@me.me"},
                 "maintainers": [],
@@ -69,14 +69,18 @@ class TestAddToHubInits:
         mock_open.side_effect = [hub_init_file, ns_init_file]
 
         mock_hub_read = mocker.patch.object(hub_init_file, "read")
-        mock_hub_read.return_value = "from guardrails.hub.guardrails_ai.test_validator.validator import helper, TestValidator"  # noqa
+        mock_hub_read.return_value = (
+            "from guardrails_ai_grhub_id import helper, TestValidator"  # noqa
+        )
 
         hub_seek_spy = mocker.spy(hub_init_file, "seek")
         hub_write_spy = mocker.spy(hub_init_file, "write")
         hub_close_spy = mocker.spy(hub_init_file, "close")
 
         mock_ns_read = mocker.patch.object(ns_init_file, "read")
-        mock_ns_read.return_value = "from guardrails.hub.guardrails_ai.test_validator.validator import helper, TestValidator"  # noqa
+        mock_ns_read.return_value = (
+            "from guardrails_ai_grhub_id import helper, TestValidator"  # noqa
+        )
 
         ns_seek_spy = mocker.spy(ns_init_file, "seek")
         ns_write_spy = mocker.spy(ns_init_file, "write")
@@ -115,7 +119,7 @@ class TestAddToHubInits:
     def test_appends_import_line_if_not_present(self, mocker):
         manifest = Manifest.from_dict(
             {
-                "id": "id",
+                "id": "guardrails-ai/id",
                 "name": "name",
                 "author": {"name": "me", "email": "me@me.me"},
                 "maintainers": [],
@@ -176,7 +180,7 @@ class TestAddToHubInits:
         hub_write_calls = [
             call("\n"),
             call(
-                "from guardrails.hub.guardrails_ai.test_validator.validator import TestValidator"  # noqa
+                "from guardrails_ai_grhub_id import TestValidator"  # noqa
             ),
         ]
         hub_write_spy.assert_has_calls(hub_write_calls)
@@ -194,14 +198,14 @@ class TestAddToHubInits:
         assert mock_ns_read.call_count == 1
         assert ns_write_spy.call_count == 1
         ns_write_spy.assert_called_once_with(
-            "from guardrails.hub.guardrails_ai.test_validator.validator import TestValidator"  # noqa
+            "from guardrails_ai_grhub_id import TestValidator"  # noqa
         )
         assert ns_close_spy.call_count == 1
 
     def test_creates_namespace_init_if_not_exists(self, mocker):
         manifest = Manifest.from_dict(
             {
-                "id": "id",
+                "id": "guardrails-ai/id",
                 "name": "name",
                 "author": {"name": "me", "email": "me@me.me"},
                 "maintainers": [],
@@ -222,7 +226,7 @@ class TestAddToHubInits:
         mock_open.side_effect = [hub_init_file, ns_init_file]
 
         mock_hub_read = mocker.patch.object(hub_init_file, "read")
-        mock_hub_read.return_value = "from guardrails.hub.guardrails_ai.test_validator.validator import TestValidator"  # noqa
+        mock_hub_read.return_value = "from guardrails_ai_grhub_id import TestValidator"  # noqa
 
         mock_ns_read = mocker.patch.object(ns_init_file, "read")
         mock_ns_read.return_value = ""
@@ -256,7 +260,7 @@ class TestAddToHubInits:
         assert mock_ns_read.call_count == 0
         assert ns_write_spy.call_count == 1
         ns_write_spy.assert_called_once_with(
-            "from guardrails.hub.guardrails_ai.test_validator.validator import TestValidator"  # noqa
+            "from guardrails_ai_grhub_id import TestValidator"  # noqa
         )
         assert ns_close_spy.call_count == 1
 
@@ -417,7 +421,7 @@ class TestRunPostInstall:
         mock_subprocess_check_output.assert_called_once_with(
             [
                 mock_sys_executable,
-                "./site_packages/guardrails/hub/guardrails_ai/test_validator/validator/post_install.py",  # noqa
+                "./site_packages/guardrails_ai_grhub_id/post_install.py",  # noqa
             ]
         )
 
@@ -512,7 +516,7 @@ class TestValidatorPackageService:
                         "author": {"name": "me", "email": "me@me.me"},
                         "maintainers": [],
                         "repository": {"url": "some-repo"},
-                        "namespace": "guardrails-ai",
+                        "namespace": "",
                         "packageName": "test-validator",
                         "moduleName": "test_validator",
                         "description": "description",
@@ -545,6 +549,11 @@ class TestValidatorPackageService:
         mock_pip_process = mocker.patch(
             "guardrails.hub.validator_package_service.pip_process"
         )
+        mock_settings = mocker.patch(
+            "guardrails.hub.validator_package_service.settings"
+        )
+        mock_settings.rc.token = "mock-token"
+
         inspect_report = {
             "installed": [
                 {
@@ -589,8 +598,11 @@ class TestValidatorPackageService:
         pip_calls = [
             call(
                 "install",
-                "mock-install-url",
-                ["--target=mock/install/directory", "--no-deps"],
+                "guardrails-ai-grhub-id",
+                [
+                    "--index-url=https://__token__:mock-token@pypi.guardrailsai.com/simple",
+                    "--extra-index-url=https://pypi.org/simple",
+                ],
                 quiet=False,
             ),
         ]


### PR DESCRIPTION
Changed:
- Updated Installation process to install from Guardrails Hub PyPi
- Removed forced installations to `guardrails/hub` folder in site packages and sequential installations of dependencies
- Support for validator versioning (see examples bellow)
- All installation of validator packages and dependencies fully managed by pip
- Added stderr logging on pip subprocess failures to surface any errors like no matching distributions (when no versions available based on provided version ranges)
- Display which version gets installed on installation messages (stdout)
- No more redundant re-installations since installs now just using pip


Examples:

```bash
$ guardrails hub install hub://guardrails/detect_pii~=1.4
$ guardrails hub install hub://guardrails/detect_pii>=1.4,==1.*
$ guardrails hub hub://guardrails/detect_pii==1.4.0

```

```python
from guardrails import install

install("hub://guardrails/detect_pii~=1.4")
install("hub://guardrails/detect_pii>=1.4,==1.*")
install("hub://guardrails/detect_pii==1.4.1")
install("hub://guardrails/detect_pii>1.0.0,<2")
```

Example Output:

```
Installing hub://guardrails/detect_pii...
✅ Successfully installed guardrails/detect_pii version 1.4.1!
```