### PR TITLE
Fix pip install version comparison on start.py

### DIFF
--- a/guardrails/cli/start.py
+++ b/guardrails/cli/start.py
@@ -39,7 +39,7 @@ def start(
 ):
     logger.debug("Checking for prerequisites...")
     if not api_is_installed():
-        package_name = 'guardrails-api>=0.0.0a0'
+        package_name = "guardrails-api>=0.0.0a0"
         pip_process("install", package_name)
 
     from guardrails_api.cli.start import start as start_api  # type: ignore

--- a/guardrails/cli/start.py
+++ b/guardrails/cli/start.py
@@ -39,7 +39,7 @@ def start(
 ):
     logger.debug("Checking for prerequisites...")
     if not api_is_installed():
-        package_name = 'guardrails-api>="^0.0.0a0"'
+        package_name = 'guardrails-api>=0.0.0a0'
         pip_process("install", package_name)
 
     from guardrails_api.cli.start import start as start_api  # type: ignore


### PR DESCRIPTION
I saw [this error](https://github.com/guardrails-ai/guardrails/issues/1269).

Pip install doesn't accept caret to specify the range of versions and this PR fixes it (Confirmed locally). Thank you!