### PR TITLE
Introducing Guardrails Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![Discord](https://img.shields.io/discord/1085077079697150023?logo=discord&label=support&link=https%3A%2F%2Fdiscord.gg%2Fgw4cR9QvYE)](https://discord.gg/U9RKkZSBgx)
 [![Static Badge](https://img.shields.io/badge/Docs-blue?link=https%3A%2F%2Fwww.guardrailsai.com%2Fdocs)](https://www.guardrailsai.com/docs)
 [![Static Badge](https://img.shields.io/badge/Blog-blue?link=https%3A%2F%2Fwww.guardrailsai.com%2Fblog)](https://www.guardrailsai.com/blog)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Guardrails%20Guru-006BFF)](https://gurubase.io/g/guardrails)
 
 </div>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Guardrails Guru](https://gurubase.io/g/guardrails) to Gurubase. Guardrails Guru uses the data from this repo and data from the [docs](https://www.guardrailsai.com/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Guardrails Guru", which highlights that Guardrails now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Guardrails Guru in Gurubase, just let me know that's totally fine.
