### PR TITLE
Fix temperature argument handling for GPT-5 models

### DIFF
--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -508,6 +508,16 @@ def get_llm_ask(
     *args,
     **kwargs,
 ) -> Optional[PromptCallableBase]:
+    if "temperature" not in kwargs:
+        model = kwargs.get("model", "")
+        if not (isinstance(model, str) and model.startswith("gpt-5")):
+            warnings.warn(
+                "The default value of 0 for temperature is deprecated "
+                "and will be removed in guardrails-ai v0.8.x and higher.",
+                DeprecationWarning,
+            )
+            kwargs.update({"temperature": 0})
+
     try:
         from litellm import completion
 

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -508,9 +508,6 @@ def get_llm_ask(
     *args,
     **kwargs,
 ) -> Optional[PromptCallableBase]:
-    if "temperature" not in kwargs:
-        kwargs.update({"temperature": 0})
-
     try:
         from litellm import completion
 

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -1615,4 +1615,5 @@ class TestCustomLLMApi:
                     "content": "Can you generate a list of 10 things that are not food?",  # noqa
                 },
             ],
+            temperature=0,
         )

--- a/tests/integration_tests/test_guard.py
+++ b/tests/integration_tests/test_guard.py
@@ -1615,5 +1615,4 @@ class TestCustomLLMApi:
                     "content": "Can you generate a list of 10 things that are not food?",  # noqa
                 },
             ],
-            temperature=0,
         )

--- a/tests/unit_tests/test_llm_providers.py
+++ b/tests/unit_tests/test_llm_providers.py
@@ -1,5 +1,6 @@
 import importlib.util
 import os
+import warnings
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List
 from unittest.mock import MagicMock
@@ -323,16 +324,26 @@ class ReturnTempCallable(Callable):
     "llm_api, args, kwargs, expected_temperature",
     [
         (ReturnTempCallable(), [], {"temperature": 0.5}, 0.5),
-        (ReturnTempCallable(), [], {}, None),
+        (ReturnTempCallable(), [], {}, 0),
+        (ReturnTempCallable(), [], {"model": "gpt-5-nano"}, None),
     ],
 )
 def test_get_llm_ask_temperature(llm_api, args, kwargs, expected_temperature):
-    result = get_llm_ask(llm_api, *args, **kwargs)
-    if expected_temperature is None:
-        assert "temperature" not in result.init_kwargs
-    else:
-        assert "temperature" in result.init_kwargs
-        assert result.init_kwargs["temperature"] == expected_temperature
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = get_llm_ask(llm_api, *args, **kwargs)
+        if expected_temperature is None:
+            assert "temperature" not in result.init_kwargs
+            assert len(w) == 0
+        else:
+            assert "temperature" in result.init_kwargs
+            assert result.init_kwargs["temperature"] == expected_temperature
+            if "temperature" not in kwargs:
+                assert len(w) == 1
+                assert issubclass(w[0].category, DeprecationWarning)
+                assert "default value of 0 for temperature is deprecated" in str(
+                    w[0].message
+                )
 
 
 @pytest.mark.skipif(

--- a/tests/unit_tests/test_llm_providers.py
+++ b/tests/unit_tests/test_llm_providers.py
@@ -323,13 +323,16 @@ class ReturnTempCallable(Callable):
     "llm_api, args, kwargs, expected_temperature",
     [
         (ReturnTempCallable(), [], {"temperature": 0.5}, 0.5),
-        (ReturnTempCallable(), [], {}, 0),
+        (ReturnTempCallable(), [], {}, None),
     ],
 )
 def test_get_llm_ask_temperature(llm_api, args, kwargs, expected_temperature):
     result = get_llm_ask(llm_api, *args, **kwargs)
-    assert "temperature" in result.init_kwargs
-    assert result.init_kwargs["temperature"] == expected_temperature
+    if expected_temperature is None:
+        assert "temperature" not in result.init_kwargs
+    else:
+        assert "temperature" in result.init_kwargs
+        assert result.init_kwargs["temperature"] == expected_temperature
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Changes Made

**Problem:** GPT-5 models failed with `UnsupportedParamsError` because they don't support `temperature=0`, only `temperature=1`.

**Root Cause:** The `get_llm_ask()` function in llm_providers.py was automatically setting `temperature=0` when users didn't provide it.

**Fix:** 
- Removed the 3 lines (511-512) that defaulted `temperature` to 0
- Now temperature is only passed to LiteLLM if explicitly provided by the user
- LiteLLM handles model-specific defaults (GPT-5 uses temperature=1, others use appropriate defaults)

**Test Update:**
- Modified `test_get_llm_ask_temperature` to expect no temperature in kwargs when not provided (instead of expecting 0)

**Result:** Users can now use GPT-5 models without explicitly setting `temperature=1`.