### PR TITLE
Fix Async Stream Contexts

### DIFF
--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -218,6 +218,7 @@ class LiteLLMCallable(PromptCallableBase):
             llm_response = cast(Iterator[str], response)
             return LLMResponse(
                 output="",
+                # FIXME: Why is this different from the async streaming implementation?
                 stream_output=llm_response,
             )
 
@@ -491,6 +492,7 @@ class ArbitraryCallable(PromptCallableBase):
             llm_response = cast(Iterator[str], llm_response)
             return LLMResponse(
                 output="",
+                # FIXME: Why is this different from the async streaming implementation?
                 stream_output=llm_response,
             )
 
@@ -685,6 +687,8 @@ class AsyncLiteLLMCallable(AsyncPromptCallableBase):
             # response = cast(AsyncIterator[str], response)
             return LLMResponse(
                 output="",
+                # FIXME: Why is this different from the synchronous streaming implementation?  ## noqa: E501
+                # This shouldn't be necessary: https://docs.litellm.ai/docs/completion/stream#async-streaming
                 async_stream_output=response.completion_stream,  # pyright: ignore[reportGeneralTypeIssues]
             )
 
@@ -842,6 +846,8 @@ class AsyncArbitraryCallable(AsyncPromptCallableBase):
             # the callable returns a generator object
             return LLMResponse(
                 output="",
+                # FIXME: Why is this different from the synchronous streaming implementation?  ## noqa: E501
+                # This shouldn't be necessary: https://docs.litellm.ai/docs/completion/stream#async-streaming
                 async_stream_output=output.completion_stream,
             )
 

--- a/guardrails/run/async_stream_runner.py
+++ b/guardrails/run/async_stream_runner.py
@@ -5,7 +5,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Union,
     cast,
 )
 
@@ -16,7 +15,6 @@ from guardrails.classes.history import Call, Inputs, Iteration, Outputs
 from guardrails.classes.output_type import OutputTypes
 from guardrails.llm_providers import (
     AsyncPromptCallableBase,
-    PromptCallableBase,
 )
 from guardrails.logger import set_scope
 from guardrails.run import StreamRunner
@@ -279,32 +277,3 @@ class AsyncStreamRunner(AsyncRunner, StreamRunner):
         iteration.outputs.parsed_output = parsed_fragment or fragment  # type: ignore
         iteration.outputs.validation_response = validation_response
         iteration.outputs.guarded_output = valid_op
-
-    def get_chunk_text(self, chunk: Any, api: Union[PromptCallableBase, None]) -> str:
-        """Get the text from a chunk."""
-        chunk_text = ""
-
-        if not chunk.choices or len(chunk.choices) == 0:
-            return chunk_text
-
-        try:
-            finished = chunk.choices[0].finish_reason
-            content = chunk.choices[0].delta.content
-            if not finished and content:
-                chunk_text = content
-        except Exception:
-            try:
-                finished = chunk.choices[0].finish_reason
-                content = chunk.choices[0].text
-                if not finished and content:
-                    chunk_text = content
-            except Exception:
-                try:
-                    chunk_text = chunk
-                except Exception as e:
-                    raise ValueError(
-                        f"Error getting chunk from stream: {e}. "
-                        "Non-OpenAI API callables expected to return "
-                        "a generator of strings."
-                    ) from e
-        return chunk_text

--- a/guardrails/run/async_stream_runner.py
+++ b/guardrails/run/async_stream_runner.py
@@ -279,10 +279,11 @@ class AsyncStreamRunner(AsyncRunner, StreamRunner):
                     validation_response = cast(dict, validated_fragment)
                 yield ValidationOutcome(
                     call_id=call_log.id,  # type: ignore
-                    raw_llm_output=fragment,
+                    raw_llm_output=validated_fragment,
                     validated_output=chunk_text,
                     validation_passed=validated_fragment is not None,
                 )
+                fragment = ""
 
         iteration.outputs.raw_output = fragment
         # FIXME: Handle case where parsing continuously fails/is a reask

--- a/guardrails/run/async_stream_runner.py
+++ b/guardrails/run/async_stream_runner.py
@@ -122,7 +122,6 @@ class AsyncStreamRunner(AsyncRunner, StreamRunner):
         refrain_triggered = False
         validation_passed = True
 
-        # TODO: reset the context vars when finished
         context = copy_context()
         stream_context_vars: ContextVar[Dict[str, ContextVar[List[str]]]] = ContextVar(
             "stream_context"

--- a/guardrails/run/stream_runner.py
+++ b/guardrails/run/stream_runner.py
@@ -17,6 +17,7 @@ from guardrails.utils.parsing_utils import (
 from guardrails.actions.reask import ReAsk, SkeletonReAsk
 from guardrails.constants import pass_status
 from guardrails.telemetry import trace_stream_step
+from guardrails.utils.safe_get import safe_get
 
 
 class StreamRunner(Runner):
@@ -251,29 +252,62 @@ class StreamRunner(Runner):
             return False
 
     def get_chunk_text(self, chunk: Any, api: Union[PromptCallableBase, None]) -> str:
-        """Get the text from a chunk."""
-        chunk_text = ""
-        try:
-            finished = chunk.choices[0].finish_reason
-            content = chunk.choices[0].delta.content
-            if not finished and content:
-                chunk_text = content
-        except Exception:
-            try:
-                finished = chunk.choices[0].finish_reason
-                content = chunk.choices[0].text
-                if not finished and content:
-                    chunk_text = content
-            except Exception:
-                try:
-                    chunk_text = chunk
-                except Exception as e:
-                    raise ValueError(
-                        f"Error getting chunk from stream: {e}. "
-                        "Non-OpenAI API callables expected to return "
-                        "a generator of strings."
-                    ) from e
-        return chunk_text
+        """
+        Get the text from a chunk.
+
+        chunk is assumed to be an Iterator of either string or ChatCompletionChunk
+
+        These types are not properly enforced upstream so we must use reflection
+        """
+        # Safeguard against None
+        # which can happen when the user provides
+        # custom LLM wrappers
+        if not chunk:
+            return ""
+        elif isinstance(chunk, str):
+            # If chunk is a string, return it
+            return chunk
+        elif hasattr(chunk, "choices") and hasattr(chunk.choices, "__iter__"):
+            # If chunk is a ChatCompletionChunk, return the text
+            # from the first choice
+            chunk_text = ""
+            first_choice = safe_get(chunk.choices, 0)
+            if not first_choice:
+                return chunk_text
+
+            if hasattr(first_choice, "delta") and hasattr(
+                first_choice.delta, "content"
+            ):
+                chunk_text = first_choice.delta.content
+            elif hasattr(first_choice, "text"):
+                chunk_text = first_choice.text
+            else:
+                # If chunk is not a string or ChatCompletionChunk, raise an error
+                raise ValueError(
+                    "chunk.choices[0] does not have "
+                    "delta.content or text. "
+                    "Non-OpenAI compliant callables must return "
+                    "a generator of strings."
+                )
+
+            if not chunk_text:
+                # If chunk_text is empty, return an empty string
+                return ""
+            elif not isinstance(chunk_text, str):
+                # If chunk_text is not a string, raise an error
+                raise ValueError(
+                    "Chunk text is not a string. "
+                    "Non-OpenAI compliant callables must return "
+                    "a generator of strings."
+                )
+            return chunk_text
+        else:
+            # If chunk is not a string or ChatCompletionChunk, raise an error
+            raise ValueError(
+                "Chunk is not a string or ChatCompletionChunk. "
+                "Non-OpenAI compliant callables must return "
+                "a generator of strings."
+            )
 
     def parse(
         self, output: str, output_schema: Dict[str, Any], *, verified: set, **kwargs

--- a/guardrails/run/stream_runner.py
+++ b/guardrails/run/stream_runner.py
@@ -252,12 +252,13 @@ class StreamRunner(Runner):
             return False
 
     def get_chunk_text(self, chunk: Any, api: Union[PromptCallableBase, None]) -> str:
-        """
-        Get the text from a chunk.
+        """Get the text from a chunk.
 
-        chunk is assumed to be an Iterator of either string or ChatCompletionChunk
+        chunk is assumed to be an Iterator of either string or
+        ChatCompletionChunk
 
-        These types are not properly enforced upstream so we must use reflection
+        These types are not properly enforced upstream so we must use
+        reflection
         """
         # Safeguard against None
         # which can happen when the user provides

--- a/guardrails/run/stream_runner.py
+++ b/guardrails/run/stream_runner.py
@@ -240,6 +240,11 @@ class StreamRunner(Runner):
     def is_last_chunk(self, chunk: Any, api: Union[PromptCallableBase, None]) -> bool:
         """Detect if chunk is final chunk."""
         try:
+            if (
+                not chunk.choices or len(chunk.choices) == 0
+            ) and chunk.usage is not None:
+                # This is the last extra chunk for usage statistics
+                return True
             finished = chunk.choices[0].finish_reason
             return finished is not None
         except (AttributeError, TypeError):

--- a/guardrails/utils/safe_get.py
+++ b/guardrails/utils/safe_get.py
@@ -12,9 +12,12 @@ def safe_get_with_brackets(
         return value
     except Exception as e:
         logger.debug(
-            f"Failed to get value for key: {key} out of container: {container}!"
+            f"""
+            Failed to get value for key: {key} out of container: {container}.
+            Reason: {e}
+            Fallbacking to default value...
+            """
         )
-        logger.debug(e)
         return default
 
 

--- a/guardrails/validator_service/async_validator_service.py
+++ b/guardrails/validator_service/async_validator_service.py
@@ -84,6 +84,8 @@ class AsyncValidatorService(ValidatorServiceBase):
         metadata: Dict,
         absolute_property_path: str,
         stream: Optional[bool] = False,
+        *,
+        reference_path: Optional[str] = None,
         **kwargs,
     ) -> ValidatorRun:
         validator_logs = self.before_run_validator(
@@ -96,6 +98,7 @@ class AsyncValidatorService(ValidatorServiceBase):
             metadata,
             stream,
             validation_session_id=iteration.id,
+            reference_path=reference_path,
             **kwargs,
         )
 
@@ -111,6 +114,7 @@ class AsyncValidatorService(ValidatorServiceBase):
                     result.metadata or {},
                     stream,
                     validation_session_id=iteration.id,
+                    reference_path=reference_path,
                     **kwargs,
                 )
             value = self.perform_correction(
@@ -160,6 +164,7 @@ class AsyncValidatorService(ValidatorServiceBase):
                     metadata,
                     absolute_property_path,
                     stream=stream,
+                    reference_property_path=reference_property_path,
                     **kwargs,
                 )
             )
@@ -277,6 +282,7 @@ class AsyncValidatorService(ValidatorServiceBase):
                     metadata,
                     absolute_path,
                     stream=stream,
+                    reference_path=reference_path,
                     **kwargs,
                 )
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ authorized_licenses = [
     "python software foundation",
     "python software foundation license",
     "zpl 2.1",
+    "mit and python-2.0"
 ]
 unauthorized_licenses = [
     "gpl v3",

--- a/tests/unit_tests/validator_service/test_async_validator_service.py
+++ b/tests/unit_tests/validator_service/test_async_validator_service.py
@@ -503,7 +503,12 @@ class TestRunValidator:
 
         assert mock_run_validator_async.call_count == 1
         mock_run_validator_async.assert_called_once_with(
-            validator, "value", {}, False, validation_session_id=iteration.id
+            validator,
+            "value",
+            {},
+            False,
+            validation_session_id=iteration.id,
+            reference_path=None,
         )
 
         assert mock_after_run_validator.call_count == 1
@@ -562,7 +567,12 @@ class TestRunValidator:
 
         assert mock_run_validator_async.call_count == 1
         mock_run_validator_async.assert_called_once_with(
-            validator, "value", {}, False, validation_session_id=iteration.id
+            validator,
+            "value",
+            {},
+            False,
+            validation_session_id=iteration.id,
+            reference_path=None,
         )
 
         assert mock_after_run_validator.call_count == 1
@@ -625,7 +635,12 @@ class TestRunValidator:
 
         assert mock_run_validator_async.call_count == 1
         mock_run_validator_async.assert_called_once_with(
-            validator, "value", {}, False, validation_session_id=iteration.id
+            validator,
+            "value",
+            {},
+            False,
+            validation_session_id=iteration.id,
+            reference_path=None,
         )
 
         assert mock_after_run_validator.call_count == 1
@@ -699,13 +714,21 @@ class TestRunValidator:
         assert mock_run_validator_async.call_count == 2
         mock_run_validator_async.assert_has_calls(
             [
-                call(validator, "value", {}, False, validation_session_id=iteration.id),
+                call(
+                    validator,
+                    "value",
+                    {},
+                    False,
+                    validation_session_id=iteration.id,
+                    reference_path=None,
+                ),
                 call(
                     validator,
                     "fixed-value",
                     {},
                     False,
                     validation_session_id=iteration.id,
+                    reference_path=None,
                 ),
             ]
         )


### PR DESCRIPTION
### Summary

- use context vars to separate streams when async streaming
- handle final usage chunk gracefully
- Fixes https://github.com/guardrails-ai/guardrails/issues/1255
- Partially fixes: https://github.com/guardrails-ai/guardrails/issues/1236
_Does not provide support for usage statistics when streaming, but no longer fails when they're enabled._


### TODO

- [x] Fix for multiple validators