### PR TITLE
docs: clarify on_fail="refrain" behavior and document validator return semantics

### DIFF
--- a/docs/how_to_guides/output.md
+++ b/docs/how_to_guides/output.md
@@ -317,6 +317,53 @@ The `on-fail-{quality-criteria}` attribute allows specifying the corrective acti
 | `exception`  | Raise an exception when validation fails.                                                                                                                                                      |
 | `fix_reask` | First, fix the generated output deterministically, and then rerun validation with the deterministically fixed output. If validation fails, then perform reasking.             |
 
+---
+
+##  Important: When does `refrain` actually trigger?
+
+`on-fail` actions (including `refrain`) are only triggered when a validator explicitly returns a `FailResult`.
+
+### Execution flow
+
+- `PassResult` → ❌ No corrective action is triggered  
+- `FailResult` → ✅ Corrective action (e.g. `refrain`) is applied  
+
+This means that even if a validator internally detects an issue, the `refrain` action will **not** be applied unless the validator returns a `FailResult`.
+
+---
+
+##  Understanding `refrain` vs `noop`
+
+These two actions are often confused but behave differently:
+
+| Action | Output returned | Validation status | Use case |
+|--------|----------------|------------------|----------|
+| `noop` | Original value | `False` | Logging/observability |
+| `refrain` | `None` | `False` | Block unsafe output |
+
+- **`refrain`** ensures no output is returned when validation fails  
+- **`noop`** allows the original value to pass through even on failure  
+
+---
+
+## Note on LLM-based validators
+
+For validators that rely on LLM calls (e.g. content moderation or prompt analysis):
+
+- In some edge cases (such as ambiguous or unparseable LLM responses), a validator may return a `PassResult`
+- When this happens, `on-fail="refrain"` will **not** be triggered
+- This can result in:
+  - `validation_passed=True`
+  - Original input being returned
+  - An `error` field being populated from a separate execution path
+
+This behavior is expected and depends on the validator’s return value, not the `refrain` action itself.
+
+### Recommendation
+
+For safety-critical use cases:
+- Prefer deterministic validators  
+- Or use stricter actions such as `on_fail="exception"`  
 
 ## 🚒 Adding compiled `output` element to prompt
 

--- a/tests/integration_tests/test_validator_base.py
+++ b/tests/integration_tests/test_validator_base.py
@@ -7,6 +7,7 @@ from guardrails.guard import Guard
 from guardrails.validator_base import (
     FailResult,
     ValidationResult,
+    PassResult,
     Validator,
     register_validator,
 )
@@ -102,3 +103,38 @@ def test_validator_instance_attr_equality(mocker, instance_attr):
     )
 
     assert guard._validators[0].an_instance_attr == instance_attr
+    
+    
+def test_on_fail_refrain_only_triggers_on_fail_result():
+    """
+    Ensures that on_fail='refrain' only triggers when the validator
+    explicitly returns FailResult.
+    """
+
+    @register_validator(name="pass-despite-issue", data_type="string")
+    def pass_despite_issue(value, metadata):
+        return PassResult()
+
+    guard = Guard().use(pass_despite_issue(on_fail="refrain"))
+    result = guard.parse("harmful input")
+
+    assert result.validation_passed is True
+    assert result.validated_output == "harmful input"
+    assert result.error is None
+
+
+def test_on_fail_refrain_blocks_output_on_fail_result():
+    """
+    Ensures that on_fail='refrain' correctly suppresses output
+    when the validator returns FailResult.
+    """
+
+    @register_validator(name="always-fails-test", data_type="string")
+    def always_fails(value, metadata):
+        return FailResult(error_message="blocked")
+
+    guard = Guard().use(always_fails(on_fail="refrain"))
+    result = guard.parse("harmful input")
+
+    assert result.validation_passed is False
+    assert result.validated_output is None


### PR DESCRIPTION
Closes #1395

## Summary
This PR clarifies the behavior of `on_fail="refrain"` and documents how
validator return values (`PassResult` vs `FailResult`) determine whether
`on_fail` actions are triggered.

The existing implementation of `refrain` is correct, but its behavior can
be confusing—particularly when used with validators that may return
`PassResult` in edge cases (e.g., LLM-based validators). This PR improves
documentation and adds tests to make the behavior explicit.

---

## Changes

###  Documentation
- Added a section explaining when `refrain` is triggered
- Documented execution flow:
  - `PassResult` → no `on_fail` action
  - `FailResult` → `on_fail` action applied
- Added comparison between `refrain` and `noop`
- Added clarification for LLM-based validators where `PassResult` may be returned in ambiguous scenarios

###  Tests
- Added test verifying that `on_fail="refrain"` only triggers on `FailResult`
- Added test confirming that `PassResult` does not trigger `refrain`

---

## Context

The confusion reported in #1395 stems from validators that internally detect
issues but return `PassResult` (e.g., due to ambiguous LLM responses). Since
`on_fail` actions are only triggered on `FailResult`, this can give the
impression that `refrain` is not working as expected.

This PR does not modify core logic. Instead, it clarifies the expected
behavior and ensures it is explicitly documented and tested.

---

## Testing
- Ran existing test suite (targeted validator tests)
- Added new tests covering both triggering and non-triggering scenarios
- All relevant tests pass locally

---

## Notes
Happy to adjust wording, structure, or placement if needed.