### PR TITLE
docs: fix chatbot example typo

### DIFF
--- a/docs/examples/chatbot.ipynb
+++ b/docs/examples/chatbot.ipynb
@@ -235,7 +235,7 @@
     "\n",
     "![chatbot example validation failed](images/chatbot_validation_failed.png \"ChatbotValidationFailedExampleImage\")\n",
     "\n",
-    "We can examine the guards history and see the raw llm output clearly has profanity in it. Validation has failed and our handling has worked successfully desipite the model following the users instructions."
+    "We can examine the guards history and see the raw llm output clearly has profanity in it. Validation has failed and our handling has worked successfully despite the model following the users instructions."
    ]
   },
   {


### PR DESCRIPTION
Summary:\n- Fix a visible typo in the chatbot example notebook prose: desipite -> despite.\n\nValidation:\n- python3 -m json.tool docs/examples/chatbot.ipynb >/tmp/guardrails-chatbot.json\n- Targeted content assertion confirmed desipite is absent and the corrected sentence is present\n- git diff --check