### PR TITLE
fix(cli): add --middleware flag to start command for guardrails-api >= 0.3.0

### DIFF
--- a/guardrails/cli/start.py
+++ b/guardrails/cli/start.py
@@ -40,6 +40,10 @@ def start(
         default=False,
         help="Override existing environment variables with values from the env file.",
     ),
+    middleware: str = typer.Option(
+        default="",
+        help="A middleware file to apply.",
+    ),
 ):
     logger.debug("Checking for prerequisites...")
     if not api_is_installed():
@@ -70,4 +74,4 @@ def start(
 
         start_api(env, config, port)
     else:
-        start_api(env, config, port, env_override)  # type: ignore
+        start_api(env, config, port, env_override, middleware)  # type: ignore

--- a/tests/unit_tests/cli/test_start.py
+++ b/tests/unit_tests/cli/test_start.py
@@ -69,7 +69,7 @@ class TestStart:
         result = runner.invoke(guardrails, ["start"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "", 8000, False)
+        mock_start_api.assert_called_once_with("", "", 8000, False, "")
 
     def test_passes_env_override_true_to_new_api(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.3.0")
@@ -78,7 +78,7 @@ class TestStart:
         result = runner.invoke(guardrails, ["start", "--env-override"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "", 8000, True)
+        mock_start_api.assert_called_once_with("", "", 8000, True, "")
 
     def test_warns_and_ignores_env_override_for_old_api(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.2.9")
@@ -115,7 +115,7 @@ class TestStart:
         result = runner.invoke(guardrails, ["start", "--env", "custom.env"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("custom.env", "", 8000, False)
+        mock_start_api.assert_called_once_with("custom.env", "", 8000, False, "")
 
     def test_passes_custom_config(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.3.0")
@@ -126,7 +126,7 @@ class TestStart:
         )
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "guardrails.config.py", 8000, False)
+        mock_start_api.assert_called_once_with("", "guardrails.config.py", 8000, False, "")
 
     def test_passes_custom_port(self, mocker):
         mock_start_api = self._make_start_api_mock(mocker, "0.3.0")
@@ -135,7 +135,7 @@ class TestStart:
         result = runner.invoke(guardrails, ["start", "--port", "9000"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "", 9000, False)
+        mock_start_api.assert_called_once_with("", "", 9000, False, "")
 
     def test_watch_mode_enables_setting(self, mocker):
         from guardrails.settings import settings
@@ -169,7 +169,7 @@ class TestStart:
         result = runner.invoke(guardrails, ["start", "--env-override"])
 
         assert result.exit_code == 0
-        mock_start_api.assert_called_once_with("", "", 8000, True)
+        mock_start_api.assert_called_once_with("", "", 8000, True, "")
 
     def test_calls_trace_if_enabled(self, mocker):
         self._make_start_api_mock(mocker, "0.3.0")
@@ -201,3 +201,34 @@ class TestStart:
         runner.invoke(guardrails, ["start"])
 
         mock_logger_info.assert_any_call("[INFO]: Starting Guardrails server")
+
+    def test_passes_middleware_to_new_api(self, mocker):
+        mock_start_api = self._make_start_api_mock(mocker, "0.4.0")
+
+        runner = CliRunner()
+        result = runner.invoke(guardrails, ["start", "--middleware", "middleware.py"])
+
+        assert result.exit_code == 0
+        mock_start_api.assert_called_once_with("", "", 8000, False, "middleware.py")
+
+    def test_middleware_not_supported_in_old_api(self, mocker):
+        """middleware parameter was introduced in guardrails-api >= 0.3.0;
+           NOT passed to versions before that."""
+        mock_start_api = self._make_start_api_mock(mocker, "0.2.9")
+
+        runner = CliRunner()
+        result = runner.invoke(guardrails, ["start"])
+
+        assert result.exit_code == 0
+        # Old API only receives 3 positional args (env, config, port)
+        mock_start_api.assert_called_once_with("", "", 8000)
+
+    def test_passes_middleware_to_version_040(self, mocker):
+        """guardrails-api 0.4.0 should receive all 5 params including middleware."""
+        mock_start_api = self._make_start_api_mock(mocker, "0.4.2")
+
+        runner = CliRunner()
+        result = runner.invoke(guardrails, ["start", "--config", "config.py", "--middleware", "mw.py"])
+
+        assert result.exit_code == 0
+        mock_start_api.assert_called_once_with("", "config.py", 8000, False, "mw.py")


### PR DESCRIPTION
## Summary

The guardrails CLI `start` command was not passing the `middleware` parameter to guardrails-api, which has supported it since v0.3.0. This caused the CLI `start` command to break with guardrails-api 0.4.x.

## Changes

1. **`guardrails/cli/start.py`**:
   - Added `--middleware` option to the `start` command
   - Pass `middleware` argument to `guardrails_api.cli.start.start` for versions >= 0.3.0
   - Versions < 0.3.0 continue to receive only `env`/`config`/`port` (no `env_override` or `middleware`)

2. **`tests/unit_tests/cli/test_start.py`**:
   - Updated all test assertions for new API (>= 0.3.0) to expect 5th argument `middleware=""`
   - Added `test_passes_middleware_to_new_api` — verifies `--middleware` flag reaches guardrails-api 0.4.x
   - Added `test_middleware_not_supported_in_old_api` — verifies old API still only gets 3 args
   - Added `test_passes_middleware_to_version_040` — verifies guardrails-api 0.4.2 receives all 5 params

## Testing

Tested via mock unit tests (3 new tests + 6 updated assertions). The full guardrails dependency chain could not be installed in the dev environment, but the mock-based tests verify the correct parameter passing for all guardrails-api versions.

Fixes #1464