### PR TITLE
update lxml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ guardrails = "guardrails.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-lxml = "^4.9.3"
+lxml = "^5.3.0"
 openai = "^1.30.1"
 rich = "^13.6.0"
 pydantic = ">=2.0.0, <3.0"


### PR DESCRIPTION
This updates `lxml` to a version that is compatible with PyDanticAI's DuckDuckGo search tool 

https://ai.pydantic.dev/common-tools/ 