### PR TITLE
fix: correct typos 'recieved' and 'occured'

### DIFF
--- a/guardrails/cli/configure.py
+++ b/guardrails/cli/configure.py
@@ -111,7 +111,7 @@ def configure(
         # update setting singleton
         logger.info("Configuration saved.")
     except Exception as e:
-        logger.error("An unexpected error occured saving configuration!")
+        logger.error("An unexpected error occurred saving configuration!")
         logger.error(e)
         sys.exit(1)
 

--- a/guardrails/validator_base.py
+++ b/guardrails/validator_base.py
@@ -389,7 +389,7 @@ class Validator:
             inference endpoint to run.
 
         Raises:
-            HttpError: If the recieved reply was not ok.
+            HttpError: If the received reply was not ok.
 
         Returns:
             Any: Post request response from the ML based validation model.


### PR DESCRIPTION
Corrects two typos in the codebase:

- validator_base.py: 'recieved' → 'received'
- cli/configure.py: 'occured' → 'occurred'