### PR TITLE
Fix custom validators failing without Hub API key

### DIFF
--- a/guardrails/classes/rc.py
+++ b/guardrails/classes/rc.py
@@ -49,6 +49,15 @@ class RC(Serializeable):
                         key, value = line_content
                         key = key.strip()
                         value = value.strip()
+                        # Strip surrounding matching quotes so that
+                        # e.g. token="" is treated as an empty string
+                        # rather than the literal two-character value '""'.
+                        if (
+                            len(value) >= 2
+                            and value[0] == value[-1]
+                            and value[0] in ('"', "'")
+                        ):
+                            value = value[1:-1]
                         if key in BOOL_CONFIGS:
                             value = to_bool(value)
 

--- a/guardrails/validator_base.py
+++ b/guardrails/validator_base.py
@@ -120,7 +120,6 @@ class Validator:
                 "No .guardrailsrc file found."
                 " Please run `guardrails configure` and try again."
             )
-        self.hub_jwt_token = get_jwt_token(settings.rc)
 
         # If use_local is not set, we can fall back to the setting determined in CLI
         if self.use_local is None:
@@ -394,8 +393,9 @@ class Validator:
         Returns:
             Any: Post request response from the ML based validation model.
         """
+        hub_jwt_token = get_jwt_token(settings.rc)
         headers = {
-            "Authorization": f"Bearer {self.hub_jwt_token}",
+            "Authorization": f"Bearer {hub_jwt_token}",
             "Content-Type": "application/json",
         }
         req = requests.post(validation_endpoint, data=request_body, headers=headers)


### PR DESCRIPTION
## Summary

Custom and local validators crash during init when no Hub API key is configured, even though they never call the Hub. This fixes both root causes.

Closes #1381

## Changes

**`guardrails/classes/rc.py`**
- Strip surrounding matching quotes from `.guardrailsrc` values during parsing. A config line like `token=""` was being stored as the literal two-character string `""` instead of an empty string, which then failed JWT decoding.

**`guardrails/validator_base.py`**
- Removed the eager `get_jwt_token()` call from `Validator.__init__()`. Token validation now happens lazily in `_hub_inference_request()`, which is the only place the token is actually used. Custom/local validators that never call the Hub no longer require a valid token.

**`tests/unit_tests/classes/test_rc.py`**
- Added parameterized tests covering double-quoted empty, single-quoted empty, double-quoted value, single-quoted value, unquoted value, and bare empty token configs.

## Testing

### Unit tests
```
$ python3 -m pytest tests/unit_tests/classes/test_rc.py -v
10 passed (4 existing + 6 new)

$ python3 -m pytest tests/unit_tests/test_validator_base.py -v
23 passed

$ python3 -m pytest tests/unit_tests/ --timeout=120
458 passed, 9 failed (all pre-existing), 12 skipped
```

### Integration tests
```
$ python3 -m pytest tests/integration_tests/test_validator_base.py -v
8 passed

$ python3 -m pytest tests/integration_tests/ --timeout=120
160 passed, 35 failed (all pre-existing), 16 skipped
```

All pre-existing failures confirmed by running the same tests on `main` -- zero regressions from this change.

cc @CalebCourier