### PR TITLE
fix: preserve falsy values in safe_get

### DIFF
--- a/guardrails/utils/safe_get.py
+++ b/guardrails/utils/safe_get.py
@@ -7,7 +7,7 @@ def safe_get_with_brackets(
 ) -> Any:
     try:
         value = container[key]
-        if not value:
+        if value is None:
             return default
         return value
     except Exception as e:

--- a/tests/unit_tests/utils/test_safe_get.py
+++ b/tests/unit_tests/utils/test_safe_get.py
@@ -16,6 +16,13 @@ from guardrails.utils.safe_get import safe_get
         ("123", 1, None, "2"),
         ("123", 4, None, None),
         ("123", 4, 42, 42),
+        # Falsy values must be returned, not replaced by default
+        ([0, "a", "b"], 0, None, 0),
+        ([False, "a"], 0, None, False),
+        (["", "a"], 0, None, ""),
+        # Out-of-bounds and non-subscriptable containers use default
+        ([], 0, "fallback", "fallback"),
+        (None, 0, "fallback", "fallback"),
     ],
 )
 def test_safe_get(container, key, default, expected_value):


### PR DESCRIPTION
## Summary

This fixes a bug in `safe_get_with_brackets` that treated valid falsy values as missing.

Previously, values like `0`, `False`, and `""` were replaced with the default because the code checked `if not value:`. This change narrows that check to `if value is None:`, so only missing values fall back to the default.

## Changes

- updated `guardrails/utils/safe_get.py` to preserve valid falsy values
- extended `tests/unit_tests/utils/test_safe_get.py` with regression coverage for:
  - `0`
  - `False`
  - `""`
  - out-of-bounds fallback
  - `None` container fallback

## Tests

```bash
python3.11 -m pytest tests/unit_tests/utils/test_safe_get.py -v -p no:deepeval