### PR TITLE
Fix Terraform code in continuous_integration_continuous_deployment.md

### DIFF
--- a/docs/how_to_guides/continuous_integration_continuous_deployment.md
+++ b/docs/how_to_guides/continuous_integration_continuous_deployment.md
@@ -639,7 +639,7 @@ resource "aws_lb_listener" "app_lb_listener" {
 resource "aws_lb_target_group" "app_lb" {
   name        = "${local.deployment_name}-nlb-tg"
   protocol    = "TCP"
-  port        = 80
+  port        = var.backend_server_port
   vpc_id      = aws_vpc.backend.id
   target_type = "ip"
 
@@ -650,6 +650,7 @@ resource "aws_lb_target_group" "app_lb" {
     timeout             = "3"
     unhealthy_threshold = "3"
     path                = "/"
+    port                = var.backend_server_port
   }
 
   lifecycle {


### PR DESCRIPTION
There's currently a mismatch between the load balancer listener (port 80) and the container port (8000). Because of this, the task never becomes healthy (since the health checks are directed towards the wrong port).