### PR TITLE
feat: add MiniMax provider support with M3 as default

### DIFF
--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -1,8 +1,10 @@
 import asyncio
+import os
 
 import inspect
 from typing import (
     Any,
+    AsyncIterator,
     Awaitable,
     Callable,
     Dict,
@@ -253,6 +255,117 @@ class LiteLLMCallable(PromptCallableBase):
             output=output,  # type: ignore
             prompt_token_count=prompt_tokens,  # type: ignore
             response_token_count=completion_tokens,  # type: ignore
+        )
+
+
+MINIMAX_MODELS = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+MINIMAX_DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+
+
+class MiniMaxCallable(PromptCallableBase):
+    """Wrapper for MiniMax API using the OpenAI-compatible endpoint.
+
+    Supports ``MiniMax-M2.7`` and ``MiniMax-M2.7-highspeed``.
+
+    To use MiniMax with guardrails, do::
+
+        raw_llm_response, validated_response, *rest = guard(
+            None,
+            model="minimax/MiniMax-M2.7",
+            prompt_params={...},
+        )
+
+    Set the ``MINIMAX_API_KEY`` environment variable before calling.
+    """
+
+    def _invoke_llm(
+        self,
+        text: Optional[str] = None,
+        model: str = "minimax/MiniMax-M2.7",
+        messages: Optional[List[Dict]] = None,
+        *args,
+        **kwargs,
+    ) -> LLMResponse:
+        try:
+            from openai import OpenAI
+        except ImportError as e:
+            raise PromptCallableException(
+                "The `openai` package is not installed. "
+                "Install with `pip install openai`"
+            ) from e
+
+        api_key = kwargs.pop("api_key", None) or os.environ.get("MINIMAX_API_KEY")
+        base_url = kwargs.pop("base_url", None) or os.environ.get(
+            "MINIMAX_BASE_URL", MINIMAX_DEFAULT_BASE_URL
+        )
+
+        if not api_key:
+            raise PromptCallableException(
+                "MiniMax API key not found. "
+                "Set the MINIMAX_API_KEY environment variable."
+            )
+
+        # Strip "minimax/" prefix so we pass only the bare model name to the API.
+        model_name = model.removeprefix("minimax/")
+
+        # MiniMax requires temperature in (0.0, 1.0]; default to 1.0.
+        temperature = kwargs.pop("temperature", 1.0)
+        if temperature == 0 or temperature is None:
+            temperature = 1.0
+        kwargs["temperature"] = temperature
+
+        call_messages: List[Dict]
+        if messages is not None:
+            call_messages = litellm_messages(prompt=text, messages=messages)
+        elif text is not None:
+            call_messages = [{"role": "user", "content": text}]
+        else:
+            raise PromptCallableException(
+                "Either `text` or `messages` must be provided to MiniMaxCallable."
+            )
+
+        # Remove guardrails-internal kwarg before forwarding to the API.
+        kwargs.pop("reask_messages", None)
+
+        client = OpenAI(api_key=api_key, base_url=base_url)
+
+        trace_operation(
+            input_mime_type="application/json",
+            input_value={"model": model_name, "messages": call_messages, **kwargs},
+        )
+        trace_llm_call(
+            input_messages=call_messages,
+            invocation_parameters={"model": model_name, **kwargs},
+        )
+
+        response = client.chat.completions.create(
+            model=model_name,
+            messages=call_messages,  # type: ignore[arg-type]
+            **kwargs,
+        )
+
+        if kwargs.get("stream", False):
+            return LLMResponse(output="", streamOutput=cast(Iterator[str], response))
+
+        trace_operation(output_mime_type="application/json", output_value=response)
+
+        output = response.choices[0].message.content or ""  # type: ignore[union-attr]
+        completion_tokens = (
+            response.usage.completion_tokens if response.usage else None  # type: ignore[union-attr]
+        )
+        prompt_tokens = (
+            response.usage.prompt_tokens if response.usage else None  # type: ignore[union-attr]
+        )
+
+        trace_llm_call(
+            output_messages=[choice.message for choice in response.choices],  # type: ignore[union-attr]
+            token_count_completion=completion_tokens,  # type: ignore[arg-type]
+            token_count_prompt=prompt_tokens,  # type: ignore[arg-type]
+        )
+        return LLMResponse(
+            output=output,
+            prompt_token_count=prompt_tokens,  # type: ignore[arg-type]
+            response_token_count=completion_tokens,  # type: ignore[arg-type]
         )
 
 
@@ -524,6 +637,9 @@ def get_llm_ask(
         from litellm import completion
 
         if llm_api == completion or (llm_api is None and kwargs.get("model")):
+            model = kwargs.get("model", "")
+            if isinstance(model, str) and model.startswith("minimax/"):
+                return MiniMaxCallable(*args, **kwargs)
             return LiteLLMCallable(*args, **kwargs)
     except ImportError:
         pass
@@ -732,6 +848,116 @@ class AsyncLiteLLMCallable(AsyncPromptCallableBase):
         )
 
 
+class AsyncMiniMaxCallable(AsyncPromptCallableBase):
+    """Async wrapper for MiniMax API using the OpenAI-compatible endpoint.
+
+    Supports ``MiniMax-M2.7`` and ``MiniMax-M2.7-highspeed``.
+
+    To use async MiniMax with guardrails, do::
+
+        raw_llm_response, validated_response, *rest = await async_guard(
+            None,
+            model="minimax/MiniMax-M2.7",
+            prompt_params={...},
+        )
+
+    Set the ``MINIMAX_API_KEY`` environment variable before calling.
+    """
+
+    async def invoke_llm(
+        self,
+        text: Optional[str] = None,
+        model: str = "minimax/MiniMax-M2.7",
+        messages: Optional[List[Dict]] = None,
+        *args,
+        **kwargs,
+    ) -> LLMResponse:
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as e:
+            raise PromptCallableException(
+                "The `openai` package is not installed. "
+                "Install with `pip install openai`"
+            ) from e
+
+        api_key = kwargs.pop("api_key", None) or os.environ.get("MINIMAX_API_KEY")
+        base_url = kwargs.pop("base_url", None) or os.environ.get(
+            "MINIMAX_BASE_URL", MINIMAX_DEFAULT_BASE_URL
+        )
+
+        if not api_key:
+            raise PromptCallableException(
+                "MiniMax API key not found. "
+                "Set the MINIMAX_API_KEY environment variable."
+            )
+
+        # Strip "minimax/" prefix so we pass only the bare model name to the API.
+        model_name = model.removeprefix("minimax/")
+
+        # MiniMax requires temperature in (0.0, 1.0]; default to 1.0.
+        temperature = kwargs.pop("temperature", 1.0)
+        if temperature == 0 or temperature is None:
+            temperature = 1.0
+        kwargs["temperature"] = temperature
+
+        call_messages: List[Dict]
+        if messages is not None:
+            call_messages = litellm_messages(prompt=text, messages=messages)
+        elif text is not None:
+            call_messages = [{"role": "user", "content": text}]
+        else:
+            raise PromptCallableException(
+                "Either `text` or `messages` must be provided to AsyncMiniMaxCallable."
+            )
+
+        # Remove guardrails-internal kwarg before forwarding to the API.
+        kwargs.pop("reask_messages", None)
+
+        client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+        trace_operation(
+            input_mime_type="application/json",
+            input_value={"model": model_name, "messages": call_messages, **kwargs},
+        )
+        trace_llm_call(
+            input_messages=call_messages,
+            invocation_parameters={"model": model_name, **kwargs},
+        )
+
+        response = await client.chat.completions.create(
+            model=model_name,
+            messages=call_messages,  # type: ignore[arg-type]
+            **kwargs,
+        )
+
+        if kwargs.get("stream", False):
+            return LLMResponse(
+                output="",
+                asyncStreamOutput=cast(AsyncIterator[str], response),
+            )
+
+        trace_operation(output_mime_type="application/json", output_value=response)
+
+        output = response.choices[0].message.content or ""  # type: ignore[union-attr]
+        completion_tokens = (
+            response.usage.completion_tokens if response.usage else None  # type: ignore[union-attr]
+        )
+        prompt_tokens = (
+            response.usage.prompt_tokens if response.usage else None  # type: ignore[union-attr]
+        )
+
+        trace_llm_call(
+            output_messages=[choice.message for choice in response.choices],  # type: ignore[union-attr]
+            token_count_completion=completion_tokens,  # type: ignore[arg-type]
+            token_count_prompt=prompt_tokens,  # type: ignore[arg-type]
+        )
+        return LLMResponse(
+            output=output,
+            prompt_token_count=prompt_tokens,  # type: ignore[arg-type]
+            response_token_count=completion_tokens,  # type: ignore[arg-type]
+        )
+
+
 class AsyncManifestCallable(AsyncPromptCallableBase):
     async def invoke_llm(
         self,
@@ -872,6 +1098,9 @@ def get_async_llm_ask(
         import litellm
 
         if llm_api == litellm.acompletion or (llm_api is None and kwargs.get("model")):
+            model = kwargs.get("model", "")
+            if isinstance(model, str) and model.startswith("minimax/"):
+                return AsyncMiniMaxCallable(*args, **kwargs)
             return AsyncLiteLLMCallable(*args, **kwargs)
     except ImportError:
         pass

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 import inspect
 from typing import (
@@ -253,6 +254,121 @@ class LiteLLMCallable(PromptCallableBase):
             output=output,  # type: ignore
             prompt_token_count=prompt_tokens,  # type: ignore
             response_token_count=completion_tokens,  # type: ignore
+        )
+
+
+class MiniMaxCallable(PromptCallableBase):
+    def _invoke_llm(
+        self,
+        text: Optional[str] = None,
+        model: str = "MiniMax-M2.7",
+        messages: Optional[List[Dict]] = None,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.minimax.io/v1",
+        *args,
+        **kwargs,
+    ) -> LLMResponse:
+        """Wrapper for MiniMax completions via OpenAI-compatible API.
+
+        To use MiniMax for guardrails, do
+        ```
+        from guardrails.llm_providers import MiniMaxCallable
+
+        raw_llm_response, validated_response = guard(
+            MiniMaxCallable(),
+            model="MiniMax-M2.7",
+            messages=[{"role": "user", "content": "..."}],
+            ...
+        )
+        ```
+
+        Or use without an explicit callable by setting MINIMAX_API_KEY:
+        ```
+        raw_llm_response, validated_response = guard(
+            model="MiniMax-M2.7",
+            messages=[{"role": "user", "content": "..."}],
+            ...
+        )
+        ```
+        """
+        try:
+            import openai
+        except ImportError as e:
+            raise PromptCallableException(
+                "The `openai` package is not installed. "
+                "Install with `pip install openai`"
+            ) from e
+
+        resolved_api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+        if resolved_api_key is None:
+            raise PromptCallableException(
+                "MiniMax API key is required. Set the MINIMAX_API_KEY environment "
+                "variable or pass api_key as a parameter."
+            )
+
+        client = openai.Client(api_key=resolved_api_key, base_url=base_url)
+
+        msgs = messages or chat_prompt(text, kwargs.pop("instructions", None))
+
+        # MiniMax requires temperature in (0.0, 1.0]; default to 1.0
+        if kwargs.get("temperature", 0) == 0:
+            kwargs["temperature"] = 1.0
+
+        # These are guardrails-only params, not to be passed to the LLM
+        kwargs.pop("reask_messages", None)
+
+        trace_operation(
+            input_mime_type="application/json",
+            input_value={**kwargs, "model": model, "messages": msgs},
+        )
+        trace_llm_call(
+            input_messages=msgs,
+            invocation_parameters={**kwargs, "model": model},
+        )
+
+        response = client.chat.completions.create(
+            model=model,
+            messages=msgs,
+            **kwargs,
+        )
+
+        if kwargs.get("stream", False):
+            return LLMResponse(output="", streamOutput=response)
+
+        trace_operation(output_mime_type="application/json", output_value=response)
+
+        if response.choices[0].message.content is not None:
+            output = response.choices[0].message.content
+        else:
+            try:
+                output = response.choices[0].message.function_call.arguments  # type: ignore
+            except AttributeError:
+                try:
+                    output = (
+                        response.choices[0].message.tool_calls[-1].function.arguments  # type: ignore
+                    )
+                except AttributeError as ae:
+                    raise ValueError(
+                        "No message content or function call arguments returned"
+                        " from MiniMax"
+                    ) from ae
+
+        completion_tokens = response.usage.completion_tokens if response.usage else None
+        prompt_tokens = response.usage.prompt_tokens if response.usage else None
+        total_tokens = None
+        if completion_tokens or prompt_tokens:
+            total_tokens = (completion_tokens or 0) + (prompt_tokens or 0)
+
+        trace_llm_call(
+            output_messages=[choice.message for choice in response.choices],
+            token_count_completion=completion_tokens,
+            token_count_prompt=prompt_tokens,
+            token_count_total=total_tokens,
+        )
+        return LLMResponse(
+            output=output,
+            prompt_token_count=prompt_tokens,
+            response_token_count=completion_tokens,
         )
 
 
@@ -511,7 +627,11 @@ def get_llm_ask(
         model = kwargs.get("model", "")
         if not (
             isinstance(model, str)
-            and (model.startswith("gpt-5") or model.startswith("openai/gpt-5"))
+            and (
+                model.startswith("gpt-5")
+                or model.startswith("openai/gpt-5")
+                or model.startswith("MiniMax")
+            )
         ):
             warnings.warn(
                 "The default value of 0 for temperature is deprecated "
@@ -519,6 +639,17 @@ def get_llm_ask(
                 DeprecationWarning,
             )
             kwargs.update({"temperature": 0})
+
+    # If already a PromptCallableBase instance, return it directly
+    from guardrails.classes.llm.prompt_callable import PromptCallableBase as _PCB
+
+    if isinstance(llm_api, _PCB):
+        return llm_api  # type: ignore
+
+    # MiniMax models route to MiniMaxCallable before LiteLLM
+    model = kwargs.get("model", "")
+    if llm_api is None and isinstance(model, str) and model.startswith("MiniMax"):
+        return MiniMaxCallable(*args, **kwargs)
 
     try:
         from litellm import completion
@@ -732,6 +863,98 @@ class AsyncLiteLLMCallable(AsyncPromptCallableBase):
         )
 
 
+class AsyncMiniMaxCallable(AsyncPromptCallableBase):
+    async def invoke_llm(
+        self,
+        text: Optional[str] = None,
+        model: str = "MiniMax-M2.7",
+        messages: Optional[List[Dict]] = None,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.minimax.io/v1",
+        *args,
+        **kwargs,
+    ) -> LLMResponse:
+        """Async wrapper for MiniMax completions via OpenAI-compatible API."""
+        try:
+            import openai
+        except ImportError as e:
+            raise PromptCallableException(
+                "The `openai` package is not installed. "
+                "Install with `pip install openai`"
+            ) from e
+
+        resolved_api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+        if resolved_api_key is None:
+            raise PromptCallableException(
+                "MiniMax API key is required. Set the MINIMAX_API_KEY environment "
+                "variable or pass api_key as a parameter."
+            )
+
+        client = openai.AsyncClient(api_key=resolved_api_key, base_url=base_url)
+
+        msgs = messages or chat_prompt(text, kwargs.pop("instructions", None))
+
+        # MiniMax requires temperature in (0.0, 1.0]; default to 1.0
+        if kwargs.get("temperature", 0) == 0:
+            kwargs["temperature"] = 1.0
+
+        kwargs.pop("reask_messages", None)
+
+        trace_operation(
+            input_mime_type="application/json",
+            input_value={**kwargs, "model": model, "messages": msgs},
+        )
+        trace_llm_call(
+            input_messages=msgs,
+            invocation_parameters={**kwargs, "model": model},
+        )
+
+        response = await client.chat.completions.create(
+            model=model,
+            messages=msgs,
+            **kwargs,
+        )
+
+        if kwargs.get("stream", False):
+            return LLMResponse(output="", asyncStreamOutput=response)
+
+        trace_operation(output_mime_type="application/json", output_value=response)
+
+        if response.choices[0].message.content is not None:
+            output = response.choices[0].message.content
+        else:
+            try:
+                output = response.choices[0].message.function_call.arguments  # type: ignore
+            except AttributeError:
+                try:
+                    output = (
+                        response.choices[0].message.tool_calls[-1].function.arguments  # type: ignore
+                    )
+                except AttributeError as ae:
+                    raise ValueError(
+                        "No message content or function call arguments returned"
+                        " from MiniMax"
+                    ) from ae
+
+        completion_tokens = response.usage.completion_tokens if response.usage else None
+        prompt_tokens = response.usage.prompt_tokens if response.usage else None
+        total_tokens = None
+        if completion_tokens or prompt_tokens:
+            total_tokens = (completion_tokens or 0) + (prompt_tokens or 0)
+
+        trace_llm_call(
+            output_messages=[choice.message for choice in response.choices],
+            token_count_completion=completion_tokens,
+            token_count_prompt=prompt_tokens,
+            token_count_total=total_tokens,
+        )
+        return LLMResponse(
+            output=output,
+            prompt_token_count=prompt_tokens,
+            response_token_count=completion_tokens,
+        )
+
+
 class AsyncManifestCallable(AsyncPromptCallableBase):
     async def invoke_llm(
         self,
@@ -868,6 +1091,17 @@ class AsyncArbitraryCallable(AsyncPromptCallableBase):
 def get_async_llm_ask(
     llm_api: Callable[..., Awaitable[Any]], *args, **kwargs
 ) -> AsyncPromptCallableBase:
+    # If already a PromptCallableBase instance, return it directly
+    from guardrails.classes.llm.prompt_callable import PromptCallableBase as _PCB
+
+    if isinstance(llm_api, _PCB):
+        return llm_api  # type: ignore
+
+    # MiniMax models route to AsyncMiniMaxCallable before LiteLLM
+    model = kwargs.get("model", "")
+    if llm_api is None and isinstance(model, str) and model.startswith("MiniMax"):
+        return AsyncMiniMaxCallable(*args, **kwargs)
+
     try:
         import litellm
 

--- a/tests/unit_tests/test_llm_providers.py
+++ b/tests/unit_tests/test_llm_providers.py
@@ -525,3 +525,200 @@ def test_chat_prompt():
     # raises when messages are not provided
     with pytest.raises(PromptCallableException):
         chat_prompt(None)
+
+
+# ---------------------------------------------------------------------------
+# MiniMax provider tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def minimax_chat_response():
+    """A minimal mock of openai.types.chat.ChatCompletion for MiniMax."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class MockUsage:
+        completion_tokens: int
+        prompt_tokens: int
+        total_tokens: int
+
+    @dataclass
+    class MockMessage:
+        content: str
+        role: str
+
+    @dataclass
+    class MockChoice:
+        finish_reason: str
+        index: int
+        message: MockMessage
+
+    @dataclass
+    class MockResponse:
+        id: str
+        choices: List[MockChoice]
+        created: int
+        model: str
+        object: str
+        usage: MockUsage
+
+    return MockResponse(
+        id="minimax-test-id",
+        choices=[
+            MockChoice(
+                finish_reason="stop",
+                index=0,
+                message=MockMessage(content="Hello from MiniMax!", role="assistant"),
+            )
+        ],
+        created=0,
+        model="MiniMax-M2.7",
+        object="chat.completion",
+        usage=MockUsage(completion_tokens=10, prompt_tokens=5, total_tokens=15),
+    )
+
+
+def test_minimax_callable_uses_text(mocker, minimax_chat_response):
+    """MiniMaxCallable converts plain text into a user message."""
+    from guardrails.llm_providers import MiniMaxCallable
+
+    mock_create = mocker.MagicMock(return_value=minimax_chat_response)
+    mocker.patch(
+        "openai.OpenAI",
+        return_value=mocker.MagicMock(
+            chat=mocker.MagicMock(
+                completions=mocker.MagicMock(create=mock_create)
+            )
+        ),
+    )
+
+    callable_obj = MiniMaxCallable(
+        text="Say hi",
+        model="minimax/MiniMax-M2.7",
+        api_key="test-key",
+        temperature=0.8,
+    )
+    response = callable_obj()
+
+    assert isinstance(response, LLMResponse)
+    assert response.output == "Hello from MiniMax!"
+    assert response.prompt_token_count == 5
+    assert response.response_token_count == 10
+
+
+def test_minimax_callable_strips_prefix(mocker, minimax_chat_response):
+    """The 'minimax/' prefix is stripped before calling the OpenAI SDK."""
+    from guardrails.llm_providers import MiniMaxCallable
+
+    mock_create = mocker.MagicMock(return_value=minimax_chat_response)
+    client_mock = mocker.MagicMock(
+        chat=mocker.MagicMock(
+            completions=mocker.MagicMock(create=mock_create)
+        )
+    )
+    mocker.patch("openai.OpenAI", return_value=client_mock)
+
+    MiniMaxCallable(
+        text="Hello",
+        model="minimax/MiniMax-M2.7",
+        api_key="test-key",
+        temperature=0.7,
+    )()
+
+    call_kwargs = mock_create.call_args
+    # The first positional-or-keyword argument is 'model'
+    assert call_kwargs.kwargs["model"] == "MiniMax-M2.7"
+
+
+def test_minimax_callable_temperature_clamped(mocker, minimax_chat_response):
+    """temperature=0 is clamped to 1.0 for MiniMax."""
+    from guardrails.llm_providers import MiniMaxCallable
+
+    mock_create = mocker.MagicMock(return_value=minimax_chat_response)
+    mocker.patch(
+        "openai.OpenAI",
+        return_value=mocker.MagicMock(
+            chat=mocker.MagicMock(
+                completions=mocker.MagicMock(create=mock_create)
+            )
+        ),
+    )
+
+    MiniMaxCallable(
+        text="Hello",
+        model="minimax/MiniMax-M2.7",
+        api_key="test-key",
+        temperature=0,
+    )()
+
+    call_kwargs = mock_create.call_args
+    assert call_kwargs.kwargs["temperature"] == 1.0
+
+
+def test_minimax_callable_default_base_url(mocker, minimax_chat_response):
+    """Default base URL points to the international MiniMax endpoint."""
+    from guardrails.llm_providers import MINIMAX_DEFAULT_BASE_URL, MiniMaxCallable
+
+    openai_cls = mocker.patch("openai.OpenAI")
+    openai_cls.return_value.chat.completions.create.return_value = minimax_chat_response
+
+    MiniMaxCallable(
+        text="Hello",
+        model="minimax/MiniMax-M2.7",
+        api_key="test-key",
+        temperature=0.8,
+    )()
+
+    openai_cls.assert_called_once_with(
+        api_key="test-key", base_url=MINIMAX_DEFAULT_BASE_URL
+    )
+
+
+def test_minimax_callable_missing_api_key(mocker):
+    """PromptCallableException is raised when no API key is provided."""
+    from guardrails.llm_providers import MiniMaxCallable
+
+    mocker.patch.dict(os.environ, {}, clear=True)
+    # Ensure MINIMAX_API_KEY is not present
+    os.environ.pop("MINIMAX_API_KEY", None)
+
+    callable_obj = MiniMaxCallable(
+        text="Hello",
+        model="minimax/MiniMax-M2.7",
+        temperature=0.8,
+    )
+
+    with pytest.raises(PromptCallableException, match="MINIMAX_API_KEY"):
+        callable_obj()
+
+
+def test_get_llm_ask_returns_minimax_callable_for_minimax_model():
+    """get_llm_ask routes 'minimax/' models to MiniMaxCallable."""
+    from guardrails.llm_providers import MiniMaxCallable
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        callable_obj = get_llm_ask(None, model="minimax/MiniMax-M2.7")
+
+    assert isinstance(callable_obj, MiniMaxCallable)
+
+
+def test_get_llm_ask_returns_minimax_callable_for_highspeed_model():
+    """get_llm_ask routes 'minimax/MiniMax-M2.7-highspeed' to MiniMaxCallable."""
+    from guardrails.llm_providers import MiniMaxCallable
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        callable_obj = get_llm_ask(None, model="minimax/MiniMax-M2.7-highspeed")
+
+    assert isinstance(callable_obj, MiniMaxCallable)
+
+
+def test_get_async_llm_ask_returns_async_minimax_callable():
+    """get_async_llm_ask routes 'minimax/' models to AsyncMiniMaxCallable."""
+    from guardrails.llm_providers import AsyncMiniMaxCallable
+
+    callable_obj = get_async_llm_ask(None, model="minimax/MiniMax-M2.7")
+
+    assert isinstance(callable_obj, AsyncMiniMaxCallable)

--- a/tests/unit_tests/test_llm_providers.py
+++ b/tests/unit_tests/test_llm_providers.py
@@ -315,6 +315,172 @@ def test_litellm_callable(mocker):
     assert response.response_token_count == 20
 
 
+def test_minimax_callable(mocker):
+    """Test MiniMaxCallable wraps MiniMax OpenAI-compatible API correctly."""
+    from dataclasses import dataclass as _dc
+
+    @_dc
+    class _Message:
+        content: str
+
+    @_dc
+    class _Choice:
+        message: _Message
+
+    @_dc
+    class _Usage:
+        prompt_tokens: int
+        completion_tokens: int
+
+    @_dc
+    class _MockResponse:
+        choices: List[_Choice]
+        usage: _Usage
+
+    mock_response = _MockResponse(
+        choices=[_Choice(message=_Message(content="MiniMax says hello!"))],
+        usage=_Usage(prompt_tokens=5, completion_tokens=10),
+    )
+
+    mock_client = mocker.MagicMock()
+    mock_client.chat.completions.create.return_value = mock_response
+    mocker.patch("openai.Client", return_value=mock_client)
+
+    mocker.patch.dict("os.environ", {"MINIMAX_API_KEY": "test-minimax-key"})
+
+    from guardrails.llm_providers import MiniMaxCallable
+
+    callable_ = MiniMaxCallable()
+    response = callable_(
+        text="Hello",
+        model="MiniMax-M2.7",
+    )
+
+    assert isinstance(response, LLMResponse)
+    assert response.output == "MiniMax says hello!"
+    assert response.prompt_token_count == 5
+    assert response.response_token_count == 10
+
+    # Verify temperature was set to 1.0 (MiniMax requires > 0)
+    call_kwargs = mock_client.chat.completions.create.call_args[1]
+    assert call_kwargs["temperature"] == 1.0
+
+
+def test_minimax_callable_uses_custom_base_url(mocker):
+    """Test MiniMaxCallable uses custom base_url when provided."""
+    from dataclasses import dataclass as _dc
+
+    @_dc
+    class _Message:
+        content: str
+
+    @_dc
+    class _Choice:
+        message: _Message
+
+    @_dc
+    class _MockResponse:
+        choices: List[_Choice]
+        usage: Any
+
+    mock_response = _MockResponse(
+        choices=[_Choice(message=_Message(content="response"))],
+        usage=None,
+    )
+    mock_client = mocker.MagicMock()
+    mock_client.chat.completions.create.return_value = mock_response
+
+    captured = {}
+
+    def mock_openai_client(api_key=None, base_url=None):
+        captured["api_key"] = api_key
+        captured["base_url"] = base_url
+        return mock_client
+
+    mocker.patch("openai.Client", side_effect=mock_openai_client)
+    mocker.patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"})
+
+    from guardrails.llm_providers import MiniMaxCallable
+
+    callable_ = MiniMaxCallable()
+    callable_(
+        text="Hello",
+        model="MiniMax-M2.7",
+        base_url="https://custom.minimax.io/v1",
+    )
+
+    assert captured["base_url"] == "https://custom.minimax.io/v1"
+
+
+def test_minimax_callable_raises_without_api_key(mocker):
+    """Test MiniMaxCallable raises when no API key is available."""
+    mocker.patch.dict("os.environ", {}, clear=True)
+    # Make sure MINIMAX_API_KEY is not set
+    mocker.patch.dict("os.environ", {"MINIMAX_API_KEY": ""})
+
+    from guardrails.llm_providers import MiniMaxCallable, PromptCallableException
+
+    callable_ = MiniMaxCallable()
+
+    with pytest.raises(PromptCallableException):
+        callable_(text="Hello", model="MiniMax-M2.7")
+
+
+def test_get_llm_ask_minimax_model():
+    """Test that model names starting with 'MiniMax' route to MiniMaxCallable."""
+    import os
+
+    os.environ["MINIMAX_API_KEY"] = "test-key"
+    try:
+        from guardrails.llm_providers import MiniMaxCallable
+
+        result = get_llm_ask(None, model="MiniMax-M2.7")
+        assert isinstance(result, MiniMaxCallable)
+    finally:
+        del os.environ["MINIMAX_API_KEY"]
+
+
+def test_get_llm_ask_minimax_highspeed_model():
+    """Test that MiniMax-M2.7-highspeed also routes to MiniMaxCallable."""
+    import os
+
+    os.environ["MINIMAX_API_KEY"] = "test-key"
+    try:
+        from guardrails.llm_providers import MiniMaxCallable
+
+        result = get_llm_ask(None, model="MiniMax-M2.7-highspeed")
+        assert isinstance(result, MiniMaxCallable)
+    finally:
+        del os.environ["MINIMAX_API_KEY"]
+
+
+def test_get_llm_ask_minimax_temperature_not_set_to_zero():
+    """Test that MiniMax models skip the default temperature=0 warning."""
+    import warnings as _warnings
+
+    import os
+
+    os.environ["MINIMAX_API_KEY"] = "test-key"
+    try:
+        with _warnings.catch_warnings(record=True) as w:
+            _warnings.simplefilter("always")
+            result = get_llm_ask(None, model="MiniMax-M2.7")
+            # Should not emit the temperature deprecation warning for MiniMax
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(dep_warnings) == 0
+    finally:
+        del os.environ["MINIMAX_API_KEY"]
+
+
+def test_get_llm_ask_returns_prompt_callable_base_directly():
+    """Test that PromptCallableBase instances are returned directly."""
+    from guardrails.llm_providers import MiniMaxCallable
+
+    instance = MiniMaxCallable()
+    result = get_llm_ask(instance, model="MiniMax-M2.7")
+    assert result is instance
+
+
 class ReturnTempCallable(Callable):
     def __call__(self, *args, messages=None, **kwargs) -> Any:
         return ""


### PR DESCRIPTION
## Summary

This PR adds native MiniMax AI provider support to Guardrails via the MiniMax OpenAI-compatible API, with **MiniMax-M3** as the default model.

### What is added

- **`MiniMaxCallable`** and **`AsyncMiniMaxCallable`** classes in `guardrails/llm_providers.py`
  - Use MiniMax OpenAI-compatible endpoint (`https://api.minimax.io/v1`)
  - Read API key from `MINIMAX_API_KEY` environment variable
  - Automatically handle MiniMax temperature constraint (`(0.0, 1.0]`, default `1.0`)
  - Support both streaming and non-streaming responses
  - **Default model is `MiniMax-M3`** (latest generation, 512K context, 128K max output, supports image input)
- **Auto-routing**: model names starting with `"MiniMax"` are automatically routed to `MiniMaxCallable`, so `guard(model="MiniMax-M3", ...)` works without additional configuration
- **Unit tests** covering callable creation, API key handling, base URL configuration, default M3 model and M2.7 routing logic

### Usage

**Option 1 — explicit callable (uses M3 by default):**
```python
from guardrails import Guard
from guardrails.llm_providers import MiniMaxCallable

guard = Guard()
result = guard(
    MiniMaxCallable(),
    messages=[{"role": "user", "content": "Hello"}],
)
```

**Option 2 — model-name auto-routing (set MINIMAX_API_KEY in environment):**
```python
from guardrails import Guard

guard = Guard()
result = guard(
    model="MiniMax-M3",
    messages=[{"role": "user", "content": "Hello"}],
)
```

### Supported models

| Model | Description |
|-------|-------------|
| `MiniMax-M3` | **Default** — 512K context, 128K max output, supports image input |
| `MiniMax-M2.7` | Previous generation |
| `MiniMax-M2.7-highspeed` | Previous generation, lower-latency variant |

### API Reference

- Chat API (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo