### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with new_event_loop()

### DIFF
--- a/guardrails/validator_service/__init__.py
+++ b/guardrails/validator_service/__init__.py
@@ -47,7 +47,9 @@ def get_loop() -> asyncio.AbstractEventLoop:
     if uvloop is not None:
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
-    return asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
 
 
 def validate(

--- a/tests/integration_tests/validator_service/test_async_validator_service_it.py
+++ b/tests/integration_tests/validator_service/test_async_validator_service_it.py
@@ -109,7 +109,8 @@ class TestValidatorConcurrency:
 
         async_validator_service = AsyncValidatorService()
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         value, metadata = async_validator_service.validate(
             value="value",
             metadata={"order": []},
@@ -180,7 +181,8 @@ class TestValidatorConcurrency:
 
         async_validator_service = AsyncValidatorService()
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         value, metadata = async_validator_service.validate(
             value="value",
             metadata={"order": []},
@@ -251,7 +253,8 @@ class TestValidatorConcurrency:
 
         async_validator_service = AsyncValidatorService()
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         value, metadata = async_validator_service.validate(
             value="value",
             metadata={"order": []},

--- a/tests/integration_tests/validator_service/test_init.py
+++ b/tests/integration_tests/validator_service/test_init.py
@@ -1,4 +1,4 @@
-from asyncio import get_event_loop
+import asyncio
 from asyncio.unix_events import _UnixSelectorEventLoop
 import os
 import pytest
@@ -41,7 +41,8 @@ class TestShouldRunSync:
 
 class TestGetLoop:
     def test_raises_if_loop_is_running(self):
-        loop = get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
         async def callback():
             # NOTE: This means only AsyncGuard will parallelize validators
@@ -49,7 +50,10 @@ class TestGetLoop:
             with pytest.raises(RuntimeError, match="An event loop is already running."):
                 get_loop()
 
-        loop.run_until_complete(callback())
+        try:
+            loop.run_until_complete(callback())
+        finally:
+            loop.close()
 
     @pytest.mark.skipif(uvloop is None, reason="uvloop is not installed")
     def test_uvloop_is_used_when_installed(self):
@@ -128,7 +132,8 @@ class TestValidate:
             index=0,
         )
 
-        loop = get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
         async def callback():
             with pytest.warns(
@@ -147,7 +152,10 @@ class TestValidate:
                 assert value == "value"
                 assert metadata == {}
 
-        loop.run_until_complete(callback())
+        try:
+            loop.run_until_complete(callback())
+        finally:
+            loop.close()
 
         SequentialValidatorService.__init__.assert_called_once()
         SequentialValidatorService.validate.assert_called_once()

--- a/tests/unit_tests/validator_service/test_validator_service.py
+++ b/tests/unit_tests/validator_service/test_validator_service.py
@@ -40,8 +40,11 @@ class TestGetLoop:
             side_effect=RuntimeError,
         )
         mocker.patch(
-            "guardrails.validator_service.asyncio.get_event_loop",
+            "guardrails.validator_service.asyncio.new_event_loop",
             return_value="event loop",
+        )
+        mocker.patch(
+            "guardrails.validator_service.asyncio.set_event_loop",
         )
         assert vs.get_loop() == "event loop"
 
@@ -55,8 +58,11 @@ class TestGetLoop:
             side_effect=RuntimeError,
         )
         mocker.patch(
-            "guardrails.validator_service.asyncio.get_event_loop",
+            "guardrails.validator_service.asyncio.new_event_loop",
             return_value="event loop",
+        )
+        mock_set_event_loop = mocker.patch(
+            "guardrails.validator_service.asyncio.set_event_loop",
         )
         mock_set_event_loop_policy = mocker.patch("asyncio.set_event_loop_policy")
 
@@ -66,6 +72,7 @@ class TestGetLoop:
         mock_set_event_loop_policy.assert_called_once_with(
             mock_event_loop_policy.return_value
         )
+        mock_set_event_loop.assert_called_once_with("event loop")
 
 
 class TestValidate:


### PR DESCRIPTION
## Summary

Fixes #1449

`asyncio.get_event_loop()` no longer implicitly creates an event loop when none exists in the current thread. This was deprecated in Python 3.10 ([cpython#83710](https://github.com/python/cpython/issues/83710)), emits `DeprecationWarning` in 3.12, and raises `RuntimeError` in Python 3.14. uvloop 0.22+ aligns with the 3.14 behavior, so `get_loop()` in `guardrails/validator_service/__init__.py` fails immediately when uvloop is installed.

## Root Cause

`get_loop()` called `asyncio.get_event_loop()` (line 50) after confirming no loop is running. With uvloop >= 0.22, this raises `RuntimeError("There is no current event loop in thread 'MainThread'.")` instead of creating a new loop. The same failure propagated to test helpers that also called `get_event_loop()` directly.

## Changes

- `guardrails/validator_service/__init__.py`: replace `asyncio.get_event_loop()` with `asyncio.new_event_loop()` + `asyncio.set_event_loop(loop)` — the forward-compatible pattern
- `tests/unit_tests/validator_service/test_validator_service.py`: update mocks to match new API calls
- `tests/integration_tests/validator_service/test_init.py`: replace deprecated `get_event_loop()` calls, add proper `loop.close()` cleanup
- `tests/integration_tests/validator_service/test_async_validator_service_it.py`: same `get_event_loop()` → `new_event_loop()` fix

## Testing

- [x] All 23 validator service tests pass (0 failures, was 6 failures before)
- [x] All 681 unit tests pass (no regressions from this change)
- [x] Lint clean (`ruff check`)

```bash
# Verify:
pip install uvloop  # >= 0.22
pytest tests/unit_tests/validator_service/test_validator_service.py tests/integration_tests/validator_service/ -v
```

## Notes

Minimal fix — only changes the loop acquisition path and corresponding test call sites. The existing guard against calling `get_loop()` from within a running event loop (lines 39-45) is preserved unchanged.