### PR TITLE
Replace barrel imports with dynamic registry-based loading (Phase 2)

### DIFF
--- a/guardrails/cli/hub/list.py
+++ b/guardrails/cli/hub/list.py
@@ -1,5 +1,4 @@
-import os
-import re
+import json
 
 from guardrails.cli.hub.hub import hub_command
 from guardrails.hub_telemetry.hub_tracing import trace
@@ -12,20 +11,24 @@ def list():
     """List all installed validators."""
     from guardrails.hub.validator_package_service import ValidatorPackageService
 
-    site_packages = ValidatorPackageService.get_site_packages_location()
-    hub_init_file = os.path.join(site_packages, "guardrails", "hub", "__init__.py")
+    registry_path = ValidatorPackageService.get_registry_path()
 
-    installed_validators = []
-
-    if os.path.isfile(hub_init_file):
-        with open(hub_init_file, "r") as file:
-            content = file.read()
-            matches = re.findall(r"from .* import (\w+)", content)
-            installed_validators.extend(matches)
-
-    if installed_validators:
-        console.print("Installed Validators:")
-        for validator in installed_validators:
-            console.print(f"- {validator}")
-    else:
+    if not registry_path.exists():
         console.print("No validators installed.")
+        return
+
+    try:
+        registry = json.loads(registry_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        console.print("No validators installed.")
+        return
+
+    validators = registry.get("validators", {})
+    if not validators:
+        console.print("No validators installed.")
+        return
+
+    console.print("Installed Validators:")
+    for validator_id, entry in sorted(validators.items()):
+        exports = ", ".join(entry.get("exports", []))
+        console.print(f"- {validator_id} ({exports})")

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -79,7 +79,6 @@ def uninstall(
     # Prep
     with console.status("Fetching manifest", spinner="bouncingBar"):
         module_manifest = get_validator_manifest(module_name)
-        site_packages = ValidatorPackageService.get_site_packages_location()
 
     # Uninstall
     with console.status("Removing module", spinner="bouncingBar"):
@@ -87,7 +86,7 @@ def uninstall(
 
     # Cleanup
     with console.status("Cleaning up", spinner="bouncingBar"):
-        remove_from_hub_inits(module_manifest, site_packages)
+        ValidatorPackageService.unregister_validator(module_name)
 
     console.print("✅ Successfully uninstalled!")  # type: ignore
     logger.log(level=LEVELS.get("SPAM"), msg="✅ Successfully uninstalled!")  # type: ignore

--- a/guardrails/hub/__init__.py
+++ b/guardrails/hub/__init__.py
@@ -1,2 +1,77 @@
-# Should contain imports for all validators
-# Will be auto-populated by the installation script
+"""guardrails.hub - Dynamic import resolution from hub_registry.json.
+
+Validators registered in .guardrails/hub_registry.json are resolved lazily
+on first attribute access and cached for subsequent imports.
+"""
+
+import importlib
+import json
+import logging
+import os
+from pathlib import Path
+
+# Use stdlib logger to avoid circular imports with guardrails.logger
+_logger = logging.getLogger(__name__)
+
+_export_map_cache = None
+
+
+def _load_registry() -> dict:
+    """Load the hub registry from .guardrails/hub_registry.json."""
+    registry_path = Path(os.getcwd()) / ".guardrails" / "hub_registry.json"
+    if not registry_path.exists():
+        return {}
+    try:
+        data = json.loads(registry_path.read_text())
+        return data.get("validators", {})
+    except (json.JSONDecodeError, OSError):
+        _logger.warning("Failed to read hub registry at %s", registry_path)
+        return {}
+
+
+def _build_export_map() -> dict:
+    """Build mapping from export name to import path.
+
+    Returns a dict mapping export names (e.g. "DetectPII") to their
+    module import paths (e.g. "guardrails_grhub_detect_pii").
+    """
+    validators = _load_registry()
+    export_map = {}
+    for entry in validators.values():
+        import_path = entry.get("import_path", "")
+        for export_name in entry.get("exports", []):
+            export_map[export_name] = import_path
+    return export_map
+
+
+def _get_export_map() -> dict:
+    """Return cached export map, building it on first access."""
+    global _export_map_cache
+    if _export_map_cache is None:
+        _export_map_cache = _build_export_map()
+    return _export_map_cache
+
+
+def __getattr__(name: str):
+    export_map = _get_export_map()
+    if name in export_map:
+        import_path = export_map[name]
+        try:
+            module = importlib.import_module(import_path)
+            attr = getattr(module, name)
+            globals()[name] = attr
+            return attr
+        except (ModuleNotFoundError, AttributeError) as e:
+            raise ImportError(
+                f"Cannot import '{name}' from hub registry. "
+                f"Module '{import_path}' not found. "
+                f"Try reinstalling: guardrails hub install "
+                f"hub://<org>/<validator>"
+            ) from e
+    raise AttributeError(f"module 'guardrails.hub' has no attribute '{name}'")
+
+
+def __dir__():
+    base = list(globals().keys())
+    base.extend(_get_export_map().keys())
+    return base

--- a/guardrails/hub/install.py
+++ b/guardrails/hub/install.py
@@ -135,7 +135,6 @@ def install(
             msg="Skipping post install, models will not be "
             "downloaded for local inference.",
         )
-    ValidatorPackageService.add_to_hub_inits(module_manifest, site_packages)
     ValidatorPackageService.register_validator(module_manifest)
 
     # 5. Get Validator Class for the installed module

--- a/guardrails/hub/validator_package_service.py
+++ b/guardrails/hub/validator_package_service.py
@@ -168,6 +168,28 @@ class ValidatorPackageService:
         registry_file.write_text(json.dumps(registry, indent=2))
 
     @staticmethod
+    def unregister_validator(validator_id: str):
+        """Remove a validator from the project-level JSON registry."""
+        registry_file = ValidatorPackageService.get_registry_path()
+        if not registry_file.exists():
+            return
+
+        try:
+            registry = json.loads(registry_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            guardrails_logger.debug(
+                "Registry at %s is unreadable; skipping unregister",
+                registry_file,
+            )
+            return
+
+        validators = registry.get("validators", {})
+        if validator_id in validators:
+            del validators[validator_id]
+            registry["validators"] = validators
+            registry_file.write_text(json.dumps(registry, indent=2))
+
+    @staticmethod
     def add_to_hub_inits(manifest: Manifest, site_packages: str):
         validator_id = manifest.id
         exports: List[str] = manifest.exports or []

--- a/tests/unit_tests/cli/hub/test_list.py
+++ b/tests/unit_tests/cli/hub/test_list.py
@@ -1,6 +1,5 @@
-from unittest.mock import mock_open
+import json
 
-import pytest
 from typer.testing import CliRunner
 
 from guardrails.cli.hub.hub import hub_command
@@ -9,44 +8,136 @@ from guardrails.cli.hub.hub import hub_command
 runner = CliRunner()
 
 
-class TestListCommand:
-    @pytest.fixture(autouse=True)
-    def setup(self, mocker):
-        mocker.patch(
-            "guardrails.hub.validator_package_service.ValidatorPackageService.get_manifest_and_site_packages",
-            return_value="/test/site-packages",
-        )
+def test_list_from_registry(tmp_path, mocker):
+    registry_path = tmp_path / ".guardrails" / "hub_registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry = {
+        "version": 1,
+        "validators": {
+            "guardrails/detect-pii": {
+                "import_path": "guardrails_grhub_detect_pii",
+                "exports": ["DetectPII"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-detect-pii",
+            },
+            "guardrails/regex-match": {
+                "import_path": "guardrails_grhub_regex_match",
+                "exports": ["RegexMatch"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-regex-match",
+            },
+        },
+    }
+    registry_path.write_text(json.dumps(registry))
 
-    def test_list_no_validators_installed(self, mocker):
-        mocker.patch("os.path.isfile", return_value=False)
+    mocker.patch(
+        "guardrails.hub.validator_package_service.ValidatorPackageService.get_registry_path",
+        return_value=registry_path,
+    )
 
-        result = runner.invoke(hub_command, ["list"])
+    result = runner.invoke(hub_command, ["list"])
 
-        assert result.exit_code == 0
-        assert "No validators installed." in result.output
+    assert result.exit_code == 0
+    assert "Installed Validators:" in result.output
+    assert "guardrails/detect-pii (DetectPII)" in result.output
+    assert "guardrails/regex-match (RegexMatch)" in result.output
 
-    def test_list_validators_installed(self, mocker):
-        mocker.patch("os.path.isfile", return_value=True)
 
-        init_file_content = """
-        from guardrails.hub.guardrails.toxic_language.validator import ToxicLanguage
-        from guardrails.hub.guardrails.competitor_check.validator import CompetitorCheck
-        """
-        mocker.patch("builtins.open", mock_open(read_data=init_file_content))
+def test_list_empty_registry(tmp_path, mocker):
+    registry_path = tmp_path / ".guardrails" / "hub_registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(json.dumps({"version": 1, "validators": {}}))
 
-        result = runner.invoke(hub_command, ["list"])
+    mocker.patch(
+        "guardrails.hub.validator_package_service.ValidatorPackageService.get_registry_path",
+        return_value=registry_path,
+    )
 
-        assert result.exit_code == 0
-        assert "Installed Validators:" in result.output
-        assert "- ToxicLanguage" in result.output
-        assert "- CompetitorCheck" in result.output
+    result = runner.invoke(hub_command, ["list"])
 
-    def test_list_handles_empty_init_file(self, mocker):
-        mocker.patch("os.path.isfile", return_value=True)
+    assert result.exit_code == 0
+    assert "No validators installed." in result.output
 
-        mocker.patch("builtins.open", mock_open(read_data=""))
 
-        result = runner.invoke(hub_command, ["list"])
+def test_list_no_registry_file(tmp_path, mocker):
+    registry_path = tmp_path / ".guardrails" / "hub_registry.json"
 
-        assert result.exit_code == 0
-        assert "No validators installed." in result.output
+    mocker.patch(
+        "guardrails.hub.validator_package_service.ValidatorPackageService.get_registry_path",
+        return_value=registry_path,
+    )
+
+    result = runner.invoke(hub_command, ["list"])
+
+    assert result.exit_code == 0
+    assert "No validators installed." in result.output
+
+
+def test_list_corrupt_registry(tmp_path, mocker):
+    registry_path = tmp_path / ".guardrails" / "hub_registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text("not valid json{{{")
+
+    mocker.patch(
+        "guardrails.hub.validator_package_service.ValidatorPackageService.get_registry_path",
+        return_value=registry_path,
+    )
+
+    result = runner.invoke(hub_command, ["list"])
+
+    assert result.exit_code == 0
+    assert "No validators installed." in result.output
+
+
+def test_list_multi_export_validator(tmp_path, mocker):
+    registry_path = tmp_path / ".guardrails" / "hub_registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry = {
+        "version": 1,
+        "validators": {
+            "guardrails/test-package": {
+                "import_path": "guardrails_grhub_test_package",
+                "exports": ["Validator", "Helper"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-test-package",
+            },
+        },
+    }
+    registry_path.write_text(json.dumps(registry))
+
+    mocker.patch(
+        "guardrails.hub.validator_package_service.ValidatorPackageService.get_registry_path",
+        return_value=registry_path,
+    )
+
+    result = runner.invoke(hub_command, ["list"])
+
+    assert result.exit_code == 0
+    assert "guardrails/test-package (Validator, Helper)" in result.output
+
+
+def test_list_entry_without_exports_key(tmp_path, mocker):
+    """Entry missing exports key should not crash."""
+    registry_path = tmp_path / ".guardrails" / "hub_registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry = {
+        "version": 1,
+        "validators": {
+            "guardrails/test": {
+                "import_path": "guardrails_grhub_test",
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-test",
+            }
+        },
+    }
+    registry_path.write_text(json.dumps(registry))
+
+    mocker.patch(
+        "guardrails.hub.validator_package_service.ValidatorPackageService.get_registry_path",
+        return_value=registry_path,
+    )
+
+    result = runner.invoke(hub_command, ["list"])
+
+    assert result.exit_code == 0
+    assert "guardrails/test ()" in result.output

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -74,16 +74,10 @@ def test_uninstall_valid_uri(mocker):
     mock_uninstall_hub_module = mocker.patch(
         "guardrails.cli.hub.uninstall.uninstall_hub_module"
     )
-    mock_remove_from_hub_inits = mocker.patch(
-        "guardrails.cli.hub.uninstall.remove_from_hub_inits"
-    )
     mocker.patch("guardrails.cli.hub.uninstall.console")
 
-    validator_package_service_mock = mocker.patch(
-        "guardrails.hub.validator_package_service.ValidatorPackageService",
-    )
-    validator_package_service_mock.get_site_packages_location.return_value = (
-        "/site-packages"
+    mock_unregister = mocker.patch(
+        "guardrails.hub.validator_package_service.ValidatorPackageService.unregister_validator"
     )
 
     from guardrails.cli.hub.uninstall import uninstall
@@ -91,7 +85,7 @@ def test_uninstall_valid_uri(mocker):
     uninstall("hub://guardrails/test-validator")
 
     mock_uninstall_hub_module.assert_called_once_with(manifest_mock)
-    mock_remove_from_hub_inits.assert_called_once_with(manifest_mock, "/site-packages")
+    mock_unregister.assert_called_once_with("guardrails/test-validator")
 
 
 def test_uninstall_hub_module(mocker):

--- a/tests/unit_tests/hub/test_hub_init_getattr.py
+++ b/tests/unit_tests/hub/test_hub_init_getattr.py
@@ -1,0 +1,282 @@
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import guardrails.hub as hub_module
+
+
+@pytest.fixture(autouse=True)
+def reset_export_map_cache():
+    """Reset the module-level cache before each test."""
+    hub_module._export_map_cache = None
+    yield
+    hub_module._export_map_cache = None
+
+
+@pytest.fixture
+def registry_dir(tmp_path):
+    guardrails_dir = tmp_path / ".guardrails"
+    guardrails_dir.mkdir()
+    return guardrails_dir
+
+
+@pytest.fixture
+def registry_file(registry_dir):
+    return registry_dir / "hub_registry.json"
+
+
+def _write_registry(registry_file, validators):
+    registry = {"version": 1, "validators": validators}
+    registry_file.write_text(json.dumps(registry))
+
+
+def test_getattr_resolves_registered_validator(tmp_path, registry_file):
+    _write_registry(
+        registry_file,
+        {
+            "guardrails/test-validator": {
+                "import_path": "guardrails_grhub_test_validator",
+                "exports": ["TestValidator"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-test-validator",
+            }
+        },
+    )
+
+    mock_module = MagicMock()
+    mock_module.TestValidator = "resolved_class"
+
+    with (
+        patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)),
+        patch(
+            "guardrails.hub.importlib.import_module",
+            return_value=mock_module,
+        ) as mock_import,
+    ):
+        result = hub_module.__getattr__("TestValidator")
+
+    assert result == "resolved_class"
+    mock_import.assert_called_once_with("guardrails_grhub_test_validator")
+
+
+def test_getattr_caches_in_globals(tmp_path, registry_file):
+    _write_registry(
+        registry_file,
+        {
+            "guardrails/test-validator": {
+                "import_path": "guardrails_grhub_test_validator",
+                "exports": ["TestValidator"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-test-validator",
+            }
+        },
+    )
+
+    mock_module = MagicMock()
+    mock_module.TestValidator = "resolved_class"
+
+    with (
+        patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)),
+        patch(
+            "guardrails.hub.importlib.import_module",
+            return_value=mock_module,
+        ) as mock_import,
+    ):
+        result1 = hub_module.__getattr__("TestValidator")
+        assert result1 == "resolved_class"
+        assert mock_import.call_count == 1
+
+        # After caching, the attr should be in globals
+        assert "TestValidator" in hub_module.__dict__
+
+        # Clean up
+        del hub_module.__dict__["TestValidator"]
+
+
+def test_getattr_raises_attribute_error_for_unknown(tmp_path, registry_file):
+    _write_registry(registry_file, {})
+
+    with patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)):
+        with pytest.raises(
+            AttributeError,
+            match="has no attribute 'NonExistent'",
+        ):
+            hub_module.__getattr__("NonExistent")
+
+
+def test_getattr_raises_import_error_for_missing_module(tmp_path, registry_file):
+    _write_registry(
+        registry_file,
+        {
+            "guardrails/missing": {
+                "import_path": "guardrails_grhub_missing",
+                "exports": ["MissingValidator"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-missing",
+            }
+        },
+    )
+
+    with (
+        patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)),
+        patch(
+            "guardrails.hub.importlib.import_module",
+            side_effect=ModuleNotFoundError(
+                "No module named 'guardrails_grhub_missing'"
+            ),
+        ),
+    ):
+        with pytest.raises(ImportError, match="Cannot import 'MissingValidator'"):
+            hub_module.__getattr__("MissingValidator")
+
+
+def test_getattr_raises_import_error_for_missing_attribute(tmp_path, registry_file):
+    """Module loads but the registered export name does not exist."""
+    _write_registry(
+        registry_file,
+        {
+            "guardrails/test-validator": {
+                "import_path": "guardrails_grhub_test_validator",
+                "exports": ["NonExistentClass"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-test-validator",
+            }
+        },
+    )
+
+    mock_module = MagicMock(spec=[])
+
+    with (
+        patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)),
+        patch(
+            "guardrails.hub.importlib.import_module",
+            return_value=mock_module,
+        ),
+    ):
+        with pytest.raises(ImportError, match="Cannot import 'NonExistentClass'"):
+            hub_module.__getattr__("NonExistentClass")
+
+
+def test_dir_includes_registered_exports(tmp_path, registry_file):
+    _write_registry(
+        registry_file,
+        {
+            "guardrails/test-validator": {
+                "import_path": "guardrails_grhub_test_validator",
+                "exports": ["TestValidator", "TestHelper"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-test-validator",
+            }
+        },
+    )
+
+    with patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)):
+        result = hub_module.__dir__()
+
+    assert "TestValidator" in result
+    assert "TestHelper" in result
+
+
+def test_dir_with_no_registry(tmp_path):
+    """__dir__ should not crash when no registry file exists."""
+    with patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)):
+        result = hub_module.__dir__()
+
+    assert isinstance(result, list)
+    assert "_load_registry" in result
+    assert "_build_export_map" in result
+
+
+def test_empty_registry(tmp_path):
+    with patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)):
+        with pytest.raises(
+            AttributeError,
+            match="has no attribute 'SomeName'",
+        ):
+            hub_module.__getattr__("SomeName")
+
+
+def test_corrupt_registry_falls_back_gracefully(tmp_path, registry_dir):
+    """Corrupt JSON should fall back to AttributeError, not crash."""
+    (registry_dir / "hub_registry.json").write_text("{not valid json")
+
+    with patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)):
+        with pytest.raises(
+            AttributeError,
+            match="has no attribute 'DetectPII'",
+        ):
+            hub_module.__getattr__("DetectPII")
+
+
+def test_export_name_collision_last_wins(tmp_path, registry_file):
+    """When two validators export the same name, last in dict wins."""
+    _write_registry(
+        registry_file,
+        {
+            "org-a/validator": {
+                "import_path": "org_a_grhub_validator",
+                "exports": ["SharedName"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "org-a-grhub-validator",
+            },
+            "org-b/validator": {
+                "import_path": "org_b_grhub_validator",
+                "exports": ["SharedName"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "org-b-grhub-validator",
+            },
+        },
+    )
+
+    with patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)):
+        export_map = hub_module._build_export_map()
+        assert export_map["SharedName"] == "org_b_grhub_validator"
+
+
+def test_build_export_map_skips_empty_exports(tmp_path, registry_file):
+    """Entry with empty exports list produces no entries."""
+    _write_registry(
+        registry_file,
+        {
+            "guardrails/no-exports": {
+                "import_path": "guardrails_grhub_no_exports",
+                "exports": [],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-no-exports",
+            }
+        },
+    )
+
+    with patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)):
+        export_map = hub_module._build_export_map()
+        assert len(export_map) == 0
+
+
+def test_build_export_map_handles_missing_keys(tmp_path, registry_file):
+    """Entry with missing import_path or exports should not crash."""
+    _write_registry(registry_file, {"guardrails/broken": {}})
+
+    with patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)):
+        export_map = hub_module._build_export_map()
+        assert len(export_map) == 0
+
+
+def test_get_export_map_caches_result(tmp_path, registry_file):
+    """_get_export_map should only build the map once."""
+    _write_registry(
+        registry_file,
+        {
+            "guardrails/test": {
+                "import_path": "guardrails_grhub_test",
+                "exports": ["Test"],
+                "installed_at": "2025-01-01T00:00:00+00:00",
+                "package_name": "guardrails-grhub-test",
+            }
+        },
+    )
+
+    with patch("guardrails.hub.os.getcwd", return_value=str(tmp_path)):
+        result1 = hub_module._get_export_map()
+        result2 = hub_module._get_export_map()
+        assert result1 is result2

--- a/tests/unit_tests/hub/test_hub_install.py
+++ b/tests/unit_tests/hub/test_hub_install.py
@@ -64,8 +64,8 @@ class TestInstall:
         mocker.patch(
             "guardrails.hub.validator_package_service.ValidatorPackageService.get_validator_from_manifest"
         )
-        mock_add_to_hub_init = mocker.patch(
-            "guardrails.hub.validator_package_service.ValidatorPackageService.add_to_hub_inits"
+        mocker.patch(
+            "guardrails.hub.validator_package_service.ValidatorPackageService.register_validator"
         )
 
         get_manifest_and_site_packages_mock.return_value = (
@@ -99,7 +99,6 @@ class TestInstall:
         mock_pip_install_hub_module.assert_called_once_with(
             self.manifest.id, validator_version=None, quiet=ANY, upgrade=ANY, logger=ANY
         )
-        mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
     def test_install_local_models__true(self, mocker, use_remote_inferencing):
         mocker.patch(
@@ -127,8 +126,8 @@ class TestInstall:
         mocker.patch(
             "guardrails.hub.validator_package_service.ValidatorPackageService.get_validator_from_manifest"
         )
-        mock_add_to_hub_init = mocker.patch(
-            "guardrails.hub.validator_package_service.ValidatorPackageService.add_to_hub_inits"
+        mocker.patch(
+            "guardrails.hub.validator_package_service.ValidatorPackageService.register_validator"
         )
 
         get_manifest_and_site_packages_mock.return_value = (
@@ -161,7 +160,6 @@ class TestInstall:
         mock_pip_install_hub_module.assert_called_once_with(
             self.manifest.id, validator_version=None, quiet=ANY, upgrade=ANY, logger=ANY
         )
-        mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
     def test_install_local_models__none(self, mocker, use_remote_inferencing):
         mocker.patch(
@@ -186,8 +184,8 @@ class TestInstall:
         mocker.patch(
             "guardrails.hub.validator_package_service.ValidatorPackageService.get_validator_from_manifest"
         )
-        mock_add_to_hub_init = mocker.patch(
-            "guardrails.hub.validator_package_service.ValidatorPackageService.add_to_hub_inits"
+        mocker.patch(
+            "guardrails.hub.validator_package_service.ValidatorPackageService.register_validator"
         )
 
         get_manifest_and_site_packages_mock.return_value = (
@@ -220,7 +218,6 @@ class TestInstall:
         mock_pip_install_hub_module.assert_called_once_with(
             self.manifest.id, validator_version=None, quiet=ANY, upgrade=ANY, logger=ANY
         )
-        mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
     def test_happy_path(self, mocker, use_remote_inferencing):
         mocker.patch(
@@ -245,8 +242,8 @@ class TestInstall:
         mocker.patch(
             "guardrails.hub.validator_package_service.ValidatorPackageService.get_validator_from_manifest"
         )
-        mock_add_to_hub_init = mocker.patch(
-            "guardrails.hub.validator_package_service.ValidatorPackageService.add_to_hub_inits"
+        mocker.patch(
+            "guardrails.hub.validator_package_service.ValidatorPackageService.register_validator"
         )
 
         get_manifest_and_site_packages_mock.return_value = (
@@ -275,7 +272,6 @@ class TestInstall:
         mock_pip_install_hub_module.assert_called_once_with(
             self.manifest.id, validator_version=None, quiet=ANY, upgrade=ANY, logger=ANY
         )
-        mock_add_to_hub_init.assert_called_once_with(self.manifest, self.site_packages)
 
     def test_install_local_models_confirmation(self, mocker, use_remote_inferencing):
         mocker.patch(
@@ -290,7 +286,7 @@ class TestInstall:
             "guardrails.hub.validator_package_service.ValidatorPackageService.get_validator_from_manifest"
         )
         mocker.patch(
-            "guardrails.hub.validator_package_service.ValidatorPackageService.add_to_hub_inits"
+            "guardrails.hub.validator_package_service.ValidatorPackageService.register_validator"
         )
 
         mock_get_manifest_and_site_packages = mocker.patch(
@@ -341,7 +337,7 @@ class TestInstall:
             "guardrails.hub.validator_package_service.ValidatorPackageService.get_validator_from_manifest"
         )
         mocker.patch(
-            "guardrails.hub.validator_package_service.ValidatorPackageService.add_to_hub_inits"
+            "guardrails.hub.validator_package_service.ValidatorPackageService.register_validator"
         )
 
         mock_get_manifest_and_site_packages = mocker.patch(
@@ -398,7 +394,7 @@ class TestInstall:
             "guardrails.hub.validator_package_service.ValidatorPackageService.get_validator_from_manifest"
         )
         mocker.patch(
-            "guardrails.hub.validator_package_service.ValidatorPackageService.add_to_hub_inits"
+            "guardrails.hub.validator_package_service.ValidatorPackageService.register_validator"
         )
 
         manifest = Manifest.from_dict(

--- a/tests/unit_tests/hub/test_validator_package_service.py
+++ b/tests/unit_tests/hub/test_validator_package_service.py
@@ -749,6 +749,101 @@ class TestRegisterValidator:
         ]
 
 
+class TestUnregisterValidator:
+    def test_removes_validator_from_registry(self, tmp_path, mocker):
+        registry_dir = tmp_path / ".guardrails"
+        registry_dir.mkdir()
+        registry_file = registry_dir / "hub_registry.json"
+        existing = {
+            "version": 1,
+            "validators": {
+                "guardrails/detect-pii": {
+                    "import_path": "guardrails_grhub_detect_pii",
+                    "exports": ["DetectPII"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-detect-pii",
+                },
+                "guardrails/regex-match": {
+                    "import_path": "guardrails_grhub_regex_match",
+                    "exports": ["RegexMatch"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-regex-match",
+                },
+            },
+        }
+        registry_file.write_text(json.dumps(existing))
+
+        mocker.patch.object(
+            ValidatorPackageService,
+            "get_registry_path",
+            return_value=registry_file,
+        )
+
+        ValidatorPackageService.unregister_validator("guardrails/detect-pii")
+
+        registry = json.loads(registry_file.read_text())
+        assert "guardrails/detect-pii" not in registry["validators"]
+        assert "guardrails/regex-match" in registry["validators"]
+        assert len(registry["validators"]) == 1
+
+    def test_noop_when_registry_missing(self, tmp_path, mocker):
+        registry_file = tmp_path / ".guardrails" / "hub_registry.json"
+        mocker.patch.object(
+            ValidatorPackageService,
+            "get_registry_path",
+            return_value=registry_file,
+        )
+
+        # Should not raise
+        ValidatorPackageService.unregister_validator("guardrails/detect-pii")
+
+    def test_noop_when_validator_not_in_registry(self, tmp_path, mocker):
+        registry_dir = tmp_path / ".guardrails"
+        registry_dir.mkdir()
+        registry_file = registry_dir / "hub_registry.json"
+        existing = {
+            "version": 1,
+            "validators": {
+                "guardrails/regex-match": {
+                    "import_path": "guardrails_grhub_regex_match",
+                    "exports": ["RegexMatch"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-regex-match",
+                }
+            },
+        }
+        registry_file.write_text(json.dumps(existing))
+
+        mocker.patch.object(
+            ValidatorPackageService,
+            "get_registry_path",
+            return_value=registry_file,
+        )
+
+        ValidatorPackageService.unregister_validator("guardrails/detect-pii")
+
+        registry = json.loads(registry_file.read_text())
+        assert len(registry["validators"]) == 1
+        assert "guardrails/regex-match" in registry["validators"]
+
+    def test_noop_on_corrupt_registry(self, tmp_path, mocker):
+        registry_dir = tmp_path / ".guardrails"
+        registry_dir.mkdir()
+        registry_file = registry_dir / "hub_registry.json"
+        registry_file.write_text("not valid json{{{")
+
+        mocker.patch.object(
+            ValidatorPackageService,
+            "get_registry_path",
+            return_value=registry_file,
+        )
+
+        ValidatorPackageService.unregister_validator("guardrails/detect-pii")
+
+        # File should remain unchanged
+        assert registry_file.read_text() == "not valid json{{{"
+
+
 class TestInstallHubModuleWithInstaller:
     @pytest.mark.parametrize(
         ("detected_installer",),


### PR DESCRIPTION
Resolves #1423

## Summary

Phase 2 of the hub registry migration. Replaces the fragile barrel import
system (mutating `hub/__init__.py` in site-packages) with dynamic PEP 562
`__getattr__` resolution from `.guardrails/hub_registry.json`.

@CalebCourier requested this on Discussion #1412.

## Changes

- `guardrails/hub/__init__.py`: Replace barrel imports with `__getattr__` +
  `__dir__` + cached export map from `hub_registry.json`
- `guardrails/hub/install.py`: Remove `add_to_hub_inits()` call (registry is
  now the sole source of truth)
- `guardrails/hub/validator_package_service.py`: Add `unregister_validator()`
  for clean removal on uninstall
- `guardrails/cli/hub/uninstall.py`: Use `unregister_validator()` instead of
  `remove_from_hub_inits()`
- `guardrails/cli/hub/list.py`: Read from registry JSON instead of
  regex-parsing `hub/__init__.py`

## Backward Compatibility

- `from guardrails.hub import DetectPII` works identically via `__getattr__`
- Existing v0.9.1 registry entries work as-is
- No migration needed: reinstalling validators auto-populates the registry
- Old functions (`add_to_hub_inits`, `remove_from_hub_inits`) kept but no
  longer called

## Testing

99 tests pass across hub core and CLI:

- 13 `__getattr__` tests: happy path, caching, corrupt registry, name
  collisions, missing modules, missing attributes, empty exports
- 6 CLI list tests: registry read, empty, missing file, corrupt, multi-export
- 4 unregister tests: remove, noop on missing/not-found/corrupt
- Full install/uninstall regression (76 existing tests unmodified and passing)