### PR TITLE
[codex] Fix history output status fallbacks

### DIFF
--- a/guardrails/classes/history/call.py
+++ b/guardrails/classes/history/call.py
@@ -230,14 +230,7 @@ class Call(ArbitraryModel):
     @property
     def raw_outputs(self) -> Stack[str]:
         """The exact outputs from all LLM calls."""
-        return Stack(
-            *[
-                i.outputs.llm_response_info.output
-                if i.outputs.llm_response_info is not None
-                else None
-                for i in self.iterations
-            ]
-        )
+        return Stack(*[i.raw_output for i in self.iterations])
 
     @property
     def parsed_outputs(self) -> Stack[Union[str, List, Dict]]:

--- a/guardrails/classes/history/outputs.py
+++ b/guardrails/classes/history/outputs.py
@@ -94,12 +94,14 @@ class Outputs(ArbitraryModel):
     def _all_empty(self) -> bool:
         return (
             self.llm_response_info is None
+            and self.raw_output is None
             and self.parsed_output is None
             and self.validation_response is None
             and self.guarded_output is None
             and len(self.reasks) == 0
             and len(self.validator_logs) == 0
             and self.error is None
+            and self.exception is None
         )
 
     @property
@@ -164,7 +166,7 @@ class Outputs(ArbitraryModel):
 
         if self._all_empty() is True:
             return not_run_status
-        elif self.error:
+        elif self.error or self.exception:
             return error_status
         elif not all_reasks_have_fixes:
             return fail_status

--- a/tests/unit_tests/classes/history/test_call.py
+++ b/tests/unit_tests/classes/history/test_call.py
@@ -40,6 +40,17 @@ def test_empty_initialization():
     assert call.tree is not None
 
 
+def test_raw_outputs_uses_iteration_raw_output_fallback():
+    call = Call(
+        iterations=Stack(
+            Iteration(outputs=Outputs(raw_output="Hello there!")),
+            Iteration(outputs=Outputs(llm_response_info=LLMResponse(output="Hi!"))),
+        )
+    )
+
+    assert call.raw_outputs == Stack("Hello there!", "Hi!")
+
+
 def test_non_empty_initialization():
     # Call input
     def custom_llm(messages, *args, **kwargs):

--- a/tests/unit_tests/classes/history/test_outputs.py
+++ b/tests/unit_tests/classes/history/test_outputs.py
@@ -86,6 +86,7 @@ non_fixable_fail_result = FailResult(
     [
         (Outputs(), True),
         (Outputs(llm_response_info=LLMResponse(output="Hello there!")), False),
+        (Outputs(raw_output="Hello there!"), False),
         (Outputs(parsed_output="Hello there!"), False),
         (Outputs(parsed_output="Hello there!"), False),
         (Outputs(guarded_output="Hello there"), False),
@@ -116,6 +117,7 @@ non_fixable_fail_result = FailResult(
             False,
         ),
         (Outputs(error="Validation Failed!"), False),
+        (Outputs(exception=RuntimeError("Validation Failed!")), False),
     ],
 )
 def test__all_empty(outputs: Outputs, expected_result: bool):
@@ -153,6 +155,7 @@ def test_failed_validations():
     [
         (Outputs(), not_run_status),
         (Outputs(error="Validations Failed!"), error_status),
+        (Outputs(exception=RuntimeError("Validations Failed!")), error_status),
         (
             Outputs(
                 validator_logs=[
@@ -175,6 +178,7 @@ def test_failed_validations():
             fail_status,
         ),
         (Outputs(validator_logs=[], guarded_output="Hello there!"), pass_status),
+        (Outputs(raw_output="Hello there!"), pass_status),
     ],
 )
 def test_status(outputs: Outputs, expected_status: str):


### PR DESCRIPTION
## Summary

- Treat `Outputs.raw_output` and `Outputs.exception` as meaningful output state instead of empty history.
- Report `error` status when an `Outputs` object carries an exception but no separate error string.
- Reuse `Iteration.raw_output` in `Call.raw_outputs` so legacy/raw-output-only iterations are included.

## Why

`Iteration.raw_output` already falls back to `Outputs.raw_output`, but `Call.raw_outputs` bypassed that property and dropped those values. Separately, `Outputs._all_empty()` ignored `raw_output` and `exception`, which could make an exception-only output report `not_run`.

## Validation

- `.venv/bin/python -m pytest tests/unit_tests/classes/history/test_outputs.py tests/unit_tests/classes/history/test_call.py -q`
- `.venv/bin/python -m ruff check guardrails/classes/history/outputs.py guardrails/classes/history/call.py tests/unit_tests/classes/history/test_outputs.py tests/unit_tests/classes/history/test_call.py`
- `.venv/bin/python -m ruff format --check guardrails/classes/history/outputs.py guardrails/classes/history/call.py tests/unit_tests/classes/history/test_outputs.py tests/unit_tests/classes/history/test_call.py`
- `.venv/bin/pyright --pythonpath .venv/bin/python guardrails/classes/history/outputs.py guardrails/classes/history/call.py`
- `git diff --check`