### PR TITLE
Auto-generate stub file for hub imports

### DIFF
--- a/guardrails/hub/validator_package_service.py
+++ b/guardrails/hub/validator_package_service.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import json
 import os
 from datetime import datetime, timezone
@@ -23,6 +24,7 @@ from guardrails.cli.hub.utils import (
 from guardrails_hub_types import Manifest
 from guardrails.cli.server.hub_client import get_validator_manifest
 from guardrails.settings import settings
+from guardrails.types.validator_registry import ValidatorRegistry
 
 
 json_format: Literal["json"] = "json"
@@ -132,6 +134,24 @@ class ValidatorPackageService:
         return ValidatorPackageService.reload_module(import_line)
 
     @staticmethod
+    def rewrite_stub_file(registry: ValidatorRegistry):
+        stub_file = (
+            Path(ValidatorPackageService.get_site_packages_location())
+            / "guardrails"
+            / "hub"
+            / "__init__.pyi"
+        )
+
+        import_statements = []
+        for v in registry.validators.values():
+            if v.exports and importlib.util.find_spec(v.import_path):
+                import_statements.extend(
+                    [f"from {v.import_path} import {e} as {e}" for e in v.exports]
+                )
+
+        stub_file.write_text("\n".join(import_statements))
+
+    @staticmethod
     def register_validator(manifest: Manifest):
         """Register a validator in the project-level JSON registry."""
         registry_file = ValidatorPackageService.get_registry_path()
@@ -168,6 +188,10 @@ class ValidatorPackageService:
 
         registry_file.write_text(json.dumps(registry, indent=2))
 
+        ValidatorPackageService.rewrite_stub_file(
+            ValidatorRegistry.model_validate(registry)
+        )
+
     @staticmethod
     def unregister_validator(validator_id: str):
         """Remove a validator from the project-level JSON registry."""
@@ -189,6 +213,9 @@ class ValidatorPackageService:
             del validators[validator_id]
             registry["validators"] = validators
             registry_file.write_text(json.dumps(registry, indent=2))
+            ValidatorPackageService.rewrite_stub_file(
+                ValidatorRegistry.model_validate(registry)
+            )
 
     @staticmethod
     def add_to_hub_inits(manifest: Manifest, site_packages: str):

--- a/guardrails/types/validator_registry.py
+++ b/guardrails/types/validator_registry.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class ValidatorRegistryEntry(BaseModel):
+    import_path: str
+    exports: list[str]
+    installed_at: str
+    package_name: str
+
+
+class ValidatorRegistry(BaseModel):
+    version: int
+    validators: dict[str, ValidatorRegistryEntry]

--- a/tests/unit_tests/hub/test_validator_package_service.py
+++ b/tests/unit_tests/hub/test_validator_package_service.py
@@ -14,6 +14,10 @@ from guardrails.hub.validator_package_service import (
     InvalidHubInstallURL,
     _GUARDRAILS_INSTALLER_ENV,
 )
+from guardrails.types.validator_registry import (
+    ValidatorRegistry,
+    ValidatorRegistryEntry,
+)
 from tests.unit_tests.mocks.mock_file import MockFile
 
 
@@ -619,6 +623,7 @@ class TestGetRegistryPath:
 
 class TestRegisterValidator:
     def test_creates_new_registry(self, tmp_path, mocker):
+        mocker.patch.object(ValidatorPackageService, "rewrite_stub_file")
         mocker.patch.object(
             ValidatorPackageService,
             "get_registry_path",
@@ -655,6 +660,7 @@ class TestRegisterValidator:
         assert "installed_at" in entry
 
     def test_appends_to_existing_registry(self, tmp_path, mocker):
+        mocker.patch.object(ValidatorPackageService, "rewrite_stub_file")
         registry_dir = tmp_path / ".guardrails"
         registry_dir.mkdir()
         registry_file = registry_dir / "hub_registry.json"
@@ -701,6 +707,7 @@ class TestRegisterValidator:
         assert "guardrails/detect_pii" in registry["validators"]
 
     def test_overwrites_existing_entry(self, tmp_path, mocker):
+        mocker.patch.object(ValidatorPackageService, "rewrite_stub_file")
         registry_dir = tmp_path / ".guardrails"
         registry_dir.mkdir()
         registry_file = registry_dir / "hub_registry.json"
@@ -751,6 +758,7 @@ class TestRegisterValidator:
 
 class TestUnregisterValidator:
     def test_removes_validator_from_registry(self, tmp_path, mocker):
+        mocker.patch.object(ValidatorPackageService, "rewrite_stub_file")
         registry_dir = tmp_path / ".guardrails"
         registry_dir.mkdir()
         registry_file = registry_dir / "hub_registry.json"
@@ -877,3 +885,378 @@ class TestInstallHubModuleWithInstaller:
             quiet=False,
             installer=detected_installer,
         )
+
+
+class TestValidatorRegistryModels:
+    def test_entry_model_validation(self):
+        entry = ValidatorRegistryEntry(
+            import_path="guardrails_grhub_detect_pii",
+            exports=["DetectPII"],
+            installed_at="2025-01-01T00:00:00+00:00",
+            package_name="guardrails-grhub-detect-pii",
+        )
+        assert entry.import_path == "guardrails_grhub_detect_pii"
+        assert entry.exports == ["DetectPII"]
+        assert entry.package_name == "guardrails-grhub-detect-pii"
+
+    def test_registry_model_validation(self):
+        registry = ValidatorRegistry(
+            version=1,
+            validators={
+                "guardrails/detect_pii": ValidatorRegistryEntry(
+                    import_path="guardrails_grhub_detect_pii",
+                    exports=["DetectPII"],
+                    installed_at="2025-01-01T00:00:00+00:00",
+                    package_name="guardrails-grhub-detect-pii",
+                )
+            },
+        )
+        assert registry.version == 1
+        assert "guardrails/detect_pii" in registry.validators
+
+    def test_registry_model_validate_from_dict(self):
+        data = {
+            "version": 1,
+            "validators": {
+                "guardrails/regex_match": {
+                    "import_path": "guardrails_grhub_regex_match",
+                    "exports": ["RegexMatch"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-regex-match",
+                }
+            },
+        }
+        registry = ValidatorRegistry.model_validate(data)
+        assert registry.version == 1
+        entry = registry.validators["guardrails/regex_match"]
+        assert entry.exports == ["RegexMatch"]
+
+    def test_entry_empty_exports(self):
+        entry = ValidatorRegistryEntry(
+            import_path="guardrails_grhub_foo",
+            exports=[],
+            installed_at="2025-01-01T00:00:00+00:00",
+            package_name="guardrails-grhub-foo",
+        )
+        assert entry.exports == []
+
+    def test_registry_empty_validators(self):
+        registry = ValidatorRegistry(version=1, validators={})
+        assert registry.validators == {}
+
+
+class TestRewriteStubFile:
+    def _make_registry(self, validators: dict) -> ValidatorRegistry:
+        return ValidatorRegistry.model_validate(
+            {"version": 1, "validators": validators}
+        )
+
+    def test_writes_import_for_available_validator(self, mocker, tmp_path):
+        stub_dir = tmp_path / "guardrails" / "hub"
+        stub_dir.mkdir(parents=True)
+
+        mocker.patch(
+            "guardrails.hub.validator_package_service"
+            ".ValidatorPackageService.get_site_packages_location",
+            return_value=str(tmp_path),
+        )
+        mocker.patch(
+            "guardrails.hub.validator_package_service.importlib.util.find_spec",
+            return_value=MagicMock(),
+        )
+
+        registry = self._make_registry(
+            {
+                "guardrails/detect_pii": {
+                    "import_path": "guardrails_grhub_detect_pii",
+                    "exports": ["DetectPII"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-detect-pii",
+                }
+            }
+        )
+
+        ValidatorPackageService.rewrite_stub_file(registry)
+
+        stub_file = stub_dir / "__init__.pyi"
+        assert stub_file.exists()
+        content = stub_file.read_text()
+        assert "from guardrails_grhub_detect_pii import DetectPII" in content
+
+    def test_skips_unavailable_module(self, mocker, tmp_path):
+        stub_dir = tmp_path / "guardrails" / "hub"
+        stub_dir.mkdir(parents=True)
+
+        mocker.patch(
+            "guardrails.hub.validator_package_service"
+            ".ValidatorPackageService.get_site_packages_location",
+            return_value=str(tmp_path),
+        )
+        mocker.patch(
+            "guardrails.hub.validator_package_service.importlib.util.find_spec",
+            return_value=None,
+        )
+
+        registry = self._make_registry(
+            {
+                "guardrails/detect_pii": {
+                    "import_path": "guardrails_grhub_detect_pii",
+                    "exports": ["DetectPII"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-detect-pii",
+                }
+            }
+        )
+
+        ValidatorPackageService.rewrite_stub_file(registry)
+
+        stub_file = stub_dir / "__init__.pyi"
+        assert stub_file.read_text() == ""
+
+    def test_skips_validator_with_no_exports(self, mocker, tmp_path):
+        stub_dir = tmp_path / "guardrails" / "hub"
+        stub_dir.mkdir(parents=True)
+
+        mocker.patch(
+            "guardrails.hub.validator_package_service"
+            ".ValidatorPackageService.get_site_packages_location",
+            return_value=str(tmp_path),
+        )
+        mocker.patch(
+            "guardrails.hub.validator_package_service.importlib.util.find_spec",
+            return_value=MagicMock(),
+        )
+
+        registry = self._make_registry(
+            {
+                "guardrails/detect_pii": {
+                    "import_path": "guardrails_grhub_detect_pii",
+                    "exports": [],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-detect-pii",
+                }
+            }
+        )
+
+        ValidatorPackageService.rewrite_stub_file(registry)
+
+        stub_file = stub_dir / "__init__.pyi"
+        assert stub_file.read_text() == ""
+
+    def test_writes_multiple_validators(self, mocker, tmp_path):
+        stub_dir = tmp_path / "guardrails" / "hub"
+        stub_dir.mkdir(parents=True)
+
+        mocker.patch(
+            "guardrails.hub.validator_package_service"
+            ".ValidatorPackageService.get_site_packages_location",
+            return_value=str(tmp_path),
+        )
+        mocker.patch(
+            "guardrails.hub.validator_package_service.importlib.util.find_spec",
+            return_value=MagicMock(),
+        )
+
+        registry = self._make_registry(
+            {
+                "guardrails/detect_pii": {
+                    "import_path": "guardrails_grhub_detect_pii",
+                    "exports": ["DetectPII"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-detect-pii",
+                },
+                "guardrails/regex_match": {
+                    "import_path": "guardrails_grhub_regex_match",
+                    "exports": ["RegexMatch"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-regex-match",
+                },
+            }
+        )
+
+        ValidatorPackageService.rewrite_stub_file(registry)
+
+        stub_file = stub_dir / "__init__.pyi"
+        content = stub_file.read_text()
+        assert "from guardrails_grhub_detect_pii import DetectPII" in content
+        assert "from guardrails_grhub_regex_match import RegexMatch" in content
+
+    def test_writes_multiple_exports_on_one_line(self, mocker, tmp_path):
+        stub_dir = tmp_path / "guardrails" / "hub"
+        stub_dir.mkdir(parents=True)
+
+        mocker.patch(
+            "guardrails.hub.validator_package_service"
+            ".ValidatorPackageService.get_site_packages_location",
+            return_value=str(tmp_path),
+        )
+        mocker.patch(
+            "guardrails.hub.validator_package_service.importlib.util.find_spec",
+            return_value=MagicMock(),
+        )
+
+        registry = self._make_registry(
+            {
+                "guardrails/detect_pii": {
+                    "import_path": "guardrails_grhub_detect_pii",
+                    "exports": ["DetectPII", "DetectPIIv2"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-detect-pii",
+                }
+            }
+        )
+
+        ValidatorPackageService.rewrite_stub_file(registry)
+
+        stub_file = stub_dir / "__init__.pyi"
+        content = stub_file.read_text()
+        assert (
+            "from guardrails_grhub_detect_pii import DetectPII as DetectPII" in content
+        )
+        assert (
+            "from guardrails_grhub_detect_pii import DetectPIIv2 as DetectPIIv2"
+            in content
+        )
+
+    def test_empty_registry_writes_empty_stub(self, mocker, tmp_path):
+        stub_dir = tmp_path / "guardrails" / "hub"
+        stub_dir.mkdir(parents=True)
+
+        mocker.patch(
+            "guardrails.hub.validator_package_service"
+            ".ValidatorPackageService.get_site_packages_location",
+            return_value=str(tmp_path),
+        )
+
+        registry = self._make_registry({})
+
+        ValidatorPackageService.rewrite_stub_file(registry)
+
+        stub_file = stub_dir / "__init__.pyi"
+        assert stub_file.read_text() == ""
+
+
+class TestRegisterValidatorCallsRewriteStub:
+    def test_calls_rewrite_stub_file(self, tmp_path, mocker):
+        mocker.patch.object(
+            ValidatorPackageService,
+            "get_registry_path",
+            return_value=tmp_path / ".guardrails" / "hub_registry.json",
+        )
+        mock_rewrite = mocker.patch.object(ValidatorPackageService, "rewrite_stub_file")
+
+        manifest = Manifest.from_dict(
+            {
+                "id": "guardrails/detect_pii",
+                "name": "detect_pii",
+                "author": {"name": "test", "email": "t@t.com"},
+                "maintainers": [],
+                "repository": {"url": "https://github.com/test/test"},
+                "namespace": "guardrails",
+                "packageName": "detect-pii",
+                "moduleName": "detect_pii",
+                "description": "Detect PII",
+                "exports": ["DetectPII"],
+                "tags": {},
+            }
+        )
+        manifest = cast(Manifest, manifest)
+
+        ValidatorPackageService.register_validator(manifest)
+
+        mock_rewrite.assert_called_once()
+        registry_arg = mock_rewrite.call_args[0][0]
+        assert isinstance(registry_arg, ValidatorRegistry)
+        assert "guardrails/detect_pii" in registry_arg.validators
+
+    def test_skips_registry_and_stub_when_id_missing_namespace(self, tmp_path, mocker):
+        mocker.patch.object(
+            ValidatorPackageService,
+            "get_registry_path",
+            return_value=tmp_path / ".guardrails" / "hub_registry.json",
+        )
+        mock_rewrite = mocker.patch.object(ValidatorPackageService, "rewrite_stub_file")
+
+        manifest = Manifest.from_dict(
+            {
+                "id": "no-namespace",
+                "name": "no_namespace",
+                "author": {"name": "test", "email": "t@t.com"},
+                "maintainers": [],
+                "repository": {"url": "https://github.com/test/test"},
+                "namespace": "guardrails",
+                "packageName": "no-namespace",
+                "moduleName": "no_namespace",
+                "description": "No namespace",
+                "exports": ["NoNamespace"],
+                "tags": {},
+            }
+        )
+        manifest = cast(Manifest, manifest)
+
+        ValidatorPackageService.register_validator(manifest)
+
+        mock_rewrite.assert_not_called()
+
+
+class TestUnregisterValidatorCallsRewriteStub:
+    def test_calls_rewrite_stub_when_validator_removed(self, tmp_path, mocker):
+        registry_dir = tmp_path / ".guardrails"
+        registry_dir.mkdir()
+        registry_file = registry_dir / "hub_registry.json"
+        existing = {
+            "version": 1,
+            "validators": {
+                "guardrails/detect-pii": {
+                    "import_path": "guardrails_grhub_detect_pii",
+                    "exports": ["DetectPII"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-detect-pii",
+                }
+            },
+        }
+        registry_file.write_text(json.dumps(existing))
+
+        mocker.patch.object(
+            ValidatorPackageService,
+            "get_registry_path",
+            return_value=registry_file,
+        )
+        mock_rewrite = mocker.patch.object(ValidatorPackageService, "rewrite_stub_file")
+
+        ValidatorPackageService.unregister_validator("guardrails/detect-pii")
+
+        mock_rewrite.assert_called_once()
+        registry_arg = mock_rewrite.call_args[0][0]
+        assert isinstance(registry_arg, ValidatorRegistry)
+        assert "guardrails/detect-pii" not in registry_arg.validators
+
+    def test_does_not_call_rewrite_stub_when_validator_not_present(
+        self, tmp_path, mocker
+    ):
+        registry_dir = tmp_path / ".guardrails"
+        registry_dir.mkdir()
+        registry_file = registry_dir / "hub_registry.json"
+        existing = {
+            "version": 1,
+            "validators": {
+                "guardrails/regex-match": {
+                    "import_path": "guardrails_grhub_regex_match",
+                    "exports": ["RegexMatch"],
+                    "installed_at": "2025-01-01T00:00:00+00:00",
+                    "package_name": "guardrails-grhub-regex-match",
+                }
+            },
+        }
+        registry_file.write_text(json.dumps(existing))
+
+        mocker.patch.object(
+            ValidatorPackageService,
+            "get_registry_path",
+            return_value=registry_file,
+        )
+        mock_rewrite = mocker.patch.object(ValidatorPackageService, "rewrite_stub_file")
+
+        ValidatorPackageService.unregister_validator("guardrails/detect-pii")
+
+        mock_rewrite.assert_not_called()


### PR DESCRIPTION
Augments the dynamic registry introduced in https://github.com/guardrails-ai/guardrails/pull/1422 with a stub file to enable autocompletion/intellisense.

Similar to the previous `add_to_hub_inits` and `remove_from_hub_inits`, `rewrite_stub_file` creates a barrel file for hub validators during install/uninstall operations.  However, it now uses the json registry introduced in https://github.com/guardrails-ai/guardrails/pull/1416 and produced a `.pyi` stub file for typing and autocompletions, allowing the dynamic registry to handle the actual imports at runtime.

Autocompletion was tested in VS Code and PyCharm and shows both autocompletions for imports as well as method signatures on the validator classes themselves (i.e. full backwards compatibility).