### PR TITLE
Add Novita AI as an LLM provider

### DIFF
--- a/guardrails/utils/novita_utils.py
+++ b/guardrails/utils/novita_utils.py
@@ -1,0 +1,108 @@
+"""Utilities for using Novita AI as an LLM provider with Guardrails.
+
+Novita AI exposes an OpenAI-compatible endpoint at https://api.novita.ai/openai,
+so it integrates naturally with Guardrails via LiteLLM.
+
+Usage (LiteLLM path, recommended):
+
+    import guardrails as gd
+    from guardrails.utils.novita_utils import novita_completion_kwargs
+
+    guard = gd.Guard()
+    result = guard(
+        messages=[{"role": "user", "content": "Hello!"}],
+        **novita_completion_kwargs("moonshotai/kimi-k2.5"),
+    )
+
+Usage (direct OpenAI-SDK path):
+
+    from guardrails.utils.novita_utils import NovitaClient
+
+    client = NovitaClient()
+    response = client.create_chat_completion(
+        model="moonshotai/kimi-k2.5",
+        messages=[{"role": "user", "content": "Hello!"}],
+    )
+"""
+
+import os
+from typing import Optional
+
+from guardrails.utils.openai_utils.v1 import OpenAIClientV1 as OpenAIClient
+
+NOVITA_API_BASE = "https://api.novita.ai/openai"
+
+# Supported chat/completion model IDs
+NOVITA_MODELS = [
+    "moonshotai/kimi-k2.5",
+    "zai-org/glm-5",
+    "minimax/minimax-m2.5",
+]
+
+# Default model
+NOVITA_DEFAULT_MODEL = "moonshotai/kimi-k2.5"
+
+
+class NovitaClient(OpenAIClient):
+    """OpenAI-compatible client pre-configured for Novita AI.
+
+    Reads ``NOVITA_API_KEY`` from the environment when ``api_key`` is not
+    supplied explicitly.  Falls back to ``OPENAI_API_KEY`` for compatibility
+    with repos that share a single key env var.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        *args,
+        **kwargs,
+    ):
+        if api_key is None:
+            api_key = os.environ.get("NOVITA_API_KEY") or os.environ.get(
+                "OPENAI_API_KEY"
+            )
+        if api_base is None:
+            api_base = os.environ.get("NOVITA_API_BASE", NOVITA_API_BASE)
+        super().__init__(api_key=api_key, api_base=api_base, *args, **kwargs)
+
+
+def novita_completion_kwargs(
+    model: str = NOVITA_DEFAULT_MODEL,
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+) -> dict:
+    """Return kwargs to pass to ``guard()`` for a Novita AI model via LiteLLM.
+
+    LiteLLM routes to an OpenAI-compatible endpoint when ``api_base`` is
+    provided alongside an ``openai/`` prefixed model string.
+
+    Args:
+        model: Novita model ID (e.g. ``"moonshotai/kimi-k2.5"``).
+        api_key: Novita API key.  Defaults to ``NOVITA_API_KEY`` env var.
+        api_base: Novita base URL.  Defaults to ``NOVITA_API_BASE``.
+
+    Returns:
+        Dict with ``model``, ``api_base``, and ``api_key`` ready to unpack
+        into ``guard()``.
+    """
+    resolved_key = api_key or os.environ.get("NOVITA_API_KEY") or os.environ.get(
+        "OPENAI_API_KEY"
+    )
+    resolved_base = api_base or os.environ.get("NOVITA_API_BASE", NOVITA_API_BASE)
+    # LiteLLM requires the "openai/" prefix to route to a custom OpenAI-compatible base
+    litellm_model = f"openai/{model}"
+    return {
+        "model": litellm_model,
+        "api_base": resolved_base,
+        "api_key": resolved_key,
+    }
+
+
+__all__ = [
+    "NOVITA_API_BASE",
+    "NOVITA_DEFAULT_MODEL",
+    "NOVITA_MODELS",
+    "NovitaClient",
+    "novita_completion_kwargs",
+]

--- a/tests/integration_tests/test_novita.py
+++ b/tests/integration_tests/test_novita.py
@@ -1,0 +1,118 @@
+"""Integration tests for Novita AI provider support.
+
+These tests require a valid NOVITA_API_KEY environment variable to run.
+They verify that Guardrails can call Novita AI's OpenAI-compatible endpoint
+through both the LiteLLM path and the direct OpenAI-SDK (NovitaClient) path.
+"""
+
+import asyncio
+import importlib
+import os
+
+import pytest
+
+import guardrails as gd
+from guardrails.utils.novita_utils import (
+    NovitaClient,
+    novita_completion_kwargs,
+    NOVITA_DEFAULT_MODEL,
+)
+
+
+def _has_novita_key() -> bool:
+    key = os.environ.get("NOVITA_API_KEY")
+    return key not in (None, "", "mocked")
+
+
+def _has_litellm() -> bool:
+    return importlib.util.find_spec("litellm") is not None
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_litellm(), reason="`litellm` is not installed")
+@pytest.mark.skipif(not _has_novita_key(), reason="NOVITA_API_KEY not set")
+def test_novita_litellm_basic():
+    """Guard can call Novita via LiteLLM and return validated output."""
+    guard = gd.Guard()
+    result = guard(
+        messages=[{"role": "user", "content": "Name 5 fruits, one per line."}],
+        **novita_completion_kwargs(NOVITA_DEFAULT_MODEL),
+    )
+    assert result.validated_output
+
+
+@pytest.mark.skipif(not _has_litellm(), reason="`litellm` is not installed")
+@pytest.mark.skipif(not _has_novita_key(), reason="NOVITA_API_KEY not set")
+def test_novita_litellm_tools():
+    """Guard structured-output (function-calling tools) works with Novita."""
+    from typing import List
+    from pydantic import BaseModel
+
+    class Fruit(BaseModel):
+        name: str
+        color: str
+
+    class Fruits(BaseModel):
+        items: List[Fruit]
+
+    guard = gd.Guard.for_pydantic(Fruits)
+    result = guard(
+        messages=[{"role": "user", "content": "Name 5 unique fruits."}],
+        tools=guard.json_function_calling_tool([]),
+        tool_choice="required",
+        **novita_completion_kwargs(NOVITA_DEFAULT_MODEL),
+    )
+    assert result.validated_output
+
+
+@pytest.mark.skipif(not _has_litellm(), reason="`litellm` is not installed")
+@pytest.mark.skipif(not _has_novita_key(), reason="NOVITA_API_KEY not set")
+def test_novita_litellm_async():
+    """AsyncGuard works with Novita via LiteLLM."""
+    guard = gd.AsyncGuard()
+    result = asyncio.run(
+        guard(
+            messages=[{"role": "user", "content": "Name 5 fruits, one per line."}],
+            **novita_completion_kwargs(NOVITA_DEFAULT_MODEL),
+        )
+    )
+    assert result.validated_output
+
+
+# ---------------------------------------------------------------------------
+# Direct NovitaClient path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_novita_key(), reason="NOVITA_API_KEY not set")
+def test_novita_client_chat_completion():
+    """NovitaClient.create_chat_completion returns an LLMResponse."""
+    client = NovitaClient()
+    response = client.create_chat_completion(
+        model=NOVITA_DEFAULT_MODEL,
+        messages=[{"role": "user", "content": "Say hello."}],
+    )
+    assert response.output
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: helper returns well-formed kwargs dict (no API call needed)
+# ---------------------------------------------------------------------------
+
+
+def test_novita_completion_kwargs_structure():
+    """novita_completion_kwargs returns required LiteLLM kwargs."""
+    kwargs = novita_completion_kwargs("moonshotai/kimi-k2.5", api_key="test-key")
+    assert kwargs["model"] == "openai/moonshotai/kimi-k2.5"
+    assert "novita.ai" in kwargs["api_base"]
+    assert kwargs["api_key"] == "test-key"
+
+
+def test_novita_client_uses_novita_base():
+    """NovitaClient defaults to the Novita API base URL."""
+    client = NovitaClient(api_key="test-key")
+    assert "novita.ai" in client.api_base


### PR DESCRIPTION
## Summary

- Adds `guardrails/utils/novita_utils.py` with a `NovitaClient` (subclass of `OpenAIClientV1`) and a `novita_completion_kwargs()` helper that makes it easy to target Novita AI's OpenAI-compatible endpoint (`https://api.novita.ai/openai`) through the existing LiteLLM code path.
- Adds `tests/integration_tests/test_novita.py` covering basic chat, function-calling tools, async usage, the direct `NovitaClient` path, and two unit-level tests that assert kwargs structure without requiring any API key.

## How it works

Guardrails already routes all API calls through LiteLLM (`LiteLLMCallable`).  LiteLLM supports any OpenAI-compatible backend via `api_base` + an `openai/<model>` prefix.  No changes to existing provider files were necessary.

```python
import guardrails as gd
from guardrails.utils.novita_utils import novita_completion_kwargs

guard = gd.Guard()
result = guard(
    messages=[{"role": "user", "content": "Name 5 fruits."}],
    **novita_completion_kwargs("moonshotai/kimi-k2.5"),  # reads NOVITA_API_KEY
)
```

## Supported models

| Model ID | Notes |
|---|---|
| `moonshotai/kimi-k2.5` | Default — 262K context, vision, function calling |
| `zai-org/glm-5` | 202K context, function calling |
| `minimax/minimax-m2.5` | 204K context, function calling |

## Checklist

- [x] No existing files modified
- [x] `NovitaClient` reads `NOVITA_API_KEY` (falls back to `OPENAI_API_KEY`)
- [x] `novita_completion_kwargs` returns correctly prefixed LiteLLM model string
- [x] Integration tests skip when `NOVITA_API_KEY` is not set
- [x] Two unit tests require no API key