### PR TITLE
fix(reask): guard against IndexError when FieldReAsk.fail_results is None

### DIFF
--- a/guardrails/actions/reask.py
+++ b/guardrails/actions/reask.py
@@ -570,7 +570,7 @@ def sub_reasks_with_fixed_values(value: Any) -> Any:
             copy[dict_key] = sub_reasks_with_fixed_values(dict_value)
     elif isinstance(copy, FieldReAsk):
         fail_results = copy.fail_results or []
-        first_fail_result = fail_results[0]
+        first_fail_result = fail_results[0] if fail_results else None
 
         fix_value = first_fail_result.fix_value if first_fail_result else None
         # TODO handle multiple fail results

--- a/tests/unit_tests/actions/test_reask.py
+++ b/tests/unit_tests/actions/test_reask.py
@@ -117,6 +117,14 @@ def test_sub_reasks_with_fixed_values(input_dict, expected_dict):
     assert sub_reasks_with_fixed_values(input_dict) == expected_dict
 
 
+def test_sub_reasks_with_fixed_values_none_fail_results():
+    """FieldReAsk with fail_results=None must not raise IndexError."""
+    reask = FieldReAsk(incorrect_value="bad_value")  # fail_results defaults to None
+    result = sub_reasks_with_fixed_values(reask)
+    # No fix_value available, so the FieldReAsk should be returned as-is
+    assert result == reask
+
+
 def test_gather_reasks():
     """Test that reasks are gathered."""
     input_dict = {


### PR DESCRIPTION
## What's broken

`sub_reasks_with_fixed_values` crashes with `IndexError: list index out of range` when a `FieldReAsk` has `fail_results=None`, which is the default value from the `ReAsk` base model. Line 572 converts `None` to an empty list via `copy.fail_results or []`, then line 573 indexes into that empty list unconditionally. The guard on line 575 (`if first_fail_result else None`) was meant to handle this case but was unreachable because the crash happened first. Any code path that produces a `FieldReAsk` without explicit fail_results and then accesses `guard.history.last.fixed_output` will hit this.

## Why it happens

The unconditional `fail_results[0]` on line 573 was written without accounting for the case where `fail_results` is empty after the `or []` coercion on the line above.

## Fix

Changed line 573 from `first_fail_result = fail_results[0]` to `first_fail_result = fail_results[0] if fail_results else None`. This lets the existing `if first_fail_result` check on line 575 handle the empty case correctly, returning the FieldReAsk unchanged when no fix value is available.

## Test

Added `test_sub_reasks_with_fixed_values_none_fail_results` to `tests/unit_tests/actions/test_reask.py`. It constructs a `FieldReAsk` with no `fail_results` and asserts the function returns it unchanged without raising.

Fixes #1491