### PR TITLE
v0.8.1 - Final

### DIFF
--- a/docs/dist/examples/response_is_on_topic.ipynb
+++ b/docs/dist/examples/response_is_on_topic.ipynb
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +217,7 @@
    ],
    "source": [
     "# Create the Guard with the OnTopic Validator\n",
-    "guard = gd.Guard.from_string(\n",
+    "guard = gd.Guard.for_string(\n",
     "    validators=[\n",
     "        RestrictToTopic(\n",
     "            valid_topics=valid_topics,\n",

--- a/docs/dist/examples/response_is_on_topic.md
+++ b/docs/dist/examples/response_is_on_topic.md
@@ -124,7 +124,7 @@ Here, we have disabled the LLM from running at all. We rely totally on what the 
 
 ```python
 # Create the Guard with the OnTopic Validator
-guard = gd.Guard.from_string(
+guard = gd.Guard.for_string(
     validators=[
         RestrictToTopic(
             valid_topics=valid_topics,

--- a/docs/src/examples/response_is_on_topic.ipynb
+++ b/docs/src/examples/response_is_on_topic.ipynb
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +217,7 @@
    ],
    "source": [
     "# Create the Guard with the OnTopic Validator\n",
-    "guard = gd.Guard.from_string(\n",
+    "guard = gd.Guard.for_string(\n",
     "    validators=[\n",
     "        RestrictToTopic(\n",
     "            valid_topics=valid_topics,\n",


### PR DESCRIPTION
### Summary

- update constructors in docs

### Quality Checks

- [x] CI
- [x] CLI Compatibility
    - https://github.com/guardrails-ai/guardrails/actions/runs/21993662806
- [~] Notebooks
    - https://github.com/guardrails-ai/guardrails/actions/runs/21993666849
    - The one failing notebook is unrelated to these changes.  The [HighQualityTranslation](https://guardrailsai.com/hub/validator/brainlogic/high_quality_translation) validator fails to install in Python 3.12 and 3.13 due to a transient dependency's use of pkg_resources
- [~] Server CI
    - https://github.com/guardrails-ai/guardrails/actions/runs/21993669994
    - This will fail untill v0.2.0 of guardrails-api is released which depends on this version of guardrails-ai