### PR TITLE
add api key to server ci tests

### DIFF
--- a/server_ci/tests/test_server.py
+++ b/server_ci/tests/test_server.py
@@ -22,7 +22,7 @@ openai.api_key = os.getenv("OPENAI_API_KEY") or "some key"
 )
 def test_guard_validation(mock_llm_output, validation_output, validation_passed, error):
     settings.use_server = True
-    guard = Guard(name="test-guard")
+    guard = Guard(name="test-guard", api_key="auth-stub")
     if error:
         with pytest.raises(Exception):
             validation_outcome = guard.validate(mock_llm_output)
@@ -35,7 +35,7 @@ def test_guard_validation(mock_llm_output, validation_output, validation_passed,
 @pytest.mark.asyncio
 async def test_async_guard_validation():
     settings.use_server = True
-    guard = AsyncGuard(name="test-guard")
+    guard = AsyncGuard(name="test-guard", api_key="auth-stub")
 
     validation_outcome = await guard(
         model="gpt-4o-mini",
@@ -50,7 +50,7 @@ async def test_async_guard_validation():
 @pytest.mark.asyncio
 async def test_async_streaming_guard_validation():
     settings.use_server = True
-    guard = AsyncGuard(name="test-guard")
+    guard = AsyncGuard(name="test-guard", api_key="auth-stub")
 
     async_iterator = await guard(
         model="gpt-4o-mini",
@@ -74,7 +74,7 @@ async def test_sync_streaming_guard_validation():
     #       guardrails-api==0.1.0a2
     os.environ["GUARD_HISTORY_ENABLED"] = "false"
     settings.use_server = True
-    guard = Guard(name="test-guard")
+    guard = Guard(name="test-guard", api_key="auth-stub")
 
     iterator = guard(
         model="gpt-4o-mini",
@@ -105,7 +105,7 @@ def test_server_guard_llm_integration(
     message_content, output, validation_passed, error
 ):
     settings.use_server = True
-    guard = Guard(name="test-guard")
+    guard = Guard(name="test-guard", api_key="auth-stub")
     messages = [{"role": "user", "content": message_content}]
     if error:
         with pytest.raises(Exception):


### PR DESCRIPTION
As of 0.4.0 of the guardrails-api-client (using the latest urllib and OpenAPI generator), there is a client side check on auth headers.  This requires a value to be passed in for the api key either through the init kwars or the `GUARDRAILS_API_KEY` environment variable