### PR TITLE
fix(cli): pass keyword arguments to guardrails-api start function

### DIFF
--- a/guardrails/cli/start.py
+++ b/guardrails/cli/start.py
@@ -68,6 +68,6 @@ def start(
                 "  'env_override' will be ignored."
             )
 
-        start_api(env, config, port)
+        start_api(env=env, config=config, port=port)
     else:
-        start_api(env, config, port, env_override)  # type: ignore
+        start_api(env=env, config=config, port=port, env_override=env_override)  # type: ignore

--- a/tests/unit_tests/cli/test_start.py
+++ b/tests/unit_tests/cli/test_start.py
@@ -60,7 +60,7 @@ class TestStart:
         result = runner.invoke(guardrails, ["start"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "", 8000)
+        mock_start_api.assert_called_once_with(env="", config="", port=8000)
 
     def test_calls_start_api_with_env_override_for_new_api(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.3.0")
@@ -69,7 +69,9 @@ class TestStart:
         result = runner.invoke(guardrails, ["start"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "", 8000, False)
+        mock_start_api.assert_called_once_with(
+            env="", config="", port=8000, env_override=False
+        )
 
     def test_passes_env_override_true_to_new_api(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.3.0")
@@ -78,7 +80,9 @@ class TestStart:
         result = runner.invoke(guardrails, ["start", "--env-override"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "", 8000, True)
+        mock_start_api.assert_called_once_with(
+            env="", config="", port=8000, env_override=True
+        )
 
     def test_warns_and_ignores_env_override_for_old_api(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.2.9")
@@ -95,7 +99,7 @@ class TestStart:
         )
         assert "0.2.9" in warning_msg
         # env_override is NOT passed to the old API
-        mock_start_api.assert_called_once_with("", "", 8000)
+        mock_start_api.assert_called_once_with(env="", config="", port=8000)
 
     def test_no_warning_when_env_override_false_with_old_api(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.2.9")
@@ -106,7 +110,7 @@ class TestStart:
 
         assert result.exit_code == 0
         mock_logger_warning.assert_not_called()
-        mock_start_api.assert_called_once_with("", "", 8000)
+        mock_start_api.assert_called_once_with(env="", config="", port=8000)
 
     def test_passes_custom_env_file(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.3.0")
@@ -115,7 +119,9 @@ class TestStart:
         result = runner.invoke(guardrails, ["start", "--env", "custom.env"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("custom.env", "", 8000, False)
+        mock_start_api.assert_called_once_with(
+            env="custom.env", config="", port=8000, env_override=False
+        )
 
     def test_passes_custom_config(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.3.0")
@@ -126,7 +132,9 @@ class TestStart:
         )
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "guardrails.config.py", 8000, False)
+        mock_start_api.assert_called_once_with(
+            env="", config="guardrails.config.py", port=8000, env_override=False
+        )
 
     def test_passes_custom_port(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.3.0")
@@ -135,7 +143,9 @@ class TestStart:
         result = runner.invoke(guardrails, ["start", "--port", "9000"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "", 9000, False)
+        mock_start_api.assert_called_once_with(
+            env="", config="", port=9000, env_override=False
+        )
 
     def test_watch_mode_enables_setting(self, mocker):
         from guardrails.settings import settings
@@ -169,7 +179,9 @@ class TestStart:
         result = runner.invoke(guardrails, ["start", "--env-override"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "", 8000, True)
+        mock_start_api.assert_called_once_with(
+            env="", config="", port=8000, env_override=True
+        )
 
     def test_calls_trace_if_enabled(self, mocker):
         self._make_start_api_mock(mocker, "0.3.0")


### PR DESCRIPTION
## Summary

Fixes #1464

The `guardrails start` command calls `guardrails_api.cli.start.start()` with positional arguments. In `guardrails-api >= 0.3.0`, the `start` function gained a `middleware` parameter with a `typer.Option()` default. When called directly as a Python function (not through typer's CLI runner), unspecified `typer.Option` parameters retain their raw `OptionInfo` objects instead of resolving to default values. This causes:

```
TypeError: expected str, bytes or os.PathLike object, not OptionInfo
```

## Fix

Switch from positional to keyword arguments when calling `start_api()`, so only explicitly provided parameters are passed and unspecified `typer.Option` defaults resolve correctly in the callee.

## Test plan

- [x] All 16 existing CLI start tests updated and passing
- [x] `ruff check` and `ruff format` clean