### PR TITLE
fix: redact() exposes short strings unredacted

### DIFF
--- a/guardrails/classes/history/call_inputs.py
+++ b/guardrails/classes/history/call_inputs.py
@@ -106,9 +106,10 @@ class CallInputs(Inputs, ArbitraryModel):
         redacted_kwargs = {}
         for k, v in kwargs.items():
             if ("key" in k.lower() or "token" in k.lower()) and isinstance(v, str):
-                redaction_length = len(v) - 4
-                stars = "*" * redaction_length
-                redacted_kwargs[k] = f"{stars}{v[-4:]}"
+                if len(v) <= 4:
+                    redacted_kwargs[k] = "*" * len(v)
+                else:
+                    redacted_kwargs[k] = "*" * (len(v) - 4) + v[-4:]
             else:
                 redacted_kwargs[k] = v
         return redacted_kwargs

--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -128,6 +128,8 @@ def redact(value: str) -> str:
         str: The redacted string with all but the last four characters
               replaced by asterisks.
     """
+    if len(value) <= 4:
+        return "*" * len(value)
     redaction_length = len(value) - 4
     stars = "*" * redaction_length
     return f"{stars}{value[-4:]}"

--- a/tests/unit_tests/redaction/test_redaction.py
+++ b/tests/unit_tests/redaction/test_redaction.py
@@ -7,7 +7,7 @@ class TestRedactFunction(unittest.TestCase):
         self.assertEqual(redact("supersecretpassword"), "***************word")
 
     def test_redact_short_string(self):
-        self.assertEqual(redact("test"), "test")
+        self.assertEqual(redact("test"), "****")
 
     def test_open_ai_example_key(self):
         self.assertEqual(
@@ -16,19 +16,19 @@ class TestRedactFunction(unittest.TestCase):
         )
 
     def test_redact_very_short_string(self):
-        self.assertEqual(redact("abc"), "abc")
+        self.assertEqual(redact("abc"), "***")
 
     def test_redact_empty_string(self):
         self.assertEqual(redact(""), "")
 
     def test_redact_exact_length(self):
-        self.assertEqual(redact("1234"), "1234")
+        self.assertEqual(redact("1234"), "****")
 
     def test_redact_special_characters(self):
         self.assertEqual(redact("ab!@#12"), "***@#12")
 
     def test_redact_single_character(self):
-        self.assertEqual(redact("a"), "a")
+        self.assertEqual(redact("a"), "*")
 
     def test_redact_spaces(self):
         self.assertEqual(redact("      test"), "******test")


### PR DESCRIPTION
When a string is 4 characters or fewer, redact() returns the original value unchanged due to negative redaction_length producing an empty star string. This means short API keys and tokens are logged in plaintext to telemetry.

Fix by fully redacting strings of 4 chars or fewer with asterisks. Also fix the same bug in CallInputs.serialize_kwargs which had duplicated inline redaction logic.