### PR TITLE
Implemented redaction functions to obscure sensitive information in strings

### DIFF
--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union, List
 from opentelemetry.baggage import get_baggage
 from opentelemetry import context
 from opentelemetry.context import Context
@@ -185,19 +185,30 @@ def can_convert_to_dict(s: str) -> bool:
 def recursive_key_operation(
     data: Optional[Union[Dict[str, Any], List[Any], str]],
     operation: Callable[[str], str],
-    keys_to_match: List[str] = ["key", "token"],
+    keys_to_match: List[str] = ["key", "token", "password"],
 ) -> Optional[Union[Dict[str, Any], List[Any], str]]:
-    """Recursively checks if any key in the dictionary or JSON object is
-    present in keys_to_match and applies the operation on the corresponding
-    value.
+    """Recursively traverses a dictionary, list, or JSON string and applies a
+    specified operation to the values of keys that match any in the
+    `keys_to_match` list. This function is useful for masking sensitive data
+    (e.g., keys, tokens, passwords) in nested structures.
 
     Args:
-        data (dict or list or str): The dictionary or JSON object to traverse.
-        operation (function): The operation to perform on the matched values.
-        keys_to_match (list): List of keys to match.
+        data (Optional[Union[Dict[str, Any], List[Any], str]]): The input data
+            to traverse. This can bea dictionary, list, or JSON string. If a
+            JSON string is provided, it will be parsed into a dictionary before
+            processing.
+
+        operation (Callable[[str], str]): A function that takes a string value
+            and returns a modified string. This operation is applied to the values
+            of keys that match any in `keys_to_match`.
+        keys_to_match (List[str]): A list of keys to search for in the data. If
+            a key matche any in this list, the corresponding value will be processed
+            by the `operation`. Defaults to ["key", "token", "password"].
 
     Returns:
-        dict or list or str: the modified dictionary, list or string.
+        Optional[Union[Dict[str, Any], List[Any], str]]: The modified data structure
+        with the operation applied to the values of matched keys. The return type
+        matches the input type (dict, list, or str).
     """
     if isinstance(data, str) and can_convert_to_dict(data):
         data_dict = json.loads(data)

--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -162,7 +162,7 @@ def ismatchingkey(
     return False
 
 
-def can_convert_to_dict(s):
+def can_convert_to_dict(s: str) -> bool:
     """Check if a string can be converted to a dictionary.
 
     This function attempts to load the input string as JSON. If successful,
@@ -182,15 +182,19 @@ def can_convert_to_dict(s):
         return False
 
 
-def recursive_key_operation(data, operation, keys_to_match=["key", "token"]):
+def recursive_key_operation(
+    data: Dict[str, Any] | List[Any] | str,
+    operation: Callable[[str], str],
+    keys_to_match: List[str] = ["key", "token"],
+) -> Dict[str, Any] | List[Any] | str:
     """Recursively checks if any key in the dictionary or JSON object is
     present in keys_to_match and applies the operation on the corresponding
     value.
 
     Args:
         data (dict or list or str): The dictionary or JSON object to traverse.
-        keys_to_match (list): List of keys to match.
         operation (function): The operation to perform on the matched values.
+        keys_to_match (list): List of keys to match.
 
     Returns:
         dict or list or str: the modified dictionary, list or string.

--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -186,7 +186,7 @@ def recursive_key_operation(
     data: Dict[str, Any] | List[Any] | str,
     operation: Callable[[str], str],
     keys_to_match: List[str] = ["key", "token"],
-) -> Dict[str, Any] | List[Any] | str:
+) -> Optional[Union[Dict[str, Any], List[Any], str]]:
     """Recursively checks if any key in the dictionary or JSON object is
     present in keys_to_match and applies the operation on the corresponding
     value.

--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -204,7 +204,7 @@ def recursive_key_operation(
         data = str(recursive_key_operation(data_dict, operation, keys_to_match))
     elif isinstance(data, dict):
         for key, value in data.items():
-            if ismatchingkey(key, keys_to_match) and isinstance(value, str):
+            if ismatchingkey(key, tuple(keys_to_match)) and isinstance(value, str):
                 # Apply the operation to the value of the matched key
                 data[key] = operation(value)
             else:

--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -188,12 +188,12 @@ def recursive_key_operation(data, operation, keys_to_match=["key", "token"]):
     value.
 
     Args:
-        data (dict or list): The dictionary or JSON object to traverse.
+        data (dict or list or str): The dictionary or JSON object to traverse.
         keys_to_match (list): List of keys to match.
         operation (function): The operation to perform on the matched values.
 
     Returns:
-        dict or list: The updated dictionary or JSON object.
+        dict or list or str: the modified dictionary, list or string.
     """
     if isinstance(data, str) and can_convert_to_dict(data):
         data_dict = json.loads(data)

--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -183,7 +183,7 @@ def can_convert_to_dict(s: str) -> bool:
 
 
 def recursive_key_operation(
-    data: Dict[str, Any] | List[Any] | str,
+    data: Optional[Union[Dict[str, Any], List[Any], str]],
     operation: Callable[[str], str],
     keys_to_match: List[str] = ["key", "token"],
 ) -> Optional[Union[Dict[str, Any], List[Any], str]]:

--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -124,3 +124,90 @@ def add_user_attributes(span: Span):
     except Exception as e:
         logger.warning("Error loading baggage user information", e)
         pass
+
+
+def redact(value: str) -> str:
+    """Redacts all but the last four characters of the given string.
+
+    Args:
+        value (str): The string to be redacted.
+
+    Returns:
+        str: The redacted string with all but the last four characters
+              replaced by asterisks.
+    """
+    redaction_length = len(value) - 4
+    stars = "*" * redaction_length
+    return f"{stars}{value[-4:]}"
+
+
+def ismatchingkey(
+    target_key: str,
+    keys_to_match: tuple[str, ...] = ("key", "token", "password"),
+) -> bool:
+    """Check if the target key contains any of the specified keys to match.
+
+    Args:
+        target_key (str): The key to be checked.
+        keys_to_match (tuple[str, ...], optional): A tuple of keys to match
+                against the target key. Defaults to ("key", "token").
+
+    Returns:
+        bool: True if any of the keys to match are found in the target key,
+              False otherwise.
+    """
+    for k in keys_to_match:
+        if k in target_key:
+            return True
+    return False
+
+
+def can_convert_to_dict(s):
+    """Check if a string can be converted to a dictionary.
+
+    This function attempts to load the input string as JSON. If successful,
+    it returns True, indicating that the string can be converted to a dictionary.
+    Otherwise, it catches ValueError and TypeError exceptions and returns False.
+
+    Args:
+        s (str): The input string to be checked.
+
+    Returns:
+        bool: True if the string can be converted to a dictionary, False otherwise.
+    """
+    try:
+        json.loads(s)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def recursive_key_operation(data, operation, keys_to_match=["key", "token"]):
+    """Recursively checks if any key in the dictionary or JSON object is
+    present in keys_to_match and applies the operation on the corresponding
+    value.
+
+    Args:
+        data (dict or list): The dictionary or JSON object to traverse.
+        keys_to_match (list): List of keys to match.
+        operation (function): The operation to perform on the matched values.
+
+    Returns:
+        dict or list: The updated dictionary or JSON object.
+    """
+    if isinstance(data, str) and can_convert_to_dict(data):
+        data_dict = json.loads(data)
+        data = str(recursive_key_operation(data_dict, operation, keys_to_match))
+    elif isinstance(data, dict):
+        for key, value in data.items():
+            if ismatchingkey(key, keys_to_match) and isinstance(value, str):
+                # Apply the operation to the value of the matched key
+                data[key] = operation(value)
+            else:
+                # Recursively process nested dictionaries or lists
+                data[key] = recursive_key_operation(value, operation, keys_to_match)
+    elif isinstance(data, list):
+        for i in range(len(data)):
+            data[i] = recursive_key_operation(data[i], operation, keys_to_match)
+
+    return data

--- a/guardrails/telemetry/open_inference.py
+++ b/guardrails/telemetry/open_inference.py
@@ -98,12 +98,18 @@ def trace_llm_call(
                     )
 
     ser_invocation_parameters = serialize(invocation_parameters)
-    if ser_invocation_parameters:
-        ser_invocation_parameters = recursive_key_operation(
-            ser_invocation_parameters, redact
-        )
+    redacted_ser_invocation_parameters = recursive_key_operation(
+        ser_invocation_parameters, redact
+    )
+    reser_invocation_parameters = (
+        json.dumps(redacted_ser_invocation_parameters)
+        if isinstance(redacted_ser_invocation_parameters, dict)
+        or isinstance(redacted_ser_invocation_parameters, list)
+        else redacted_ser_invocation_parameters
+    )
+    if reser_invocation_parameters:
         current_span.set_attribute(
-            "llm.invocation_parameters", ser_invocation_parameters
+            "llm.invocation_parameters", reser_invocation_parameters
         )
 
     ser_model_name = serialize(model_name)

--- a/guardrails/telemetry/open_inference.py
+++ b/guardrails/telemetry/open_inference.py
@@ -1,6 +1,12 @@
 from typing import Any, Dict, List, Optional
 
-from guardrails.telemetry.common import get_span, to_dict, serialize
+from guardrails.telemetry.common import (
+    get_span,
+    to_dict,
+    serialize,
+    recursive_key_operation,
+    redact,
+)
 
 
 def trace_operation(
@@ -93,6 +99,9 @@ def trace_llm_call(
 
     ser_invocation_parameters = serialize(invocation_parameters)
     if ser_invocation_parameters:
+        ser_invocation_parameters = recursive_key_operation(
+            ser_invocation_parameters, redact
+        )
         current_span.set_attribute(
             "llm.invocation_parameters", ser_invocation_parameters
         )

--- a/guardrails/telemetry/open_inference.py
+++ b/guardrails/telemetry/open_inference.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, List, Optional
 
 from guardrails.telemetry.common import (

--- a/tests/unit_tests/redaction/test_matching_key.py
+++ b/tests/unit_tests/redaction/test_matching_key.py
@@ -1,0 +1,25 @@
+import unittest
+from guardrails.telemetry.common import ismatchingkey
+
+
+class TestIsMatchingKey(unittest.TestCase):
+    def test_key_matches_with_default_keys(self):
+        self.assertTrue(ismatchingkey("api_key"))
+        self.assertTrue(ismatchingkey("user_token"))
+        self.assertFalse(ismatchingkey("username"))
+        self.assertTrue(ismatchingkey("password"))
+
+    def test_key_matches_with_custom_keys(self):
+        self.assertTrue(ismatchingkey("api_secret", keys_to_match=("secret",)))
+        self.assertTrue(ismatchingkey("client_id", keys_to_match=("id",)))
+        self.assertFalse(ismatchingkey("session", keys_to_match=("key", "token")))
+
+    def test_empty_key(self):
+        self.assertFalse(ismatchingkey("", keys_to_match=("key", "token")))
+
+    def test_empty_keys_to_match(self):
+        self.assertFalse(ismatchingkey("key", keys_to_match=()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/redaction/test_recursive_redaction.py
+++ b/tests/unit_tests/redaction/test_recursive_redaction.py
@@ -40,7 +40,7 @@ class TestRecursiveKeyOperation(unittest.TestCase):
         self.assertEqual(result, data)
 
     def test_non_string_value(self):
-        data = {'key': 123, 'another_key': 'value'}
+        data = {"key": 123, "another_key": "value"}
         result = recursive_key_operation(data, redact)
         self.assertEqual(result, data)
 

--- a/tests/unit_tests/redaction/test_recursive_redaction.py
+++ b/tests/unit_tests/redaction/test_recursive_redaction.py
@@ -1,0 +1,49 @@
+import unittest
+from guardrails.telemetry.common import recursive_key_operation, redact
+import ast
+
+
+# Test suite for recursive_key_operation function
+class TestRecursiveKeyOperation(unittest.TestCase):
+    def test_list(self):
+        data = '{"init_args": [], "init_kwargs": {"model": "gpt-4o-mini", \
+            "api_base": "https://api.openai.com/v1", "api_key": "sk-1234"}}'
+        result = recursive_key_operation(data, redact)
+        assert ast.literal_eval(result)["init_kwargs"]["api_key"] == "***1234"
+
+    def test_dict_kwargs(self):
+        data = {
+            "index": "0",
+            "api": '{"init_args": [], "init_kwargs": {"model": "gpt-4o-mini",\
+                "api_base": "https://api.openai.com/v1", "api_key": "sk-1234"}}',
+            "messages": None,
+            "prompt_params": "{}",
+            "output_schema": '{"type": "string"}',
+            "output": None,
+        }
+        result = recursive_key_operation(data, redact)
+        assert ast.literal_eval(result["api"])["init_kwargs"]["api_key"] == "***1234"
+
+    def test_nomatch(self):
+        data = {"somekey": "soemvalue"}
+        result = recursive_key_operation(data, redact)
+        self.assertEqual(result, data)
+
+    # def test_empty_dict(self):
+    #     data = {}
+    #     result = recursive_key_operation(data, redact)
+    #     self.assertEqual(result, data)
+
+    # def test_empty_list(self):
+    #     data = []
+    #     result = recursive_key_operation(data, redact)
+    #     self.assertEqual(result, data)
+
+    # def test_non_string_value(self):
+    #     data = {'key': 123, 'another_key': 'value'}
+    #     result = recursive_key_operation(data, redact)
+    #     self.assertEqual(result, data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/redaction/test_recursive_redaction.py
+++ b/tests/unit_tests/redaction/test_recursive_redaction.py
@@ -29,20 +29,20 @@ class TestRecursiveKeyOperation(unittest.TestCase):
         result = recursive_key_operation(data, redact)
         self.assertEqual(result, data)
 
-    # def test_empty_dict(self):
-    #     data = {}
-    #     result = recursive_key_operation(data, redact)
-    #     self.assertEqual(result, data)
+    def test_empty_dict(self):
+        data = {}
+        result = recursive_key_operation(data, redact)
+        self.assertEqual(result, data)
 
-    # def test_empty_list(self):
-    #     data = []
-    #     result = recursive_key_operation(data, redact)
-    #     self.assertEqual(result, data)
+    def test_empty_list(self):
+        data = []
+        result = recursive_key_operation(data, redact)
+        self.assertEqual(result, data)
 
-    # def test_non_string_value(self):
-    #     data = {'key': 123, 'another_key': 'value'}
-    #     result = recursive_key_operation(data, redact)
-    #     self.assertEqual(result, data)
+    def test_non_string_value(self):
+        data = {'key': 123, 'another_key': 'value'}
+        result = recursive_key_operation(data, redact)
+        self.assertEqual(result, data)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/redaction/test_redaction.py
+++ b/tests/unit_tests/redaction/test_redaction.py
@@ -1,0 +1,38 @@
+import unittest
+from guardrails.telemetry.common import redact
+
+
+class TestRedactFunction(unittest.TestCase):
+    def test_redact_long_string(self):
+        self.assertEqual(redact("supersecretpassword"), "***************word")
+
+    def test_redact_short_string(self):
+        self.assertEqual(redact("test"), "test")
+
+    def test_open_ai_example_key(self):
+        self.assertEqual(
+            redact("sk-1234abcdefghijklmnopqrstuvwxhp37"),
+            "*******************************hp37",
+        )
+
+    def test_redact_very_short_string(self):
+        self.assertEqual(redact("abc"), "abc")
+
+    def test_redact_empty_string(self):
+        self.assertEqual(redact(""), "")
+
+    def test_redact_exact_length(self):
+        self.assertEqual(redact("1234"), "1234")
+
+    def test_redact_special_characters(self):
+        self.assertEqual(redact("ab!@#12"), "***@#12")
+
+    def test_redact_single_character(self):
+        self.assertEqual(redact("a"), "a")
+
+    def test_redact_spaces(self):
+        self.assertEqual(redact("      test"), "******test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/redaction/test_redaction.py
+++ b/tests/unit_tests/redaction/test_redaction.py
@@ -11,8 +11,8 @@ class TestRedactFunction(unittest.TestCase):
 
     def test_open_ai_example_key(self):
         self.assertEqual(
-            redact("sk-1234abcdefghijklmnopqrstuvwxhp37"),
-            "*******************************hp37",
+            redact("sk-hp37"),
+            "***hp37",
         )
 
     def test_redact_very_short_string(self):


### PR DESCRIPTION
- added below functions in common.py
   - [redact]
   - [ismatchingkey](https://github.com/guardrails-ai/guardrails/compare/main...abhishek9sharma:guardrails:main#diff-17ac5d80046e0124d7818ae1e1c56afe9ce6f7a9211fb039d63fa801953bca3dR144)
   - [can_convert_to_dict](https://github.com/guardrails-ai/guardrails/compare/main...abhishek9sharma:guardrails:main#diff-17ac5d80046e0124d7818ae1e1c56afe9ce6f7a9211fb039d63fa801953bca3dR165)
   - [recursive_key_operation](https://github.com/guardrails-ai/guardrails/compare/main...abhishek9sharma:guardrails:main#diff-17ac5d80046e0124d7818ae1e1c56afe9ce6f7a9211fb039d63fa801953bca3dR185)
   
   - Fix for the bug. https://github.com/guardrails-ai/guardrails/issues/1213