### PR TITLE
Limit Size of in Memory History

### DIFF
--- a/guardrails/classes/generic/stack.py
+++ b/guardrails/classes/generic/stack.py
@@ -4,8 +4,14 @@ T = TypeVar("T")
 
 
 class Stack(List[T]):
-    def __init__(self, *args):
-        super().__init__(args)
+    _max_length: Optional[int]
+
+    def __init__(self, *args, max_length: Optional[int] = None):
+        initial_entries = args
+        if max_length:
+            initial_entries = initial_entries[:max_length]
+        super().__init__(initial_entries)
+        self._max_length = max_length
 
     def empty(self) -> bool:
         """Tests if this stack is empty."""
@@ -29,8 +35,12 @@ class Stack(List[T]):
         """Pushes an item onto the top of this stack.
 
         Proxy of List.append
+
+        Limits Stack Length to _max_length entries
         """
         self.append(item)
+        if self._max_length:
+            self = self[: self._max_length]
 
     def search(self, x: T) -> Optional[int]:
         """Returns the 0-based position of the last item whose value is equal

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -123,6 +123,7 @@ class Guard(IGuard, Generic[OT]):
     validators: List[ValidatorReference]
     output_schema: ModelSchema
     history: Stack[Call]
+    _history_max_length: int
 
     # Pydantic Config
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -137,6 +138,7 @@ class Guard(IGuard, Generic[OT]):
         output_schema: Optional[Dict[str, Any]] = None,
         base_url: Optional[str] = None,
         api_key: Optional[str] = None,
+        history_max_length: Optional[int] = None,
     ):
         """Initialize the Guard with serialized validator references and an
         output schema.
@@ -153,6 +155,7 @@ class Guard(IGuard, Generic[OT]):
         # Defaults
         validators = validators or []
         output_schema = output_schema or {"type": "string"}
+        history_max_length = history_max_length or 10
 
         # Init ModelSchema class
         # schema_with_type = {**output_schema}
@@ -162,7 +165,7 @@ class Guard(IGuard, Generic[OT]):
         model_schema = ModelSchema.from_dict(output_schema)
 
         # TODO: Support a sink for history so that it is not solely held in memory
-        history: Stack[Call] = Stack(max_length=10)
+        history: Stack[Call] = Stack(max_length=history_max_length)
 
         # Super Init
         super().__init__(
@@ -185,6 +188,7 @@ class Guard(IGuard, Generic[OT]):
 
         ### Overrides ###
         self.validators = validators
+        self._history_max_length = history_max_length
 
         ### Legacy ##
         self._num_reasks = None
@@ -1336,7 +1340,7 @@ class Guard(IGuard, Generic[OT]):
             if i_guard.history
             else []
         )
-        guard.history = Stack(*history, max_length=10)
+        guard.history = Stack(*history, max_length=guard._history_max_length)
         return guard
 
     # attempts to get a guard from the server

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -162,7 +162,7 @@ class Guard(IGuard, Generic[OT]):
         model_schema = ModelSchema.from_dict(output_schema)
 
         # TODO: Support a sink for history so that it is not solely held in memory
-        history: Stack[Call] = Stack()
+        history: Stack[Call] = Stack(max_length=10)
 
         # Super Init
         super().__init__(
@@ -1336,7 +1336,7 @@ class Guard(IGuard, Generic[OT]):
             if i_guard.history
             else []
         )
-        guard.history = Stack(*history)
+        guard.history = Stack(*history, max_length=10)
         return guard
 
     # attempts to get a guard from the server

--- a/guardrails/integrations/databricks/ml_flow_instrumentor.py
+++ b/guardrails/integrations/databricks/ml_flow_instrumentor.py
@@ -127,7 +127,7 @@ class MlFlowInstrumentor:
                 },
             ) as guard_span:
                 guard_self = args[0]
-                history = Stack()
+                history = Stack(max_length=10)
 
                 if guard_self is not None and isinstance(guard_self, Guard):
                     guard_span.set_attribute("guard.name", guard_self.name)
@@ -180,7 +180,7 @@ class MlFlowInstrumentor:
                 },
             ) as guard_span:
                 guard_self = args[0]
-                history = Stack()
+                history = Stack(max_length=10)
 
                 if guard_self is not None and isinstance(guard_self, Guard):
                     guard_span.set_attribute("guard.name", guard_self.name)

--- a/guardrails/integrations/databricks/ml_flow_instrumentor.py
+++ b/guardrails/integrations/databricks/ml_flow_instrumentor.py
@@ -127,6 +127,7 @@ class MlFlowInstrumentor:
                 },
             ) as guard_span:
                 guard_self = args[0]
+                # Use default bc we don't know if the Guard instance exists yet or not
                 history = Stack(max_length=10)
 
                 if guard_self is not None and isinstance(guard_self, Guard):
@@ -180,6 +181,7 @@ class MlFlowInstrumentor:
                 },
             ) as guard_span:
                 guard_self = args[0]
+                # Use default bc we don't know if the Guard instance exists yet or not
                 history = Stack(max_length=10)
 
                 if guard_self is not None and isinstance(guard_self, Guard):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guardrails-ai"
-version = "0.7.3"
+version = "0.8.0"
 description = "Adding guardrails to large language models."
 authors = [
     {name = "Guardrails AI", email = "contact@guardrailsai.com"}


### PR DESCRIPTION
### !!! NOTICE !!!
HOLD UNTIL https://github.com/guardrails-ai/guardrails/pull/1396 IS RELEASED AS v0.7.3


### Summary

- Allow users to configure the max stack length of Guard.history
- Default to 10 entries
- This is technically a breaking change since history will be automatically truncated.  Target 0.8.0

QA

- [x]  Lint
- [x]  Type
- [x]  Tests
- [x]  Server CI
    - https://github.com/guardrails-ai/guardrails/actions/runs/21756631389
- [x]  Notebooks
    - https://github.com/guardrails-ai/guardrails/actions/runs/21756618662
- [x]  CLI Compatibility
    - https://github.com/guardrails-ai/guardrails/actions/runs/21756607449