### PR TITLE
feat: add 5 URL/domain validators for hallucination detection

### DIFF
--- a/guardrails/validators/__init__.py
+++ b/guardrails/validators/__init__.py
@@ -7,6 +7,12 @@ from guardrails.validator_base import (
     ErrorSpan,
 )
 
+from guardrails.validators.url_format import URLFormatValidator
+from guardrails.validators.url_dns_resolver import URLDNSResolver
+from guardrails.validators.url_reachability import URLReachability
+from guardrails.validators.domain_blocklist import DomainBlocklist
+from guardrails.validators.url_risk_scorer import URLRiskScorer
+
 __all__ = [
     "Validator",
     "register_validator",
@@ -14,4 +20,9 @@ __all__ = [
     "PassResult",
     "FailResult",
     "ErrorSpan",
+    "URLFormatValidator",
+    "URLDNSResolver",
+    "URLReachability",
+    "DomainBlocklist",
+    "URLRiskScorer",
 ]

--- a/guardrails/validators/domain_blocklist.py
+++ b/guardrails/validators/domain_blocklist.py
@@ -1,0 +1,103 @@
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlparse
+
+from guardrails.logger import logger
+from guardrails.validator_base import (
+    FailResult,
+    PassResult,
+    ValidationResult,
+    Validator,
+    register_validator,
+)
+
+
+def _extract_domain(value: str) -> Optional[str]:
+    if "://" not in value:
+        value = "https://" + value
+    try:
+        return urlparse(value).hostname
+    except ValueError:
+        return None
+
+
+def _domain_matches(domain: str, pattern: str, match_subdomains: bool) -> bool:
+    if domain == pattern:
+        return True
+    if match_subdomains and domain.endswith("." + pattern):
+        return True
+    return False
+
+
+@register_validator(name="domain-blocklist", data_type=["string"])
+class DomainBlocklist(Validator):
+    """Domain blocklist and allowlist filtering.
+
+    Checks whether the domain in a URL appears in a blocked list or is
+    absent from an allowed list, depending on the chosen mode.
+
+    **Key Properties**
+
+    | Property                      | Description                       |
+    | ----------------------------- | --------------------------------- |
+    | Name for `format` attribute   | `domain-blocklist`                |
+    | Supported data types          | `string`                          |
+    | Programmatic fix              | None                              |
+
+    Args:
+        blocked: Domains to reject.
+        allowed: Domains to accept (used in allowlist mode).
+        mode: "blocklist" rejects domains in `blocked`;
+              "allowlist" rejects domains NOT in `allowed`.
+        match_subdomains: Whether sub.evil.com matches evil.com.
+    """
+
+    def __init__(
+        self,
+        blocked: Optional[List[str]] = None,
+        allowed: Optional[List[str]] = None,
+        mode: str = "blocklist",
+        match_subdomains: bool = True,
+        on_fail: Optional[Callable] = None,
+    ):
+        assert mode in ("blocklist", "allowlist"), (
+            'mode must be "blocklist" or "allowlist"'
+        )
+        super().__init__(
+            on_fail=on_fail,
+            blocked=blocked,
+            allowed=allowed,
+            mode=mode,
+            match_subdomains=match_subdomains,
+        )
+        self._blocked = [d.lower() for d in (blocked or [])]
+        self._allowed = [d.lower() for d in (allowed or [])]
+        self._mode = mode
+        self._match_subdomains = match_subdomains
+
+    def validate(self, value: Any, metadata: Dict) -> ValidationResult:
+        logger.debug(f"Checking domain blocklist for: {value}")
+
+        domain = _extract_domain(value)
+        if domain is None:
+            return FailResult(error_message=f"Cannot extract domain from: {value}")
+
+        domain = domain.lower()
+
+        if self._mode == "blocklist":
+            for pattern in self._blocked:
+                if _domain_matches(domain, pattern, self._match_subdomains):
+                    return FailResult(
+                        error_message=f"Domain '{domain}' is blocked"
+                    )
+
+        elif self._mode == "allowlist":
+            matched = any(
+                _domain_matches(domain, pattern, self._match_subdomains)
+                for pattern in self._allowed
+            )
+            if not matched:
+                return FailResult(
+                    error_message=f"Domain '{domain}' is not in the allowlist"
+                )
+
+        return PassResult()

--- a/guardrails/validators/url_dns_resolver.py
+++ b/guardrails/validators/url_dns_resolver.py
@@ -1,0 +1,118 @@
+import socket
+import time
+from collections import OrderedDict
+from typing import Any, Callable, Dict, Optional
+from urllib.parse import urlparse
+
+from guardrails.logger import logger
+from guardrails.validator_base import (
+    FailResult,
+    PassResult,
+    ValidationResult,
+    Validator,
+    register_validator,
+)
+
+
+class _TTLCache:
+    """Simple LRU cache with per-entry TTL."""
+
+    def __init__(self, maxsize: int = 256, ttl: float = 3600.0):
+        self._maxsize = maxsize
+        self._ttl = ttl
+        self._cache: OrderedDict[str, tuple] = OrderedDict()
+
+    def get(self, key: str):
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        value, ts = entry
+        if time.monotonic() - ts > self._ttl:
+            self._cache.pop(key, None)
+            return None
+        self._cache.move_to_end(key)
+        return value
+
+    def put(self, key: str, value: bool):
+        if key in self._cache:
+            self._cache.move_to_end(key)
+        self._cache[key] = (value, time.monotonic())
+        while len(self._cache) > self._maxsize:
+            self._cache.popitem(last=False)
+
+
+@register_validator(name="url-dns-resolver", data_type=["string"])
+class URLDNSResolver(Validator):
+    """Validates that the domain in a URL resolves via DNS.
+
+    Uses socket.getaddrinfo to check whether the hostname actually exists.
+    Results are cached with a configurable TTL to avoid repeated lookups.
+
+    **Key Properties**
+
+    | Property                      | Description                       |
+    | ----------------------------- | --------------------------------- |
+    | Name for `format` attribute   | `url-dns-resolver`                |
+    | Supported data types          | `string`                          |
+    | Programmatic fix              | None                              |
+
+    Args:
+        timeout: DNS lookup timeout in seconds.
+        cache_size: Maximum number of cached DNS results.
+        cache_ttl: Cache entry lifetime in seconds.
+    """
+
+    def __init__(
+        self,
+        timeout: float = 5.0,
+        cache_size: int = 256,
+        cache_ttl: float = 3600.0,
+        on_fail: Optional[Callable] = None,
+    ):
+        super().__init__(
+            on_fail=on_fail,
+            timeout=timeout,
+            cache_size=cache_size,
+            cache_ttl=cache_ttl,
+        )
+        self._timeout = timeout
+        self._cache = _TTLCache(maxsize=cache_size, ttl=cache_ttl)
+
+    def _resolve(self, hostname: str) -> bool:
+        cached = self._cache.get(hostname)
+        if cached is not None:
+            return cached
+
+        old_timeout = socket.getdefaulttimeout()
+        try:
+            socket.setdefaulttimeout(self._timeout)
+            socket.getaddrinfo(hostname, None)
+            result = True
+        except (socket.gaierror, socket.timeout, OSError):
+            result = False
+        finally:
+            socket.setdefaulttimeout(old_timeout)
+
+        self._cache.put(hostname, result)
+        return result
+
+    def validate(self, value: Any, metadata: Dict) -> ValidationResult:
+        logger.debug(f"Resolving DNS for: {value}")
+
+        url = value if "://" in value else "https://" + value
+        try:
+            hostname = urlparse(url).hostname
+        except ValueError:
+            hostname = None
+
+        if not hostname:
+            return FailResult(
+                error_message=f"Cannot extract hostname from: {value}"
+            )
+
+        if self._resolve(hostname):
+            return PassResult()
+
+        return FailResult(
+            error_message=f"Domain does not resolve: {hostname}"
+        )

--- a/guardrails/validators/url_format.py
+++ b/guardrails/validators/url_format.py
@@ -1,0 +1,127 @@
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlparse
+
+from guardrails.logger import logger
+from guardrails.validator_base import (
+    FailResult,
+    PassResult,
+    ValidationResult,
+    Validator,
+    register_validator,
+)
+
+VALID_TLDS = {
+    "com", "org", "net", "edu", "gov", "mil", "int",
+    "io", "co", "us", "uk", "de", "fr", "jp", "cn", "ru", "br", "in",
+    "au", "ca", "it", "es", "nl", "se", "no", "fi", "dk", "pl", "cz",
+    "at", "ch", "be", "ie", "pt", "kr", "tw", "hk", "sg", "nz", "za",
+    "mx", "ar", "cl", "info", "biz", "name", "pro", "museum", "coop",
+    "aero", "asia", "cat", "jobs", "mobi", "tel", "travel",
+    "ai", "app", "dev", "cloud", "tech", "online", "store", "site",
+    "xyz", "top", "tk", "ml", "ga", "cf", "gq",
+}
+
+
+def _is_ip_address(host: str) -> bool:
+    parts = host.split(".")
+    if len(parts) == 4:
+        try:
+            return all(0 <= int(p) <= 255 for p in parts)
+        except ValueError:
+            pass
+    return ":" in host
+
+
+@register_validator(name="url-format", data_type=["string"])
+class URLFormatValidator(Validator):
+    """Enhanced URL format validation.
+
+    Validates URL structure beyond basic parsing: checks scheme whitelist,
+    rejects bare IP addresses, and verifies domain structural quality.
+
+    **Key Properties**
+
+    | Property                      | Description                       |
+    | ----------------------------- | --------------------------------- |
+    | Name for `format` attribute   | `url-format`                      |
+    | Supported data types          | `string`                          |
+    | Programmatic fix              | None                              |
+
+    Args:
+        require_https: Reject non-HTTPS URLs.
+        allowed_schemes: Accepted URL schemes. Defaults to ["http", "https"].
+        allow_ip: Whether to accept IP addresses as the host.
+    """
+
+    def __init__(
+        self,
+        require_https: bool = False,
+        allowed_schemes: Optional[List[str]] = None,
+        allow_ip: bool = False,
+        on_fail: Optional[Callable] = None,
+    ):
+        super().__init__(
+            on_fail=on_fail,
+            require_https=require_https,
+            allowed_schemes=allowed_schemes,
+            allow_ip=allow_ip,
+        )
+        self._require_https = require_https
+        self._allowed_schemes = allowed_schemes or ["http", "https"]
+        self._allow_ip = allow_ip
+
+    def validate(self, value: Any, metadata: Dict) -> ValidationResult:
+        logger.debug(f"Validating URL format: {value}")
+
+        try:
+            parsed = urlparse(value)
+        except ValueError:
+            return FailResult(error_message=f"URL cannot be parsed: {value}")
+
+        if not parsed.scheme or not parsed.netloc:
+            return FailResult(
+                error_message=f"URL missing scheme or host: {value}"
+            )
+
+        if parsed.scheme not in self._allowed_schemes:
+            return FailResult(
+                error_message=f"Scheme '{parsed.scheme}' not allowed. "
+                f"Accepted: {self._allowed_schemes}"
+            )
+
+        if self._require_https and parsed.scheme != "https":
+            return FailResult(
+                error_message=f"HTTPS required, got '{parsed.scheme}'"
+            )
+
+        hostname = parsed.hostname or ""
+
+        if not self._allow_ip and _is_ip_address(hostname):
+            return FailResult(
+                error_message=f"IP addresses not allowed as host: {hostname}"
+            )
+
+        if ".." in hostname:
+            return FailResult(
+                error_message=f"Invalid domain (consecutive dots): {hostname}"
+            )
+
+        if not _is_ip_address(hostname):
+            parts = hostname.split(".")
+            if len(parts) < 2:
+                return FailResult(
+                    error_message=f"Domain must have at least two parts: {hostname}"
+                )
+
+            tld = parts[-1]
+            if len(tld) < 2 or len(tld) > 63:
+                return FailResult(
+                    error_message=f"Invalid TLD length ({len(tld)}): {hostname}"
+                )
+
+            if len(hostname) > 253:
+                return FailResult(
+                    error_message=f"Domain too long ({len(hostname)} chars): {hostname}"
+                )
+
+        return PassResult()

--- a/guardrails/validators/url_reachability.py
+++ b/guardrails/validators/url_reachability.py
@@ -1,0 +1,104 @@
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from guardrails.logger import logger
+from guardrails.validator_base import (
+    FailResult,
+    PassResult,
+    ValidationResult,
+    Validator,
+    register_validator,
+)
+
+
+@register_validator(name="url-reachability", data_type=["string"])
+class URLReachability(Validator):
+    """Validates that a URL is reachable via HTTP and optionally checks TLS.
+
+    Sends an HTTP HEAD request to the URL and checks whether the response
+    status code falls within an acceptable range.
+
+    **Key Properties**
+
+    | Property                      | Description                       |
+    | ----------------------------- | --------------------------------- |
+    | Name for `format` attribute   | `url-reachability`                |
+    | Supported data types          | `string`                          |
+    | Programmatic fix              | None                              |
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+        check_tls: Whether to verify TLS certificates.
+        accept_status: HTTP status codes considered acceptable.
+            Defaults to 200-399.
+    """
+
+    def __init__(
+        self,
+        timeout: float = 10.0,
+        check_tls: bool = True,
+        accept_status: Optional[List[int]] = None,
+        on_fail: Optional[Callable] = None,
+    ):
+        super().__init__(
+            on_fail=on_fail,
+            timeout=timeout,
+            check_tls=check_tls,
+            accept_status=accept_status,
+        )
+        self._timeout = timeout
+        self._check_tls = check_tls
+        self._accept_status = accept_status or list(range(200, 400))
+
+    def validate(self, value: Any, metadata: Dict) -> ValidationResult:
+        logger.debug(f"Checking URL reachability: {value}")
+
+        url = value if "://" in value else "https://" + value
+
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return FailResult(
+                error_message=f"Cannot parse URL: {value}"
+            )
+
+        if not parsed.scheme or not parsed.netloc:
+            return FailResult(
+                error_message=f"Invalid URL (missing scheme or host): {value}"
+            )
+
+        try:
+            response = httpx.head(
+                url,
+                timeout=self._timeout,
+                verify=self._check_tls,
+                follow_redirects=True,
+            )
+        except httpx.ConnectError:
+            return FailResult(
+                error_message=f"URL not reachable (connection failed): {value}"
+            )
+        except httpx.TimeoutException:
+            return FailResult(
+                error_message=f"URL not reachable (timeout after {self._timeout}s): {value}"
+            )
+        except httpx.HTTPError as exc:
+            if "SSL" in str(exc) or "TLS" in str(exc) or "certificate" in str(exc).lower():
+                return FailResult(
+                    error_message=f"TLS certificate error for: {value}"
+                )
+            return FailResult(
+                error_message=f"HTTP error for {value}: {exc}"
+            )
+
+        if response.status_code not in self._accept_status:
+            return FailResult(
+                error_message=(
+                    f"URL returned status {response.status_code} "
+                    f"(accepted: {self._accept_status[0]}-{self._accept_status[-1]}): {value}"
+                )
+            )
+
+        return PassResult()

--- a/guardrails/validators/url_risk_scorer.py
+++ b/guardrails/validators/url_risk_scorer.py
@@ -1,0 +1,174 @@
+import re
+from difflib import SequenceMatcher
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlparse
+
+from guardrails.logger import logger
+from guardrails.validator_base import (
+    FailResult,
+    PassResult,
+    ValidationResult,
+    Validator,
+    register_validator,
+)
+
+SUSPICIOUS_TLDS = frozenset({
+    "tk", "ml", "ga", "cf", "gq", "top", "xyz", "buzz", "club",
+    "work", "click", "link", "surf", "rest", "fit",
+})
+
+DEFAULT_KNOWN_DOMAINS = [
+    "google.com", "facebook.com", "amazon.com", "apple.com",
+    "microsoft.com", "github.com", "twitter.com", "linkedin.com",
+    "youtube.com", "netflix.com", "instagram.com", "reddit.com",
+    "wikipedia.org", "stackoverflow.com", "openai.com",
+    "paypal.com", "chase.com", "bankofamerica.com",
+]
+
+
+def _extract_domain(value: str) -> Optional[str]:
+    if "://" not in value:
+        value = "https://" + value
+    try:
+        return urlparse(value).hostname
+    except ValueError:
+        return None
+
+
+def _score_suspicious_tld(domain: str) -> float:
+    tld = domain.rsplit(".", 1)[-1].lower()
+    return 1.0 if tld in SUSPICIOUS_TLDS else 0.0
+
+
+def _score_subdomain_depth(domain: str) -> float:
+    parts = domain.split(".")
+    depth = len(parts) - 2
+    if depth <= 1:
+        return 0.0
+    if depth <= 3:
+        return 0.5
+    return 1.0
+
+
+def _score_digit_mix(domain: str) -> float:
+    name = domain.rsplit(".", 1)[0]
+    if not name:
+        return 0.0
+    has_alpha = any(c.isalpha() for c in name)
+    has_digit = any(c.isdigit() for c in name)
+    if has_alpha and has_digit:
+        digit_ratio = sum(c.isdigit() for c in name) / len(name)
+        if 0.1 < digit_ratio < 0.6:
+            return 1.0
+    return 0.0
+
+
+def _score_long_domain(domain: str) -> float:
+    if len(domain) > 50:
+        return 1.0
+    if len(domain) > 30:
+        return 0.5
+    return 0.0
+
+
+def _score_typosquatting(domain: str, known_domains: List[str]) -> float:
+    base = domain.split(".")
+    if len(base) >= 2:
+        candidate = ".".join(base[-2:]).lower()
+    else:
+        candidate = domain.lower()
+
+    best_ratio = 0.0
+    for known in known_domains:
+        if candidate == known:
+            return 0.0
+        ratio = SequenceMatcher(None, candidate, known).ratio()
+        if ratio > best_ratio:
+            best_ratio = ratio
+
+    if best_ratio > 0.85:
+        return 1.0
+    if best_ratio > 0.75:
+        return 0.5
+    return 0.0
+
+
+@register_validator(name="url-risk-scorer", data_type=["string"])
+class URLRiskScorer(Validator):
+    """Pattern-based URL risk scoring.
+
+    Calculates a weighted risk score from multiple signals: suspicious TLDs,
+    excessive subdomains, digit-letter mixing, long domains, and
+    typosquatting similarity to well-known domains.
+
+    **Key Properties**
+
+    | Property                      | Description                       |
+    | ----------------------------- | --------------------------------- |
+    | Name for `format` attribute   | `url-risk-scorer`                 |
+    | Supported data types          | `string`                          |
+    | Programmatic fix              | None                              |
+
+    Args:
+        threshold: Risk score above which the URL fails validation (0.0-1.0).
+        known_domains: Domains used for typosquatting detection.
+    """
+
+    WEIGHTS = {
+        "suspicious_tld": 0.20,
+        "subdomain_depth": 0.15,
+        "digit_mix": 0.20,
+        "long_domain": 0.10,
+        "typosquatting": 0.35,
+    }
+
+    def __init__(
+        self,
+        threshold: float = 0.7,
+        known_domains: Optional[List[str]] = None,
+        on_fail: Optional[Callable] = None,
+    ):
+        super().__init__(
+            on_fail=on_fail,
+            threshold=threshold,
+            known_domains=known_domains,
+        )
+        self._threshold = threshold
+        self._known_domains = known_domains or DEFAULT_KNOWN_DOMAINS
+
+    def _score(self, domain: str) -> tuple:
+        signals = {
+            "suspicious_tld": _score_suspicious_tld(domain),
+            "subdomain_depth": _score_subdomain_depth(domain),
+            "digit_mix": _score_digit_mix(domain),
+            "long_domain": _score_long_domain(domain),
+            "typosquatting": _score_typosquatting(domain, self._known_domains),
+        }
+
+        total = sum(
+            signals[k] * self.WEIGHTS[k] for k in signals
+        )
+
+        reasons = [k for k, v in signals.items() if v > 0]
+        return total, reasons
+
+    def validate(self, value: Any, metadata: Dict) -> ValidationResult:
+        logger.debug(f"Scoring URL risk: {value}")
+
+        domain = _extract_domain(value)
+        if domain is None:
+            return FailResult(
+                error_message=f"Cannot extract domain from: {value}"
+            )
+
+        score, reasons = self._score(domain)
+
+        if score > self._threshold:
+            return FailResult(
+                error_message=(
+                    f"High risk URL (score={score:.2f}, "
+                    f"threshold={self._threshold}): {', '.join(reasons)}"
+                )
+            )
+
+        return PassResult()

--- a/tests/unit_tests/validators/test_domain_blocklist.py
+++ b/tests/unit_tests/validators/test_domain_blocklist.py
@@ -1,0 +1,66 @@
+import pytest
+from guardrails.validators.domain_blocklist import DomainBlocklist
+from guardrails.validator_base import PassResult, FailResult
+
+
+class TestDomainBlocklist:
+    def test_blocked_domain_rejected(self):
+        v = DomainBlocklist(blocked=["evil.com"])
+        result = v.validate("https://evil.com/malware", {})
+        assert isinstance(result, FailResult)
+        assert "blocked" in result.error_message
+
+    def test_clean_domain_passes_blocklist(self):
+        v = DomainBlocklist(blocked=["evil.com"])
+        result = v.validate("https://google.com", {})
+        assert isinstance(result, PassResult)
+
+    def test_subdomain_matched_by_default(self):
+        v = DomainBlocklist(blocked=["evil.com"])
+        result = v.validate("https://sub.evil.com/page", {})
+        assert isinstance(result, FailResult)
+
+    def test_subdomain_not_matched_when_disabled(self):
+        v = DomainBlocklist(blocked=["evil.com"], match_subdomains=False)
+        result = v.validate("https://sub.evil.com/page", {})
+        assert isinstance(result, PassResult)
+
+    def test_allowlist_mode_passes_allowed(self):
+        v = DomainBlocklist(allowed=["trusted.com"], mode="allowlist")
+        result = v.validate("https://trusted.com/api", {})
+        assert isinstance(result, PassResult)
+
+    def test_allowlist_mode_rejects_unknown(self):
+        v = DomainBlocklist(allowed=["trusted.com"], mode="allowlist")
+        result = v.validate("https://unknown.com", {})
+        assert isinstance(result, FailResult)
+        assert "not in the allowlist" in result.error_message
+
+    def test_allowlist_with_subdomain(self):
+        v = DomainBlocklist(allowed=["trusted.com"], mode="allowlist")
+        result = v.validate("https://api.trusted.com", {})
+        assert isinstance(result, PassResult)
+
+    def test_case_insensitive(self):
+        v = DomainBlocklist(blocked=["Evil.COM"])
+        result = v.validate("https://evil.com", {})
+        assert isinstance(result, FailResult)
+
+    def test_bare_domain_input(self):
+        v = DomainBlocklist(blocked=["evil.com"])
+        result = v.validate("evil.com", {})
+        assert isinstance(result, FailResult)
+
+    def test_empty_blocklist_passes_all(self):
+        v = DomainBlocklist(blocked=[])
+        result = v.validate("https://anything.com", {})
+        assert isinstance(result, PassResult)
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(AssertionError):
+            DomainBlocklist(mode="invalid")
+
+    def test_unparseable_input(self):
+        v = DomainBlocklist(blocked=["evil.com"])
+        result = v.validate("", {})
+        assert isinstance(result, FailResult)

--- a/tests/unit_tests/validators/test_url_dns_resolver.py
+++ b/tests/unit_tests/validators/test_url_dns_resolver.py
@@ -1,0 +1,66 @@
+import socket
+from unittest.mock import patch
+
+import pytest
+from guardrails.validators.url_dns_resolver import URLDNSResolver
+from guardrails.validator_base import PassResult, FailResult
+
+
+class TestURLDNSResolver:
+    def setup_method(self):
+        self.validator = URLDNSResolver(timeout=2.0, cache_size=16)
+
+    @patch("guardrails.validators.url_dns_resolver.socket.getaddrinfo")
+    def test_resolvable_domain_passes(self, mock_dns):
+        mock_dns.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+        ]
+        result = self.validator.validate("https://example.com", {})
+        assert isinstance(result, PassResult)
+        mock_dns.assert_called_once_with("example.com", None)
+
+    @patch("guardrails.validators.url_dns_resolver.socket.getaddrinfo")
+    def test_unresolvable_domain_fails(self, mock_dns):
+        mock_dns.side_effect = socket.gaierror("Name resolution failed")
+        result = self.validator.validate("https://fake-domain-xyz-12345.com", {})
+        assert isinstance(result, FailResult)
+        assert "does not resolve" in result.error_message
+
+    @patch("guardrails.validators.url_dns_resolver.socket.getaddrinfo")
+    def test_timeout_fails(self, mock_dns):
+        mock_dns.side_effect = socket.timeout("Timed out")
+        result = self.validator.validate("https://slow-domain.com", {})
+        assert isinstance(result, FailResult)
+
+    @patch("guardrails.validators.url_dns_resolver.socket.getaddrinfo")
+    def test_cache_hit_avoids_second_lookup(self, mock_dns):
+        mock_dns.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 0))
+        ]
+        self.validator.validate("https://cached.com", {})
+        self.validator.validate("https://cached.com/other-path", {})
+        assert mock_dns.call_count == 1
+
+    @patch("guardrails.validators.url_dns_resolver.socket.getaddrinfo")
+    def test_failed_result_cached(self, mock_dns):
+        mock_dns.side_effect = socket.gaierror("fail")
+        self.validator.validate("https://bad.com", {})
+        self.validator.validate("https://bad.com", {})
+        assert mock_dns.call_count == 1
+
+    def test_bare_domain_input(self):
+        with patch("guardrails.validators.url_dns_resolver.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 0))]
+            result = self.validator.validate("example.com", {})
+            assert isinstance(result, PassResult)
+
+    def test_empty_input_fails(self):
+        result = self.validator.validate("", {})
+        assert isinstance(result, FailResult)
+
+    @patch("guardrails.validators.url_dns_resolver.socket.getaddrinfo")
+    def test_url_with_path_extracts_host(self, mock_dns):
+        mock_dns.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 0))]
+        result = self.validator.validate("https://example.com/path/to/page?q=1", {})
+        assert isinstance(result, PassResult)
+        mock_dns.assert_called_once_with("example.com", None)

--- a/tests/unit_tests/validators/test_url_format.py
+++ b/tests/unit_tests/validators/test_url_format.py
@@ -1,0 +1,74 @@
+import pytest
+from guardrails.validators.url_format import URLFormatValidator
+from guardrails.validator_base import PassResult, FailResult
+
+
+class TestURLFormatValidator:
+    def setup_method(self):
+        self.validator = URLFormatValidator()
+
+    def test_valid_http_url(self):
+        result = self.validator.validate("http://example.com", {})
+        assert isinstance(result, PassResult)
+
+    def test_valid_https_url(self):
+        result = self.validator.validate("https://example.com/path?q=1", {})
+        assert isinstance(result, PassResult)
+
+    def test_missing_scheme(self):
+        result = self.validator.validate("example.com", {})
+        assert isinstance(result, FailResult)
+
+    def test_missing_host(self):
+        result = self.validator.validate("https://", {})
+        assert isinstance(result, FailResult)
+
+    def test_empty_string(self):
+        result = self.validator.validate("", {})
+        assert isinstance(result, FailResult)
+
+    def test_require_https_rejects_http(self):
+        v = URLFormatValidator(require_https=True)
+        result = v.validate("http://example.com", {})
+        assert isinstance(result, FailResult)
+        assert "HTTPS required" in result.error_message
+
+    def test_require_https_accepts_https(self):
+        v = URLFormatValidator(require_https=True)
+        result = v.validate("https://example.com", {})
+        assert isinstance(result, PassResult)
+
+    def test_disallowed_scheme(self):
+        v = URLFormatValidator(allowed_schemes=["https"])
+        result = v.validate("ftp://files.example.com", {})
+        assert isinstance(result, FailResult)
+        assert "not allowed" in result.error_message
+
+    def test_ip_rejected_by_default(self):
+        result = self.validator.validate("http://192.168.1.1/path", {})
+        assert isinstance(result, FailResult)
+        assert "IP addresses" in result.error_message
+
+    def test_ip_allowed_when_configured(self):
+        v = URLFormatValidator(allow_ip=True)
+        result = v.validate("http://192.168.1.1/path", {})
+        assert isinstance(result, PassResult)
+
+    def test_consecutive_dots_rejected(self):
+        result = self.validator.validate("https://example..com", {})
+        assert isinstance(result, FailResult)
+        assert "consecutive dots" in result.error_message
+
+    def test_single_part_domain_rejected(self):
+        result = self.validator.validate("https://localhost", {})
+        assert isinstance(result, FailResult)
+
+    def test_valid_subdomain(self):
+        result = self.validator.validate("https://sub.example.com", {})
+        assert isinstance(result, PassResult)
+
+    def test_long_domain_rejected(self):
+        long_host = "a" * 250 + ".com"
+        result = self.validator.validate(f"https://{long_host}", {})
+        assert isinstance(result, FailResult)
+        assert "too long" in result.error_message

--- a/tests/unit_tests/validators/test_url_reachability.py
+++ b/tests/unit_tests/validators/test_url_reachability.py
@@ -1,0 +1,87 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+from guardrails.validators.url_reachability import URLReachability
+from guardrails.validator_base import PassResult, FailResult
+
+
+class TestURLReachability:
+    def setup_method(self):
+        self.validator = URLReachability(timeout=5.0)
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_reachable_url_passes(self, mock_head):
+        mock_head.return_value = MagicMock(status_code=200)
+        result = self.validator.validate("https://example.com", {})
+        assert isinstance(result, PassResult)
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_redirect_passes(self, mock_head):
+        mock_head.return_value = MagicMock(status_code=301)
+        result = self.validator.validate("https://example.com", {})
+        assert isinstance(result, PassResult)
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_404_fails(self, mock_head):
+        mock_head.return_value = MagicMock(status_code=404)
+        result = self.validator.validate("https://example.com/missing", {})
+        assert isinstance(result, FailResult)
+        assert "404" in result.error_message
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_500_fails(self, mock_head):
+        mock_head.return_value = MagicMock(status_code=500)
+        result = self.validator.validate("https://example.com/error", {})
+        assert isinstance(result, FailResult)
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_connection_error(self, mock_head):
+        import httpx
+        mock_head.side_effect = httpx.ConnectError("Connection refused")
+        result = self.validator.validate("https://nonexistent.example", {})
+        assert isinstance(result, FailResult)
+        assert "connection failed" in result.error_message
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_timeout_error(self, mock_head):
+        import httpx
+        mock_head.side_effect = httpx.TimeoutException("Timed out")
+        result = self.validator.validate("https://slow.example.com", {})
+        assert isinstance(result, FailResult)
+        assert "timeout" in result.error_message
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_tls_error(self, mock_head):
+        import httpx
+        mock_head.side_effect = httpx.HTTPError("SSL certificate verify failed")
+        result = self.validator.validate("https://expired-cert.com", {})
+        assert isinstance(result, FailResult)
+        assert "TLS" in result.error_message or "SSL" in result.error_message
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_custom_accept_status(self, mock_head):
+        mock_head.return_value = MagicMock(status_code=404)
+        v = URLReachability(accept_status=[200, 404])
+        result = v.validate("https://example.com", {})
+        assert isinstance(result, PassResult)
+
+    def test_invalid_url_fails(self):
+        result = self.validator.validate("", {})
+        assert isinstance(result, FailResult)
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_check_tls_disabled(self, mock_head):
+        mock_head.return_value = MagicMock(status_code=200)
+        v = URLReachability(check_tls=False)
+        v.validate("https://self-signed.example.com", {})
+        mock_head.assert_called_once()
+        _, kwargs = mock_head.call_args
+        assert kwargs["verify"] is False
+
+    @patch("guardrails.validators.url_reachability.httpx.head")
+    def test_bare_domain_gets_scheme(self, mock_head):
+        mock_head.return_value = MagicMock(status_code=200)
+        result = self.validator.validate("example.com", {})
+        assert isinstance(result, PassResult)
+        call_url = mock_head.call_args[0][0]
+        assert call_url.startswith("https://")

--- a/tests/unit_tests/validators/test_url_risk_scorer.py
+++ b/tests/unit_tests/validators/test_url_risk_scorer.py
@@ -1,0 +1,72 @@
+import pytest
+from guardrails.validators.url_risk_scorer import URLRiskScorer
+from guardrails.validator_base import PassResult, FailResult
+
+
+class TestURLRiskScorer:
+    def setup_method(self):
+        self.validator = URLRiskScorer(threshold=0.7)
+
+    def test_legitimate_domain_passes(self):
+        result = self.validator.validate("https://google.com", {})
+        assert isinstance(result, PassResult)
+
+    def test_legitimate_domain_with_path_passes(self):
+        result = self.validator.validate("https://github.com/user/repo", {})
+        assert isinstance(result, PassResult)
+
+    def test_suspicious_tld(self):
+        v = URLRiskScorer(threshold=0.15)
+        result = v.validate("https://something.tk", {})
+        assert isinstance(result, FailResult)
+        assert "suspicious_tld" in result.error_message
+
+    def test_typosquatting_detected(self):
+        v = URLRiskScorer(threshold=0.3)
+        result = v.validate("https://gooogle.com", {})
+        assert isinstance(result, FailResult)
+        assert "typosquatting" in result.error_message
+
+    def test_digit_mix_detected(self):
+        v = URLRiskScorer(threshold=0.15)
+        result = v.validate("https://g00gle.com", {})
+        assert isinstance(result, FailResult)
+
+    def test_deep_subdomains(self):
+        v = URLRiskScorer(threshold=0.1)
+        result = v.validate("https://a.b.c.d.e.example.com", {})
+        assert isinstance(result, FailResult)
+        assert "subdomain_depth" in result.error_message
+
+    def test_long_domain(self):
+        v = URLRiskScorer(threshold=0.05)
+        long_name = "a" * 55 + ".com"
+        result = v.validate(f"https://{long_name}", {})
+        assert isinstance(result, FailResult)
+        assert "long_domain" in result.error_message
+
+    def test_combined_risk_signals(self):
+        v = URLRiskScorer(threshold=0.3)
+        result = v.validate("https://g00gle.tk", {})
+        assert isinstance(result, FailResult)
+
+    def test_custom_known_domains(self):
+        v = URLRiskScorer(
+            threshold=0.3,
+            known_domains=["mycompany.com"]
+        )
+        result = v.validate("https://myconpany.com", {})
+        assert isinstance(result, FailResult)
+
+    def test_exact_match_known_domain_passes(self):
+        result = self.validator.validate("https://google.com", {})
+        assert isinstance(result, PassResult)
+
+    def test_empty_input_fails(self):
+        result = self.validator.validate("", {})
+        assert isinstance(result, FailResult)
+
+    def test_high_threshold_passes_more(self):
+        v = URLRiskScorer(threshold=0.99)
+        result = v.validate("https://something-weird.tk", {})
+        assert isinstance(result, PassResult)

--- a/tests/unit_tests/validators/test_validators_integration.py
+++ b/tests/unit_tests/validators/test_validators_integration.py
@@ -1,0 +1,84 @@
+"""Integration tests: composing multiple URL validators together."""
+
+import socket
+from unittest.mock import patch, MagicMock
+
+import pytest
+from guardrails.validators.url_format import URLFormatValidator
+from guardrails.validators.url_dns_resolver import URLDNSResolver
+from guardrails.validators.domain_blocklist import DomainBlocklist
+from guardrails.validators.url_risk_scorer import URLRiskScorer
+from guardrails.validator_base import PassResult, FailResult
+
+
+class TestValidatorComposition:
+    """Test validators used in sequence, simulating Guard().use_many()."""
+
+    def _run_chain(self, validators, value):
+        for v in validators:
+            result = v.validate(value, {})
+            if isinstance(result, FailResult):
+                return result
+        return PassResult()
+
+    def test_legitimate_url_passes_all(self):
+        validators = [
+            URLFormatValidator(),
+            DomainBlocklist(blocked=["evil.com"]),
+            URLRiskScorer(threshold=0.7),
+        ]
+        result = self._run_chain(validators, "https://github.com/user/repo")
+        assert isinstance(result, PassResult)
+
+    def test_blocked_domain_caught_early(self):
+        validators = [
+            URLFormatValidator(),
+            DomainBlocklist(blocked=["malware.com"]),
+            URLRiskScorer(threshold=0.7),
+        ]
+        result = self._run_chain(validators, "https://malware.com/payload")
+        assert isinstance(result, FailResult)
+        assert "blocked" in result.error_message
+
+    def test_bad_format_caught_first(self):
+        validators = [
+            URLFormatValidator(),
+            DomainBlocklist(blocked=["evil.com"]),
+        ]
+        result = self._run_chain(validators, "not-a-url")
+        assert isinstance(result, FailResult)
+        assert "scheme" in result.error_message.lower() or "missing" in result.error_message.lower()
+
+    @patch("guardrails.validators.url_dns_resolver.socket.getaddrinfo")
+    def test_hallucinated_url_caught_by_dns(self, mock_dns):
+        mock_dns.side_effect = socket.gaierror("NXDOMAIN")
+        validators = [
+            URLFormatValidator(),
+            URLDNSResolver(timeout=2.0),
+        ]
+        result = self._run_chain(validators, "https://fake-company-xyz-12345.com")
+        assert isinstance(result, FailResult)
+        assert "does not resolve" in result.error_message
+
+    def test_typosquatting_caught_by_risk_scorer(self):
+        validators = [
+            URLFormatValidator(),
+            URLRiskScorer(threshold=0.3),
+        ]
+        result = self._run_chain(validators, "https://gooogle.com")
+        assert isinstance(result, FailResult)
+        assert "typosquatting" in result.error_message
+
+    def test_strict_allowlist_mode(self):
+        validators = [
+            URLFormatValidator(require_https=True),
+            DomainBlocklist(
+                allowed=["api.internal.com", "docs.internal.com"],
+                mode="allowlist",
+            ),
+        ]
+        result = self._run_chain(validators, "https://api.internal.com/v1")
+        assert isinstance(result, PassResult)
+
+        result = self._run_chain(validators, "https://external.com")
+        assert isinstance(result, FailResult)


### PR DESCRIPTION
Add production-ready URL validation capabilities that guardrails-ai currently lacks:

- URLFormatValidator: enhanced format checks (scheme whitelist, IP rejection, structural quality)
- DomainBlocklist: blocklist/allowlist filtering with subdomain matching
- URLDNSResolver: DNS resolution verification with TTL cache
- URLRiskScorer: weighted risk scoring (suspicious TLD, typosquatting, digit mixing)
- URLReachability: HTTP HEAD + TLS certificate validation

All validators follow single-responsibility design and compose via Guard().use_many(). 63 unit tests and integration tests included, all passing.
Closes #1497