### PR TITLE
[GR-1710] Deprecate hub CLI + private registry; move to public PyPI (WS-G/H/I)

### DIFF
--- a/.github/actions/validator_pypi_publish/README.md
+++ b/.github/actions/validator_pypi_publish/README.md
@@ -1,0 +1,31 @@
+# ⚠️ DEPRECATED: `validator_pypi_publish`
+
+**This action is deprecated and will be removed.**
+
+It publishes a validator to the **private** Guardrails registry
+(`pypi.guardrailsai.com`) via `twine`, using the legacy `<org>-grhub-<name>`
+package-name mangling. Both the private registry and that naming scheme are
+being retired.
+
+## What replaces it
+
+Guardrails-owned validators now live in the
+[`guardrails-ai/guardrails-hub`](https://github.com/guardrails-ai/guardrails-hub)
+monorepo and publish to **public PyPI** as `guardrails-ai-<name>` (importable as
+`guardrails_ai.<name>`) using **trusted publishing** (OIDC — no tokens). See
+`guardrails-hub/.github/workflows/validators_publish.yml`.
+
+| Old | New |
+|---|---|
+| Private registry `pypi.guardrailsai.com` | Public PyPI |
+| Dist name `guardrails-grhub-<name>` | `guardrails-ai-<name>` |
+| `twine upload` with a Guardrails token | `pypa/gh-action-pypi-publish` via OIDC |
+| This shared composite action | Change-detected `validators_publish.yml` in the monorepo |
+
+## Why it's still here
+
+The old per-validator repositories still reference this action at
+`guardrails-ai/guardrails/.github/actions/validator_pypi_publish@main`. To avoid
+breaking their CI, the action remains functional but now emits a loud
+deprecation warning. **Full removal is tracked with the per-validator repo
+archival phase** (out of scope for the current migration).

--- a/.github/actions/validator_pypi_publish/action.yml
+++ b/.github/actions/validator_pypi_publish/action.yml
@@ -19,6 +19,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Deprecation notice
+      shell: bash
+      run: |
+        echo "::warning title=Deprecated action::guardrails-ai/guardrails/.github/actions/validator_pypi_publish is DEPRECATED. It publishes to the private registry (pypi.guardrailsai.com), which is being retired. New validators live in the guardrails-ai/guardrails-hub monorepo and publish to public PyPI as guardrails-ai-<name> via trusted publishing (OIDC). See guardrails-hub/.github/workflows/validators_publish.yml. This action will be removed once the old per-validator repos are archived."
+
     - name: Checkout "Validator" Repository
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:

--- a/.github/workflows/examples_check.yml
+++ b/.github/workflows/examples_check.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         source .venv/bin/activate
         mkdir /tmp/nltk_data;
-        python -m nltk.downloader -d /tmp/nltk_data punkt;
+        python -m nltk.downloader -d /tmp/nltk_data punkt punkt_tab;
     - name: Login to Guardrails
       run: |
         source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ pip install guardrails-ai
 2. Install a guardrail from Guardrails Hub.
 
     ```bash
-    guardrails hub install hub://guardrails/regex_match
+    pip install guardrails-ai-regex-match
     ```
 3. Create a Guard from the installed guardrail.
 
     ```python
     from guardrails import Guard, OnFailAction
-    from guardrails.hub import RegexMatch
+    from guardrails_ai.regex_match import RegexMatch
 
     guard = Guard().use(
         RegexMatch, regex="\(?\d{3}\)?-? *\d{3}-? *-?\d{4}", on_fail=OnFailAction.EXCEPTION
@@ -91,15 +91,15 @@ pip install guardrails-ai
     First, install the necessary guardrails from Guardrails Hub.
 
     ```bash
-    guardrails hub install hub://guardrails/competitor_check
-    guardrails hub install hub://guardrails/toxic_language
+    pip install guardrails-ai-competitor-check guardrails-ai-toxic-language
     ```
 
     Then, create a Guard from the installed guardrails.
 
     ```python
     from guardrails import Guard, OnFailAction
-    from guardrails.hub import CompetitorCheck, ToxicLanguage
+    from guardrails_ai.competitor_check import CompetitorCheck
+    from guardrails_ai.toxic_language import ToxicLanguage
 
     guard = Guard().use(
         CompetitorCheck(["Apple", "Microsoft", "Google"], on_fail=OnFailAction.EXCEPTION),

--- a/docs/examples/bug_free_python_code.ipynb
+++ b/docs/examples/bug_free_python_code.ipynb
@@ -46,7 +46,7 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://reflex/valid_python --quiet"
+    "!pip install guardrails-ai-valid-python --quiet"
    ]
   },
   {

--- a/docs/examples/bug_free_python_code.ipynb
+++ b/docs/examples/bug_free_python_code.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guardrails.hub import ValidPython\n",
+    "from guardrails_ai.valid_python import ValidPython\n",
     "from guardrails import Guard\n",
     "\n",
     "guard = Guard().use(ValidPython(on_fail=\"reask\"))"

--- a/docs/examples/chatbot.ipynb
+++ b/docs/examples/chatbot.ipynb
@@ -33,8 +33,8 @@
     }
    ],
    "source": [
-    "! guardrails hub install hub://guardrails/profanity_free --quiet\n",
-    "! guardrails hub install hub://guardrails/toxic_language --quiet\n",
+    "! pip install guardrails-ai-profanity-free --quiet\n",
+    "! pip install guardrails-ai-toxic-language --quiet\n",
     "! pip install -q gradio"
    ]
   },

--- a/docs/examples/chatbot.ipynb
+++ b/docs/examples/chatbot.ipynb
@@ -39,6 +39,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These validators tokenize text with NLTK at runtime; `pip install` doesn't run\n",
+    "# the package post-install step, so fetch the tokenizer data explicitly.\n",
+    "import nltk\n",
+    "\n",
+    "nltk.download(\"punkt_tab\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/examples/chatbot.ipynb
+++ b/docs/examples/chatbot.ipynb
@@ -129,7 +129,8 @@
     }
    ],
    "source": [
-    "from guardrails.hub import ProfanityFree, ToxicLanguage\n",
+    "from guardrails_ai.profanity_free import ProfanityFree\n",
+    "from guardrails_ai.toxic_language import ToxicLanguage\n",
     "\n",
     "guard = Guard()\n",
     "guard.name = \"ChatBotGuard\"\n",

--- a/docs/examples/check_for_pii.ipynb
+++ b/docs/examples/check_for_pii.ipynb
@@ -37,7 +37,7 @@
     "! pip install presidio-analyzer presidio-anonymizer -q\n",
     "! python -m spacy download en_core_web_lg -q\n",
     "\n",
-    "! guardrails hub install hub://guardrails/detect_pii --quiet"
+    "! pip install guardrails-ai-detect-pii --quiet"
    ]
   },
   {

--- a/docs/examples/check_for_pii.ipynb
+++ b/docs/examples/check_for_pii.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "# Import the guardrails package\n",
-    "from guardrails.hub import DetectPII\n",
+    "from guardrails_ai.detect_pii import DetectPII\n",
     "import guardrails as gd\n",
     "from rich import print"
    ]

--- a/docs/examples/check_for_pii.ipynb
+++ b/docs/examples/check_for_pii.ipynb
@@ -42,6 +42,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These validators tokenize text with NLTK at runtime; `pip install` doesn't run\n",
+    "# the package post-install step, so fetch the tokenizer data explicitly.\n",
+    "import nltk\n",
+    "\n",
+    "nltk.download(\"punkt_tab\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],

--- a/docs/examples/competitors_check.ipynb
+++ b/docs/examples/competitors_check.ipynb
@@ -35,7 +35,7 @@
    ],
    "source": [
     "! pip install nltk --quiet\n",
-    "! guardrails hub install hub://guardrails/competitor_check --quiet"
+    "! pip install guardrails-ai-competitor-check --quiet"
    ]
   },
   {

--- a/docs/examples/competitors_check.ipynb
+++ b/docs/examples/competitors_check.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guardrails.hub import CompetitorCheck\n",
+    "from guardrails_ai.competitor_check import CompetitorCheck\n",
     "import guardrails as gd\n",
     "from rich import print"
    ]

--- a/docs/examples/competitors_check.ipynb
+++ b/docs/examples/competitors_check.ipynb
@@ -40,6 +40,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These validators tokenize text with NLTK at runtime; `pip install` doesn't run\n",
+    "# the package post-install step, so fetch the tokenizer data explicitly.\n",
+    "import nltk\n",
+    "\n",
+    "nltk.download(\"punkt_tab\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],

--- a/docs/examples/extracting_entities.ipynb
+++ b/docs/examples/extracting_entities.ipynb
@@ -35,11 +35,11 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/valid_length --quiet\n",
-    "!guardrails hub install hub://guardrails/two_words --quiet\n",
-    "!guardrails hub install hub://guardrails/valid_range --quiet\n",
-    "!guardrails hub install hub://guardrails/lowercase --quiet\n",
-    "!guardrails hub install hub://guardrails/one_line --quiet\n",
+    "!pip install guardrails-ai-valid-length --quiet\n",
+    "!pip install guardrails-ai-two-words --quiet\n",
+    "!pip install guardrails-ai-valid-range --quiet\n",
+    "!pip install guardrails-ai-lowercase --quiet\n",
+    "!pip install guardrails-ai-one-line --quiet\n",
     "\n",
     "%pip install pypdfium2"
    ]

--- a/docs/examples/extracting_entities.ipynb
+++ b/docs/examples/extracting_entities.ipynb
@@ -140,7 +140,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guardrails.hub import LowerCase, TwoWords, OneLine\n",
+    "from guardrails_ai.lowercase import LowerCase\n",
+    "from guardrails_ai.two_words import TwoWords\n",
+    "from guardrails_ai.one_line import OneLine\n",
     "from pydantic import BaseModel, Field\n",
     "\n",
     "prompt = \"\"\"\n",

--- a/docs/examples/generate_structured_data.ipynb
+++ b/docs/examples/generate_structured_data.ipynb
@@ -25,9 +25,9 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/valid_length --quiet\n",
-    "!guardrails hub install hub://guardrails/two_words --quiet\n",
-    "!guardrails hub install hub://guardrails/valid_range --quiet"
+    "!pip install guardrails-ai-valid-length --quiet\n",
+    "!pip install guardrails-ai-two-words --quiet\n",
+    "!pip install guardrails-ai-valid-range --quiet"
    ]
   },
   {

--- a/docs/examples/generate_structured_data.ipynb
+++ b/docs/examples/generate_structured_data.ipynb
@@ -66,7 +66,9 @@
    "outputs": [],
    "source": [
     "from pydantic import BaseModel, Field\n",
-    "from guardrails.hub import ValidLength, TwoWords, ValidRange\n",
+    "from guardrails_ai.valid_length import ValidLength\n",
+    "from guardrails_ai.two_words import TwoWords\n",
+    "from guardrails_ai.valid_range import ValidRange\n",
     "from typing import List\n",
     "\n",
     "prompt = \"\"\"\n",

--- a/docs/examples/generate_structured_data_cohere.ipynb
+++ b/docs/examples/generate_structured_data_cohere.ipynb
@@ -45,7 +45,7 @@
    "id": "6a7c7d4a",
    "metadata": {},
    "outputs": [],
-   "source": "!guardrails hub install hub://guardrails/valid_length --quiet\n!guardrails hub install hub://guardrails/two_words --quiet\n!guardrails hub install hub://guardrails/valid_range --quiet"
+   "source": "!pip install guardrails-ai-valid-length --quiet\n!pip install guardrails-ai-two-words --quiet\n!pip install guardrails-ai-valid-range --quiet"
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/generate_structured_data_cohere.ipynb
+++ b/docs/examples/generate_structured_data_cohere.ipynb
@@ -66,7 +66,9 @@
    "outputs": [],
    "source": [
     "from pydantic import BaseModel, Field\n",
-    "from guardrails.hub import ValidLength, TwoWords, ValidRange\n",
+    "from guardrails_ai.valid_length import ValidLength\n",
+    "from guardrails_ai.two_words import TwoWords\n",
+    "from guardrails_ai.valid_range import ValidRange\n",
     "from typing import List\n",
     "\n",
     "\n",

--- a/docs/examples/guard_use.ipynb
+++ b/docs/examples/guard_use.ipynb
@@ -21,8 +21,8 @@
     }
    ],
    "source": [
-    "! guardrails hub install hub://guardrails/regex_match --quiet\n",
-    "! guardrails hub install hub://guardrails/valid_range --quiet"
+    "! pip install guardrails-ai-regex-match --quiet\n",
+    "! pip install guardrails-ai-valid-range --quiet"
    ]
   },
   {

--- a/docs/examples/guard_use.ipynb
+++ b/docs/examples/guard_use.ipynb
@@ -33,7 +33,8 @@
    "source": [
     "from pydantic import BaseModel, Field\n",
     "from guardrails import Guard, OnFailAction\n",
-    "from guardrails.hub import RegexMatch, ValidRange\n",
+    "from guardrails_ai.regex_match import RegexMatch\n",
+    "from guardrails_ai.valid_range import ValidRange\n",
     "\n",
     "\n",
     "class Person(BaseModel):\n",

--- a/docs/examples/guardrails_server.ipynb
+++ b/docs/examples/guardrails_server.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! guardrails hub install hub://guardrails/regex_match --quiet"
+    "! pip install guardrails-ai-regex-match --quiet"
    ]
   },
   {

--- a/docs/examples/guardrails_with_chat_models.ipynb
+++ b/docs/examples/guardrails_with_chat_models.ipynb
@@ -27,9 +27,9 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/lowercase --quiet\n",
-    "!guardrails hub install hub://guardrails/two_words --quiet\n",
-    "!guardrails hub install hub://guardrails/one_line --quiet\n",
+    "!pip install guardrails-ai-lowercase --quiet\n",
+    "!pip install guardrails-ai-two-words --quiet\n",
+    "!pip install guardrails-ai-one-line --quiet\n",
     "\n",
     "%pip install pypdfium2"
    ]

--- a/docs/examples/guardrails_with_chat_models.ipynb
+++ b/docs/examples/guardrails_with_chat_models.ipynb
@@ -329,7 +329,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guardrails.hub import LowerCase, TwoWords, OneLine\n",
+    "from guardrails_ai.lowercase import LowerCase\n",
+    "from guardrails_ai.two_words import TwoWords\n",
+    "from guardrails_ai.one_line import OneLine\n",
     "from pydantic import BaseModel, Field\n",
     "\n",
     "prompt = \"\"\"\n",

--- a/docs/examples/input_validation.ipynb
+++ b/docs/examples/input_validation.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "! guardrails hub install hub://guardrails/two_words --quiet"
+    "! pip install guardrails-ai-two-words --quiet"
    ]
   },
   {

--- a/docs/examples/input_validation.ipynb
+++ b/docs/examples/input_validation.ipynb
@@ -124,7 +124,7 @@
     }
    ],
    "source": [
-    "from guardrails.hub import TwoWords\n",
+    "from guardrails_ai.two_words import TwoWords\n",
     "from pydantic import BaseModel\n",
     "\n",
     "\n",

--- a/docs/examples/json_function_calling_tools.ipynb
+++ b/docs/examples/json_function_calling_tools.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "! guardrails hub install hub://guardrails/regex_match --quiet"
+    "! pip install guardrails-ai-regex-match --quiet"
    ]
   },
   {

--- a/docs/examples/json_function_calling_tools.ipynb
+++ b/docs/examples/json_function_calling_tools.ipynb
@@ -198,7 +198,7 @@
    "source": [
     "from rich import print\n",
     "from guardrails import Guard\n",
-    "from guardrails.hub import RegexMatch\n",
+    "from guardrails_ai.regex_match import RegexMatch\n",
     "from pydantic import BaseModel, Field\n",
     "from typing import List\n",
     "\n",

--- a/docs/examples/langchain_integration.ipynb
+++ b/docs/examples/langchain_integration.ipynb
@@ -48,8 +48,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! guardrails hub install hub://guardrails/competitor_check --quiet\n",
-    "! guardrails hub install hub://guardrails/toxic_language --quiet"
+    "! pip install guardrails-ai-competitor-check --quiet\n",
+    "! pip install guardrails-ai-toxic-language --quiet"
    ]
   },
   {

--- a/docs/examples/langchain_integration.ipynb
+++ b/docs/examples/langchain_integration.ipynb
@@ -112,7 +112,8 @@
    "outputs": [],
    "source": [
     "from guardrails import Guard\n",
-    "from guardrails.hub import CompetitorCheck, ToxicLanguage\n",
+    "from guardrails_ai.competitor_check import CompetitorCheck\n",
+    "from guardrails_ai.toxic_language import ToxicLanguage\n",
     "\n",
     "competitors_list = [\"delta\", \"american airlines\", \"united\"]\n",
     "guard = Guard().use(\n",

--- a/docs/examples/langchain_integration.ipynb
+++ b/docs/examples/langchain_integration.ipynb
@@ -53,6 +53,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These validators tokenize text with NLTK at runtime; `pip install` doesn't run\n",
+    "# the package post-install step, so fetch the tokenizer data explicitly.\n",
+    "import nltk\n",
+    "\n",
+    "nltk.download(\"punkt_tab\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9ab6fdd9",
    "metadata": {},

--- a/docs/examples/lite_llm_defaults.ipynb
+++ b/docs/examples/lite_llm_defaults.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "! guardrails hub install hub://guardrails/regex_match --quiet"
+    "! pip install guardrails-ai-regex-match --quiet"
    ]
   },
   {

--- a/docs/examples/lite_llm_defaults.ipynb
+++ b/docs/examples/lite_llm_defaults.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "from rich import print\n",
     "from guardrails import Guard\n",
-    "from guardrails.hub import RegexMatch\n",
+    "from guardrails_ai.regex_match import RegexMatch\n",
     "\n",
     "# Add your OPENAI_API_KEY as an environment variable if it's not already set\n",
     "# import os\n",

--- a/docs/examples/provenance.ipynb
+++ b/docs/examples/provenance.ipynb
@@ -17,8 +17,8 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/provenance_embeddings --quiet\n",
-    "!guardrails hub install hub://guardrails/provenance_llm --quiet"
+    "!pip install guardrails-ai-provenance-embeddings --quiet\n",
+    "!pip install guardrails-ai-provenance-llm --quiet"
    ]
   },
   {

--- a/docs/examples/provenance.ipynb
+++ b/docs/examples/provenance.ipynb
@@ -283,7 +283,31 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Create an embedding function that uses an OpenAI model to embed the text\nimport numpy as np\nfrom openai import OpenAI\nfrom guardrails import Guard\nfrom guardrails.hub import ProvenanceEmbeddings\nfrom typing import List, Union\nimport os\n\n# Create an OpenAI client (reads the OPENAI_API_KEY environment variable)\nopenai_client = OpenAI()\n\n\ndef embed_function(text: Union[str, List[str]]) -> np.ndarray:\n    \"\"\"Embed the text using OpenAI's embedding model.\"\"\"\n    if isinstance(text, str):  # If text is a string, wrap it in a list\n        text = [text]\n\n    response = openai_client.embeddings.create(\n        model=\"text-embedding-3-small\",\n        input=text,\n    )\n    embeddings_list = [item.embedding for item in response.data]\n    return np.array(embeddings_list)"
+   "source": [
+    "# Create an embedding function that uses an OpenAI model to embed the text\n",
+    "import numpy as np\n",
+    "from openai import OpenAI\n",
+    "from guardrails import Guard\n",
+    "from guardrails_ai.provenance_embeddings import ProvenanceEmbeddings\n",
+    "from typing import List, Union\n",
+    "import os\n",
+    "\n",
+    "# Create an OpenAI client (reads the OPENAI_API_KEY environment variable)\n",
+    "openai_client = OpenAI()\n",
+    "\n",
+    "\n",
+    "def embed_function(text: Union[str, List[str]]) -> np.ndarray:\n",
+    "    \"\"\"Embed the text using OpenAI's embedding model.\"\"\"\n",
+    "    if isinstance(text, str):  # If text is a string, wrap it in a list\n",
+    "        text = [text]\n",
+    "\n",
+    "    response = openai_client.embeddings.create(\n",
+    "        model=\"text-embedding-3-small\",\n",
+    "        input=text,\n",
+    "    )\n",
+    "    embeddings_list = [item.embedding for item in response.data]\n",
+    "    return np.array(embeddings_list)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -486,7 +510,7 @@
    "outputs": [],
    "source": [
     "# Initialize the guard object\n",
-    "from guardrails.hub import ProvenanceLLM\n",
+    "from guardrails_ai.provenance_llm import ProvenanceLLM\n",
     "\n",
     "guard_1 = Guard.for_string(\n",
     "    validators=[\n",

--- a/docs/examples/provenance.ipynb
+++ b/docs/examples/provenance.ipynb
@@ -22,6 +22,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These validators tokenize text with NLTK at runtime; `pip install` doesn't run\n",
+    "# the package post-install step, so fetch the tokenizer data explicitly.\n",
+    "import nltk\n",
+    "\n",
+    "nltk.download(\"punkt_tab\")"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/docs/examples/regex_validation.ipynb
+++ b/docs/examples/regex_validation.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/regex_match --quiet"
+    "!pip install guardrails-ai-regex-match --quiet"
    ]
   },
   {

--- a/docs/examples/regex_validation.ipynb
+++ b/docs/examples/regex_validation.ipynb
@@ -70,7 +70,7 @@
    ],
    "source": [
     "from guardrails import Guard\n",
-    "from guardrails.hub import RegexMatch\n",
+    "from guardrails_ai.regex_match import RegexMatch\n",
     "from rich import print\n",
     "\n",
     "# Set your OPENAI_API_KEY as an environment variable\n",

--- a/docs/examples/response_is_on_topic.ipynb
+++ b/docs/examples/response_is_on_topic.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://tryolabs/restricttotopic --quiet"
+    "!pip install guardrails-ai-restricttotopic --quiet"
    ]
   },
   {

--- a/docs/examples/response_is_on_topic.ipynb
+++ b/docs/examples/response_is_on_topic.ipynb
@@ -158,7 +158,7 @@
    ],
    "source": [
     "import guardrails as gd\n",
-    "from guardrails.hub import RestrictToTopic\n",
+    "from guardrails_ai.restricttotopic import RestrictToTopic\n",
     "from guardrails.errors import ValidationError\n",
     "\n",
     "# Create the Guard with the OnTopic Validator\n",

--- a/docs/examples/secrets_detection.ipynb
+++ b/docs/examples/secrets_detection.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/secrets_present --quiet"
+    "!pip install guardrails-ai-secrets-present --quiet"
    ]
   },
   {

--- a/docs/examples/secrets_detection.ipynb
+++ b/docs/examples/secrets_detection.ipynb
@@ -60,7 +60,7 @@
     "# and import the SecretsPresent validator\n",
     "# from Guardrails Hub\n",
     "import guardrails as gd\n",
-    "from guardrails.hub import SecretsPresent\n",
+    "from guardrails_ai.secrets_present import SecretsPresent\n",
     "from rich import print"
    ]
   },

--- a/docs/examples/select_choice_based_on_action.ipynb
+++ b/docs/examples/select_choice_based_on_action.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/valid_choices --quiet"
+    "!pip install guardrails-ai-valid-choices --quiet"
    ]
   },
   {

--- a/docs/examples/select_choice_based_on_action.ipynb
+++ b/docs/examples/select_choice_based_on_action.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guardrails.hub import ValidChoices\n",
+    "from guardrails_ai.valid_choices import ValidChoices\n",
     "from pydantic import BaseModel, Field\n",
     "from typing import Literal, Union\n",
     "\n",

--- a/docs/examples/summarizer.ipynb
+++ b/docs/examples/summarizer.ipynb
@@ -44,9 +44,9 @@
    ],
    "source": [
     "%pip install numpy -q\n",
-    "! guardrails hub install hub://guardrails/reading_time --quiet --install-local-models\n",
-    "! guardrails hub install hub://guardrails/similar_to_document --quiet --install-local-models\n",
-    "! guardrails hub install hub://guardrails/valid_length --quiet --install-local-models"
+    "! pip install guardrails-ai-reading-time --quiet --install-local-models\n",
+    "! pip install guardrails-ai-similar-to-document --quiet --install-local-models\n",
+    "! pip install guardrails-ai-valid-length --quiet --install-local-models"
    ]
   },
   {

--- a/docs/examples/summarizer.ipynb
+++ b/docs/examples/summarizer.ipynb
@@ -44,9 +44,9 @@
    ],
    "source": [
     "%pip install numpy -q\n",
-    "! pip install guardrails-ai-reading-time --quiet --install-local-models\n",
-    "! pip install guardrails-ai-similar-to-document --quiet --install-local-models\n",
-    "! pip install guardrails-ai-valid-length --quiet --install-local-models"
+    "! pip install guardrails-ai-reading-time --quiet\n",
+    "! pip install guardrails-ai-similar-to-document --quiet\n",
+    "! pip install guardrails-ai-valid-length --quiet"
    ]
   },
   {
@@ -101,7 +101,9 @@
    "source": [
     "from pydantic import BaseModel, Field\n",
     "\n",
-    "from guardrails.hub import SimilarToDocument, ValidLength, ReadingTime\n",
+    "from guardrails_ai.similar_to_document import SimilarToDocument\n",
+    "from guardrails_ai.valid_length import ValidLength\n",
+    "from guardrails_ai.reading_time import ReadingTime\n",
     "\n",
     "prompt = \"\"\"\n",
     "Summarize the following text faithfully:\n",

--- a/docs/examples/syntax_error_free_sql.ipynb
+++ b/docs/examples/syntax_error_free_sql.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/valid_sql --quiet"
+    "!pip install guardrails-ai-valid-sql --quiet"
    ]
   },
   {

--- a/docs/examples/syntax_error_free_sql.ipynb
+++ b/docs/examples/syntax_error_free_sql.ipynb
@@ -127,7 +127,7 @@
     }
    ],
    "source": [
-    "from guardrails.hub import ValidSQL\n",
+    "from guardrails_ai.valid_sql import ValidSQL\n",
     "from pydantic import BaseModel, Field\n",
     "\n",
     "prompt = \"\"\"\n",

--- a/docs/examples/text_summarization_quality.ipynb
+++ b/docs/examples/text_summarization_quality.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/similar_to_document --quiet"
+    "!pip install guardrails-ai-similar-to-document --quiet"
    ]
   },
   {

--- a/docs/examples/text_summarization_quality.ipynb
+++ b/docs/examples/text_summarization_quality.ipynb
@@ -148,7 +148,7 @@
    "source": [
     "from pydantic import BaseModel, Field\n",
     "\n",
-    "from guardrails.hub import SimilarToDocument\n",
+    "from guardrails_ai.similar_to_document import SimilarToDocument\n",
     "\n",
     "prompt = \"\"\"\n",
     "Summarize the following document:\n",

--- a/docs/examples/toxic_language.ipynb
+++ b/docs/examples/toxic_language.ipynb
@@ -17,7 +17,7 @@
     }
    ],
    "source": [
-    "! guardrails hub install hub://guardrails/toxic_language --quiet"
+    "! pip install guardrails-ai-toxic-language --quiet"
    ]
   },
   {

--- a/docs/examples/toxic_language.ipynb
+++ b/docs/examples/toxic_language.ipynb
@@ -50,7 +50,7 @@
     "# and the ToxicLanguage validator\n",
     "# from Guardrails Hub\n",
     "import guardrails as gd\n",
-    "from guardrails.hub import ToxicLanguage\n",
+    "from guardrails_ai.toxic_language import ToxicLanguage\n",
     "from rich import print"
    ]
   },

--- a/docs/examples/toxic_language.ipynb
+++ b/docs/examples/toxic_language.ipynb
@@ -21,6 +21,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These validators tokenize text with NLTK at runtime; `pip install` doesn't run\n",
+    "# the package post-install step, so fetch the tokenizer data explicitly.\n",
+    "import nltk\n",
+    "\n",
+    "nltk.download(\"punkt_tab\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/examples/translation_with_quality_check.ipynb
+++ b/docs/examples/translation_with_quality_check.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://brainlogic/high_quality_translation -q"
+    "!pip install guardrails-ai-high-quality-translation -q"
    ]
   },
   {

--- a/docs/examples/translation_with_quality_check.ipynb
+++ b/docs/examples/translation_with_quality_check.ipynb
@@ -78,7 +78,7 @@
    "source": [
     "from guardrails import Guard\n",
     "from rich import print\n",
-    "from guardrails.hub import HighQualityTranslation"
+    "from guardrails_ai.high_quality_translation import HighQualityTranslation"
    ]
   },
   {

--- a/docs/examples/value_within_distribution.ipynb
+++ b/docs/examples/value_within_distribution.ipynb
@@ -19,7 +19,7 @@
     }
    ],
    "source": [
-    "!guardrails hub install hub://guardrails/similar_to_previous_values --quiet"
+    "!pip install guardrails-ai-similar-to-previous-values --quiet"
    ]
   },
   {

--- a/docs/examples/value_within_distribution.ipynb
+++ b/docs/examples/value_within_distribution.ipynb
@@ -46,7 +46,7 @@
     "# Create the Guard with the SimilarToList validator\n",
     "from pydantic import BaseModel, Field\n",
     "from guardrails import Guard\n",
-    "from guardrails.hub import SimilarToPreviousValues\n",
+    "from guardrails_ai.similar_to_previous_values import SimilarToPreviousValues\n",
     "\n",
     "\n",
     "class MyModel(BaseModel):\n",

--- a/docs/how_to_guides/async_streaming.ipynb
+++ b/docs/how_to_guides/async_streaming.ipynb
@@ -35,7 +35,7 @@
     "Install the necessary validators from Guardrails hub in your CLI.\n",
     "\n",
     "```bash\n",
-    "!guardrails hub install hub://guardrails/competitor_check\n",
+    "!pip install guardrails-ai-competitor-check\n",
     "```\n"
    ]
   },

--- a/docs/how_to_guides/async_streaming.ipynb
+++ b/docs/how_to_guides/async_streaming.ipynb
@@ -59,6 +59,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# These validators tokenize text with NLTK at runtime; `pip install` doesn't run\n",
+    "# the package post-install step, so fetch the tokenizer data explicitly.\n",
+    "import nltk\n",
+    "\n",
+    "nltk.download(\"punkt_tab\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from guardrails_ai.competitor_check import CompetitorCheck\n",
     "\n",
     "prompt = \"Tell me about the Apple Iphone\"\n",

--- a/docs/how_to_guides/async_streaming.ipynb
+++ b/docs/how_to_guides/async_streaming.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guardrails.hub import CompetitorCheck\n",
+    "from guardrails_ai.competitor_check import CompetitorCheck\n",
     "\n",
     "prompt = \"Tell me about the Apple Iphone\"\n",
     "\n",

--- a/docs/how_to_guides/remote_validation_inference.ipynb
+++ b/docs/how_to_guides/remote_validation_inference.ipynb
@@ -55,7 +55,7 @@
    },
    "outputs": [],
    "source": [
-    "guardrails hub install hub://guardrails/toxic_language --quiet;\n",
+    "pip install guardrails-ai-toxic-language --quiet;\n",
     "\n",
     "# This will not download local models if you opted into remote inferencing during guardrails configure\n",
     "# If you did not opt in, you can explicitly opt in for just this validator by passing the --no-install-local-models flag\n"

--- a/docs/how_to_guides/remote_validation_inference.ipynb
+++ b/docs/how_to_guides/remote_validation_inference.ipynb
@@ -58,7 +58,7 @@
     "pip install guardrails-ai-toxic-language --quiet;\n",
     "\n",
     "# This will not download local models if you opted into remote inferencing during guardrails configure\n",
-    "# If you did not opt in, you can explicitly opt in for just this validator by passing the --no-install-local-models flag\n"
+    "# If you did not opt in, you can explicitly opt in for just this validator by passing the flag\n"
    ]
   },
   {
@@ -75,7 +75,7 @@
    "outputs": [],
    "source": [
     "from guardrails import Guard\n",
-    "from guardrails.hub import ToxicLanguage\n",
+    "from guardrails_ai.toxic_language import ToxicLanguage\n",
     "\n",
     "guard = Guard().use(ToxicLanguage())"
    ]
@@ -157,13 +157,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guardrails import Guard, install\n",
+    "from guardrails import Guard\n",
     "\n",
     "try:\n",
-    "    from guardrails.hub import ToxicLanguage\n",
+    "    from guardrails_ai.toxic_language import ToxicLanguage\n",
     "except ImportError:\n",
-    "    install(\"hub://guardrails/toxic_language\", install_local_models=True)\n",
-    "    from guardrails.hub import ToxicLanguage\n",
+    "    # Installed above via: pip install guardrails-ai-toxic-language\n",
+    "    from guardrails_ai.toxic_language import ToxicLanguage\n",
     "\n",
     "# uses validator locally.\n",
     "guard.use(ToxicLanguage(use_local=True))"

--- a/docs/how_to_guides/streaming.ipynb
+++ b/docs/how_to_guides/streaming.ipynb
@@ -42,6 +42,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# These validators tokenize text with NLTK at runtime; `pip install` doesn't run\n",
+    "# the package post-install step, so fetch the tokenizer data explicitly.\n",
+    "import nltk\n",
+    "\n",
+    "nltk.download(\"punkt_tab\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from guardrails_ai.competitor_check import CompetitorCheck\n",
     "\n",
     "prompt = \"Tell me about the Apple Iphone\"\n",

--- a/docs/how_to_guides/streaming.ipynb
+++ b/docs/how_to_guides/streaming.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guardrails.hub import CompetitorCheck\n",
+    "from guardrails_ai.competitor_check import CompetitorCheck\n",
     "\n",
     "prompt = \"Tell me about the Apple Iphone\"\n",
     "\n",

--- a/docs/how_to_guides/streaming_structured_data.ipynb
+++ b/docs/how_to_guides/streaming_structured_data.ipynb
@@ -36,13 +36,19 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    from guardrails.hub import LowerCase, UpperCase, ValidRange, OneLine\n",
+    "    from guardrails_ai.lowercase import LowerCase\n",
+    "    from guardrails_ai.uppercase import UpperCase\n",
+    "    from guardrails_ai.valid_range import ValidRange\n",
+    "    from guardrails_ai.one_line import OneLine\n",
     "except ImportError:\n",
-    "    gd.install(\"hub://guardrails/valid_range\")\n",
-    "    gd.install(\"hub://guardrails/uppercase\")\n",
-    "    gd.install(\"hub://guardrails/lowercase\")\n",
-    "    gd.install(\"hub://guardrails/one_line\")\n",
-    "    from guardrails.hub import LowerCase, UpperCase, ValidRange, OneLine"
+    "    # Installed above via: pip install guardrails-ai-valid-range\n",
+    "    # Installed above via: pip install guardrails-ai-uppercase\n",
+    "    # Installed above via: pip install guardrails-ai-lowercase\n",
+    "    # Installed above via: pip install guardrails-ai-one-line\n",
+    "    from guardrails_ai.lowercase import LowerCase\n",
+    "    from guardrails_ai.uppercase import UpperCase\n",
+    "    from guardrails_ai.valid_range import ValidRange\n",
+    "    from guardrails_ai.one_line import OneLine"
    ]
   },
   {
@@ -815,7 +821,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from guardrails.hub import UpperCase, OneLine\n",
+    "from guardrails_ai.uppercase import UpperCase\n",
+    "from guardrails_ai.one_line import OneLine\n",
     "\n",
     "prompt = \"\"\"\n",
     "Generate a short description of large language models. Each new sentence should be on another line.\n",

--- a/docs/how_to_guides/use_on_fail_actions.ipynb
+++ b/docs/how_to_guides/use_on_fail_actions.ipynb
@@ -39,6 +39,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These validators tokenize text with NLTK at runtime; `pip install` doesn't run\n",
+    "# the package post-install step, so fetch the tokenizer data explicitly.\n",
+    "import nltk\n",
+    "\n",
+    "nltk.download(\"punkt_tab\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "vscode": {

--- a/docs/how_to_guides/use_on_fail_actions.ipynb
+++ b/docs/how_to_guides/use_on_fail_actions.ipynb
@@ -29,13 +29,13 @@
    ],
    "source": [
     "# setup, run imports\n",
-    "from guardrails import Guard, install\n",
+    "from guardrails import Guard\n",
     "\n",
     "try:\n",
-    "    from guardrails.hub import DetectPII\n",
+    "    from guardrails_ai.detect_pii import DetectPII\n",
     "except ImportError:\n",
-    "    install(\"hub://guardrails/detect_pii\")\n",
-    "    from guardrails.hub import DetectPII"
+    "    # Installed above via: pip install guardrails-ai-detect-pii\n",
+    "    from guardrails_ai.detect_pii import DetectPII"
    ]
   },
   {

--- a/docs/migration_guides/hub-to-public-pypi.md
+++ b/docs/migration_guides/hub-to-public-pypi.md
@@ -1,0 +1,65 @@
+# Migration guide: Hub install → public PyPI
+
+Guardrails-AI-owned validators have moved from the private Guardrails registry
+(`pypi.guardrailsai.com`, installed via `guardrails hub install`) to **public
+PyPI**. Each validator is now published as a `guardrails-ai-<name>` distribution
+and imported from the PEP 420 `guardrails_ai` namespace.
+
+## What changed
+
+| Before | After |
+|---|---|
+| `guardrails hub install hub://guardrails/detect_pii` | `pip install guardrails-ai-detect-pii` |
+| `from guardrails.hub import DetectPII` | `from guardrails_ai.detect_pii import DetectPII` |
+| Private registry `pypi.guardrailsai.com` (token required) | Public PyPI (no token) |
+| Dist name `guardrails-grhub-detect-pii` | `guardrails-ai-detect-pii` |
+
+The registered validator name is **unchanged** — `@register_validator(name="guardrails/detect_pii")`
+still resolves, so `Guard().use(...)` and existing guards keep working.
+
+## Deprecation timeline (back-compat is preserved for now)
+
+Nothing breaks today. During the deprecation window:
+
+- **`guardrails hub install hub://guardrails/<name>`** still works — it now
+  installs `guardrails-ai-<name>` from public PyPI and prints a
+  `DeprecationWarning` pointing at the equivalent `pip install` command. The
+  same warning is emitted by `uninstall`, `list`, `submit`, and
+  `create-validator`.
+- **`from guardrails.hub import X`** still works — if an export isn't found in
+  the local hub registry, it falls back to scanning installed `guardrails_ai.*`
+  packages and emits a one-time `DeprecationWarning` recommending the direct
+  `from guardrails_ai.<name> import X` import.
+
+Both the `guardrails hub` CLI and the `guardrails.hub` import shim are scheduled
+for **removal in the next major release**. Update install commands and imports
+to the public-PyPI form at your convenience before then.
+
+## How to migrate
+
+1. Replace `guardrails hub install hub://guardrails/<name>` with
+   `pip install guardrails-ai-<name>` (underscores in `<name>` become dashes in
+   the dist name).
+2. Replace `from guardrails.hub import <Export>` with
+   `from guardrails_ai.<name> import <Export>`.
+3. For validators that ship local models, run the post-install step after
+   installing — see the package's README on PyPI.
+
+Browse the full catalog of validators and their new package names in the
+[`guardrails-hub` repo's `VALIDATORS.md`](https://github.com/guardrails-ai/guardrails-hub).
+
+---
+
+## Related: RAIL (`.rail`) removal — next major
+
+The `.rail` XML spec format and the `Guard.for_rail` / `Guard.for_rail_string`
+APIs are being removed in the next major release (this also drops the `lxml`
+dependency). Migrate RAIL-defined guards to Pydantic or JSON-schema guards:
+
+- `Guard.for_rail("spec.rail")` / `Guard.for_rail_string(...)` →
+  `Guard.for_pydantic(MyModel)` or a JSON-schema-based guard plus plain
+  `messages`.
+- The `guardrails validate` CLI command (which parsed `.rail`) is removed.
+
+Validator quality criteria expressed in RAIL map directly onto
+`Guard().use(<Validator>, ...)` calls.

--- a/docs/migration_guides/hub-to-public-pypi.md
+++ b/docs/migration_guides/hub-to-public-pypi.md
@@ -1,6 +1,6 @@
 # Migration guide: Hub install → public PyPI
 
-Guardrails-AI-owned validators have moved from the private Guardrails registry
+As of Guardrails **0.11.0**, Guardrails-AI-owned validators have moved from the private Guardrails registry
 (`pypi.guardrailsai.com`, installed via `guardrails hub install`) to **public
 PyPI**. Each validator is now published as a `guardrails-ai-<name>` distribution
 and imported from the PEP 420 `guardrails_ai` namespace.

--- a/guardrails-features-list.md
+++ b/guardrails-features-list.md
@@ -1,0 +1,308 @@
+# Guardrails Features and Functionalities
+
+Comprehensive list of all user-impacting features and functionalities in the Guardrails framework.
+
+---
+
+## 1. CLI
+
+**Command Line Interface tools and commands**
+
+1. `guardrails configure` - Configure API keys and preferences
+2. `guardrails create` - Create guards from validators
+3. `guardrails hub install` - **(Deprecated)** Install validators from Hub. Now translates to `pip install guardrails-ai-<name>` from public PyPI and emits a `DeprecationWarning`; the private registry coupling has been removed.
+4. `guardrails hub uninstall` - **(Deprecated)** Remove installed validators (use `pip uninstall guardrails-ai-<name>`)
+5. `guardrails hub create-validator` - **(Deprecated)** Create lightweight custom validators
+6. `guardrails hub submit` - **(Deprecated)** Submit validators to Hub for publishing
+7. `guardrails start` - Start Guardrails Server in dev mode
+8. `guardrails validate` - Validate LLM output from CLI
+9. `guardrails watch` - Monitor and tail Guard execution logs
+10. Remote Inferencing Configuration - Enable/disable remote model inference
+
+---
+
+## 2. Guard Configuration
+
+**Setting up and initializing Guards**
+
+1. Guard Class - Main entry point for Guardrails validation
+2. AsyncGuard Class - Asynchronous version of Guard
+3. Guard Serialization - Save and load guards using `to_dict()` and `from_dict()`
+4. Guard Name and Description - Metadata for guard identification
+
+**Schema Definition:**
+5. RAIL Specification - XML-based markup language for output structure
+6. RAIL String Support - `Guard.for_rail_string()` for inline RAIL
+7. RAIL File Loading - `Guard.for_rail()` to load RAIL from files
+8. Pydantic Model Integration - `Guard.for_pydantic()` for schema-based validation
+9. String Output Guards - `Guard.for_string()` for simple string validation
+10. Complex Output Structures - Support for nested objects, lists, and complex JSON
+
+**RAIL Schema Types:**
+11. String Type
+12. Integer Type
+13. Float Type
+14. Boolean Type
+15. Object Type
+16. List Type
+17. Email Type
+18. URL Type
+19. Output Element - Define expected output structure
+20. Messages Element - Define prompt messages and roles
+
+**RAIL Attributes:**
+21. Validators Attribute - Attach validators in RAIL
+22. Format Attribute - Specify validation criteria
+23. On-Fail Attribute - Specify corrective actions
+24. Description Attribute - Field descriptions for LLM
+25. Required Attribute - Mark fields as required
+26. Strict Mode - Enforce schema strictness
+
+**Pydantic Integration:**
+27. BaseModel Validation - Use Pydantic models as schemas
+28. Field Validators - Attach validators to Pydantic fields
+29. Field Descriptions - Use field descriptions in prompts
+30. Type Annotations - Automatic schema generation from types
+31. Nested Models - Support for nested Pydantic models
+32. List Models - Support for list output types
+33. Optional Fields - Handle optional model fields
+
+**Prompt Configuration:**
+34. Prompt Templating - Variable substitution in prompts
+35. Prompt Primitives - Pre-built prompt templates
+36. Prompt Substitution - ${variable_name} substitution
+37. Output Schema Injection - ${output_schema} automatic injection
+38. JSON Suffix Prompts - Prompt guidance for JSON generation
+39. XML Prefix Prompts - Prompt guidance for XML parsing
+40. Instruction Templates - Reusable instruction patterns
+41. Dynamic Prompt Building - Format prompts with parameters
+
+**General Configuration:**
+42. Environment Variables - Configure via env vars
+43. RC Configuration File - Persistent configuration in ~/.guardrailsrc
+44. Settings Module - Global settings management
+45. Output Type Configuration - Specify expected output type
+46. Num Reasks Configuration - Default reask limit
+47. Process Count Configuration - Set multiprocessing concurrency level
+48. Log Level Configuration - Set via GUARDRAILS_LOG_LEVEL
+
+---
+
+## 3. Guard Runtime
+
+**Validation execution, streaming, and all runtime behaviors**
+
+**Core Validation:**
+1. Validation Execution - Primary method to validate LLM outputs with optional reasks
+2. Parsing - Parse and validate outputs without LLM calls
+3. Async/Await Support - Full async/await compatibility
+
+**Validator Management:**
+4. Custom Validator Creation - Create validators as functions or classes with `@register_validator`
+5. Validator Registration - Register custom validators for use across guards
+6. Multiple Validators Per Field - Stack validators with `use()` and `use_many()`
+7. ML-Based Validators - Support for machine learning model validators
+8. LLM-Based Validators - Validators that use LLM calls
+9. Logic-Based Validators - Pure code validators
+10. Validator Input/Output Validation - Validate inputs and outputs separately with `on` parameter
+11. Validator Metadata Requirements - Pass runtime metadata to validators
+
+**On-Fail Actions:**
+12. NOOP (No Operation) - Log failure but continue
+13. EXCEPTION - Raise exception on validation failure
+14. REASK - Automatically re-prompt LLM with failure information
+15. FIX - Programmatically fix failed output
+16. FILTER - Remove incorrect structured data fields
+17. REFRAIN - Return None instead of invalid output
+18. FIX_REASK - First fix deterministically, then reask if still invalid
+19. Custom On-Fail Functions - Implement custom logic for handling failures
+
+**Validation Features:**
+20. Field-Level Validation - Validate individual fields in structured outputs
+21. Field-Level Reasks - Request re-generation of specific fields only
+22. Skeleton Reasks - Request re-generation when JSON structure is malformed
+23. Full Schema Reasks - Reask entire output structure
+24. Partial Field Reasks - FieldReAsk for specific fields only
+25. NonParseableReAsk - Handle JSON parsing failures
+26. SkeletonReAsk - Reask for schema structure mismatches
+27. Max Reasks - Configurable limit on number of reasking attempts
+28. Reask Prompts - Auto-generated prompts for reasking with error context
+
+**Error Handling:**
+29. Validation Failures - Detect and report validation failures
+30. Field-Level Errors - Identify which fields failed validation
+31. Error Spans - Track character position ranges of errors
+32. Error Messages - Validator-generated error messages for reasks
+33. Validation Error Exception - Raise ValidationError on failure
+34. XMLSyntaxError Handling - Proper escaping guidance for RAIL specs
+35. LLM API Error Handling - Connection error recovery and retry
+
+**Streaming:**
+36. Synchronous Streaming - Stream validated output chunks as they're generated
+37. Asynchronous Streaming - Async streaming for concurrent operations
+38. Stream Validation - Real-time validation of streaming chunks
+39. Streaming with Structured Data - Support for streaming structured JSON
+40. Streaming Validators - Custom chunking strategies for streaming validation
+41. Error Span Tracking - Identify failure locations in streamed output
+42. Sentence-Based Chunking - Default chunking strategy for validation
+43. Custom Chunking Strategies - Override chunking per validator
+
+**Performance:**
+44. Parallelized Validator Execution - Concurrent validator runs via asyncio
+45. Field-Level Concurrency - Parallel validation of object fields
+46. Multiprocessing Support - Background process executor for sync validators
+47. Stream Processing Optimization - Sentence-level chunking to reduce latency
+48. GPU Support - Utilize GPUs for model validators
+49. Lazy Loading - Load models on-demand, not at init
+50. Caching - Cache parsed outputs to avoid re-parsing
+51. Early Exit - Skip expensive checks if cheap ones fail
+
+**Output Processing:**
+52. Raw LLM Output - Access unchanged LLM output
+53. Parsed Output - Extracted and type-coerced output
+54. Validated Output - Final output after validation and fixes
+55. Guarded Output - Complete output with all validations applied
+56. Output Type Coercion - Automatic type conversion between LLM output and schema types
+57. Filter Application - Remove invalid structured data
+58. Refrain Application - Replace invalid output with None
+59. Fix Application - Apply automatic fixes to output
+60. Merge Utilities - Merge multiple validation results
+61. Merge Strategies - Merge multiple validation results
+
+**Advanced Patterns:**
+62. Interrupt on Exception - Stop validation on first exception
+63. Continue on Filter - Stop processing field on filter
+64. Continue on Refrain - Set field to None on refrain
+
+---
+
+## 4. Core Features
+
+**Fundamental capabilities that define Guardrails**
+
+**LLM Integration:**
+1. OpenAI Support - Native integration with OpenAI models
+2. Anthropic Support - Native integration with Claude models
+3. Azure OpenAI - Support for Azure-hosted OpenAI deployments
+4. Google Gemini - Integration with Google's Gemini models
+5. Databricks - Support for Databricks model serving
+6. LiteLLM Integration - Support for 100+ models through LiteLLM
+7. Custom LLM Wrappers - Build custom wrappers for unsupported LLMs
+8. Ollama Support - Local model serving via Ollama
+9. Message Format Support - Chat-based message format (system/user/assistant roles)
+10. LLM API Retry Logic - Automatic retries with exponential backoff
+
+**Structured Data:**
+11. JSON Function Calling Tool - Generate OpenAI-compatible function/tool definitions
+12. JSON Schema Response Format - Generate OpenAI strict JSON mode compatible schemas
+13. JSON Mode - Native JSON mode for models supporting it
+14. Strict JSON Mode - Strict schema enforcement for models supporting it
+15. Constrained Decoding - Support for JSONFormer and other constrained decoding
+16. Function/Tool Calling - Use native function calling where supported
+17. Schema Compilation - Automatic compilation of output schema to XML for prompts
+18. JSON Schema Validation - Full JSON Schema compliance checking
+19. Schema Pruning - Removal of extra properties not specified in schema
+20. JSON Schema Generation - Convert Pydantic to JSON Schema
+
+---
+
+## 5. Auxiliary Features and Nice-to-haves
+
+**Secondary features that enhance the experience**
+
+**History and Debugging:**
+1. History Tracking - Complete audit trail of all Guard executions
+2. Guard History - Access complete Call history via `guard.history`
+3. Call Objects - Inspect individual Guard call executions
+4. Iteration Tracking - View each iteration of validation loop
+5. Token Consumption Tracking - Monitor LLM token usage
+6. Validator Logs - Detailed logs from individual validators
+7. Failed Validations - Filter history for failures
+8. Execution Time Metrics - Track time spent in validation
+9. Log Levels - Configurable logging verbosity
+10. Call Tree Visualization - Visual representation of validation flow
+
+**Telemetry and Observability:**
+11. OpenTelemetry Integration - Full OpenTelemetry support for traces and metrics
+12. OTLP Exporter - Export metrics via OTLP protocol (HTTP/gRPC)
+13. Tracer Configuration - Custom tracer setup for telemetry collection
+14. Guard Execution Tracing - Trace individual guard executions
+15. Validator Execution Tracing - Trace individual validator runs
+16. Runner Tracing - Trace the validation runner orchestration
+17. Grafana Integration - Support for Grafana dashboards
+18. Arize AI Integration - Integration with Arize for LLM observability
+19. Anonymous Metrics Collection - Opt-in metrics to improve Guardrails
+20. Hub Telemetry - Track validator usage and failures
+21. Span Context Propagation - OTEL context preservation across async boundaries
+22. Call History Logging - Full logging of all guard execution calls
+23. Metrics Collection Opt-In - Enable/disable anonymous usage metrics
+24. Metrics Dashboard - Track validation success rates
+
+**Guardrails Hub:**
+25. Guardrails Hub - Central repository of validators
+26. Validator Search/Browse - Explore validators by category
+27. Hub Validator Templates - Browse and use pre-built validators
+28. Validator Templates - Pre-built guard templates
+29. Validator Documentation - Auto-generated docs on Hub
+30. Version Management - Track validator versions
+31. Model Hosting - Some validators available on hosted inference
+32. Infrastructure Tags - Filter validators by requirements (ML, LLM, Logic)
+33. Remote Validation/Inference - Host validator models on FastAPI servers
+
+**Integrations:**
+34. LangChain Integration - Guard.to_runnable() for LangChain
+35. LlamaIndex Integration - Support for LlamaIndex workflows
+36. Databricks MLflow - Integration with Databricks MLflow
+37. SQLValidator Support - Validate SQL outputs
+38. VectorDB Support - Support for FAISS vector databases
+39. Manifest ML - Support for Manifest machine learning framework
+
+**Configuration and Management:**
+40. Metrics Collection Opt-In - Enable/disable anonymous usage metrics
+41. Remote Inference Opt-In - Enable/disable hosted model inference
+42. Synchronous Validation - Force synchronous validation via GUARDRAILS_RUN_SYNC
+43. API Key Management - Secure credential handling
+44. Connection Pooling - Efficient API call management
+
+---
+
+## 6. Useful Data Structures and Interfaces
+
+**Classes, objects, and interfaces for working with Guardrails**
+
+1. ValidationResult Classes - PassResult, FailResult, ValidationResult
+2. Error Classes - Custom exceptions for debugging
+3. Validators Base Class - Validator parent class for custom creation
+4. Call Objects - Represent individual Guard call executions
+5. Iteration Objects - Represent iterations within a call
+6. Type Hints - Full type annotation coverage
+7. Constants - Pre-defined constants for common use cases
+8. Utility Functions - Helper functions for common tasks
+9. BasePrompt Class - Prompt management interface
+
+---
+
+## 7. Guardrails Server
+
+**Standalone server deployment and API features**
+
+1. Guardrails Server - Standalone Flask server for guard execution
+2. Server-Based Guard Execution - Execute guards via Guardrails Server (use_server setting)
+3. Docker Deployment - Containerization with Docker and Gunicorn
+4. AWS Deployment - AWS ECS deployment with Terraform examples
+5. OpenAPI/Swagger Docs - Auto-generated REST API documentation
+6. OpenAI-Compatible Endpoints - Guardrails Server provides OpenAI SDK compatible endpoints
+7. Guard Templates - Create guards from Hub templates
+8. Config-Based Guards - Define guards in Python config files
+9. Uvicorn/Gunicorn Support - WSGI/ASGI server options
+10. Multi-Worker Deployment - Scale guards across multiple server instances
+11. REST API Validation - Validate via HTTP POST requests
+12. Guard Upsert - Save guards to server database
+13. Flask Server - Guardrails Server backend
+14. FastAPI - Remote validator hosting examples
+
+---
+
+**Total: 194 core user-impacting features**
+
+This reorganized list focuses on the most relevant features organized by how users interact with Guardrails, from CLI tools through runtime validation to server deployment.

--- a/guardrails/cli/hub/create_validator.py
+++ b/guardrails/cli/hub/create_validator.py
@@ -161,6 +161,10 @@ def create_validator(
     For more complex submissions see here:
     https://github.com/guardrails-ai/validator-template?tab=readme-ov-file#how-to-create-a-guardrails-validator
     """
+    from guardrails.cli.hub.deprecation import warn_hub_cli_deprecated
+
+    warn_hub_cli_deprecated()
+
     disclaimer = """
 
     This utility is intended for creating simple validators.

--- a/guardrails/cli/hub/deprecation.py
+++ b/guardrails/cli/hub/deprecation.py
@@ -1,0 +1,45 @@
+"""Shared deprecation helpers for the `guardrails hub` CLI command group.
+
+The hub CLI and the private validator registry are deprecated. Validators are
+now published to public PyPI as ``guardrails-ai-<name>`` and should be managed
+with ``pip`` directly. These helpers emit a ``DeprecationWarning`` and print a
+user-facing pointer to the equivalent ``pip`` command.
+"""
+
+import warnings
+from typing import Optional
+
+from guardrails.hub.validator_package_service import ValidatorPackageService
+
+
+def pip_name_for_uri(package_uri: str) -> Optional[str]:
+    """Translate a ``hub://<namespace>/<name>`` URI to its public PyPI dist name.
+
+    Returns ``None`` if the URI can't be parsed into a validator id.
+    """
+    try:
+        validator_id, _ = ValidatorPackageService.get_validator_id(package_uri)
+        return ValidatorPackageService.get_normalized_package_name(validator_id)
+    except Exception:
+        return None
+
+
+def warn_hub_cli_deprecated(console=None, pip_hint: Optional[str] = None) -> None:
+    """Emit the standard hub-CLI deprecation warning.
+
+    Args:
+        console: Optional rich console for a user-facing message.
+        pip_hint: Optional ``pip install ...`` command to recommend.
+    """
+    message = (
+        "The `guardrails hub` CLI and the private Guardrails validator registry "
+        "are deprecated and will be removed in a future major release. "
+        "Validators are now published to public PyPI as `guardrails-ai-<name>`; "
+        "manage them with `pip` directly."
+    )
+    if pip_hint:
+        message = f"{message} Use `{pip_hint}` instead."
+
+    warnings.warn(message, DeprecationWarning, stacklevel=2)
+    if console is not None:
+        console.print(f"[yellow]DeprecationWarning:[/yellow] {message}")

--- a/guardrails/cli/hub/install.py
+++ b/guardrails/cli/hub/install.py
@@ -50,6 +50,16 @@ def install_cli(
             ]
 
         from guardrails.hub.install import install_multiple
+        from guardrails.cli.hub.deprecation import (
+            pip_name_for_uri,
+            warn_hub_cli_deprecated,
+        )
+
+        pip_names = [
+            name for name in (pip_name_for_uri(uri) for uri in package_uris) if name
+        ]
+        pip_hint = "pip install " + " ".join(pip_names) if pip_names else "pip install"
+        warn_hub_cli_deprecated(console, pip_hint=pip_hint)
 
         def confirm():
             return typer.confirm(

--- a/guardrails/cli/hub/list.py
+++ b/guardrails/cli/hub/list.py
@@ -8,6 +8,10 @@ from .console import console
 @trace(name="guardrails-cli/hub/list")
 def list():
     """List all installed validators."""
+    from guardrails.cli.hub.deprecation import warn_hub_cli_deprecated
+
+    warn_hub_cli_deprecated(console, pip_hint="pip list")
+
     registry = get_registry()
 
     validators = registry.validators

--- a/guardrails/cli/hub/submit.py
+++ b/guardrails/cli/hub/submit.py
@@ -21,6 +21,10 @@ def submit(
 ):
     """Submit a validator to the Guardrails AI team for review and
     publishing."""
+    from guardrails.cli.hub.deprecation import warn_hub_cli_deprecated
+
+    warn_hub_cli_deprecated()
+
     try:
         if not filepath or filepath == "./{package_name}.py":
             filepath = f"./{package_name}.py"

--- a/guardrails/cli/hub/uninstall.py
+++ b/guardrails/cli/hub/uninstall.py
@@ -62,6 +62,16 @@ def uninstall(
 ):
     """Uninstall a validator from the Hub."""
     from guardrails.hub.validator_package_service import ValidatorPackageService
+    from guardrails.cli.hub.deprecation import (
+        pip_name_for_uri,
+        warn_hub_cli_deprecated,
+    )
+
+    pip_name = pip_name_for_uri(package_uri)
+    warn_hub_cli_deprecated(
+        console,
+        pip_hint=f"pip uninstall {pip_name}" if pip_name else "pip uninstall",
+    )
 
     if not package_uri.startswith("hub://"):
         logger.error("Invalid URI!")

--- a/guardrails/hub/__init__.py
+++ b/guardrails/hub/__init__.py
@@ -1,22 +1,32 @@
-"""guardrails.hub - Dynamic import resolution from hub_registry.json.
+"""guardrails.hub - Dynamic import resolution for hub validators.
 
-Validators registered in .guardrails/hub_registry.json are resolved lazily
+Validators registered in ``.guardrails/hub_registry.json`` are resolved lazily
 on first attribute access and cached for subsequent imports.
+
+DEPRECATED: ``from guardrails.hub import X`` is deprecated. Validators are now
+published to public PyPI as ``guardrails-ai-<name>`` and should be imported
+directly, e.g. ``from guardrails_ai.detect_pii import DetectPII``. As a
+back-compat shim, if an export is not found in the local hub registry this
+module falls back to scanning the installed ``guardrails_ai.*`` namespace
+packages for it (emitting a one-time deprecation warning).
 """
 
 import importlib
+import pkgutil
+import warnings
 
 from guardrails.hub.registry import get_registry
 
 
 _export_map_cache = None
+_namespace_deprecation_warned = False
 
 
 def _build_export_map() -> dict:
     """Build mapping from export name to import path.
 
     Returns a dict mapping export names (e.g. "DetectPII") to their
-    module import paths (e.g. "guardrails_grhub_detect_pii").
+    module import paths (e.g. "guardrails_ai.detect_pii").
     """
     registry = get_registry()
     export_map = {}
@@ -35,6 +45,46 @@ def _get_export_map() -> dict:
     return _export_map_cache
 
 
+def _resolve_from_namespace(name: str):
+    """Fallback resolver: scan installed ``guardrails_ai.*`` packages.
+
+    Returns the resolved attribute, or ``None`` if no installed
+    ``guardrails_ai`` namespace package exports ``name``.
+    """
+    try:
+        import guardrails_ai  # type: ignore
+    except ImportError:
+        return None
+
+    namespace_path = getattr(guardrails_ai, "__path__", None)
+    if namespace_path is None:
+        return None
+
+    for mod in pkgutil.iter_modules(namespace_path, "guardrails_ai."):
+        try:
+            module = importlib.import_module(mod.name)
+        except Exception:
+            continue
+        if hasattr(module, name):
+            return getattr(module, name)
+    return None
+
+
+def _warn_namespace_shim_once(name: str) -> None:
+    global _namespace_deprecation_warned
+    if _namespace_deprecation_warned:
+        return
+    _namespace_deprecation_warned = True
+    warnings.warn(
+        "Importing validators from `guardrails.hub` is deprecated and will be "
+        "removed in a future major release. Import directly from the "
+        f"`guardrails_ai` namespace instead, e.g. "
+        f"`from guardrails_ai.<name> import {name}`.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 def __getattr__(name: str):
     export_map = _get_export_map()
     if name in export_map:
@@ -48,9 +98,16 @@ def __getattr__(name: str):
             raise ImportError(
                 f"Cannot import '{name}' from hub registry. "
                 f"Module '{import_path}' not found. "
-                f"Try reinstalling: guardrails hub install "
-                f"hub://<org>/<validator>"
+                f"Try installing it: pip install guardrails-ai-<validator>"
             ) from e
+
+    # Back-compat fallback: resolve from the installed guardrails_ai namespace.
+    attr = _resolve_from_namespace(name)
+    if attr is not None:
+        _warn_namespace_shim_once(name)
+        globals()[name] = attr
+        return attr
+
     raise AttributeError(f"module 'guardrails.hub' has no attribute '{name}'")
 
 

--- a/guardrails/hub/install.py
+++ b/guardrails/hub/install.py
@@ -156,26 +156,31 @@ def install(
     verbose_printer(
         f"✅Successfully installed {validator_id}{installed_version_message}!\n\n"
     )
+    import_path = ValidatorPackageService.get_import_path_from_validator_id(
+        validator_id
+    )
     success_message_cli = Template(
         "[bold]Import validator:[/bold]\n"
-        "from guardrails.hub import ${export}\n\n"
+        "from ${import_path} import ${export}\n\n"
         "[bold]Get more info:[/bold]\n"
         "https://guardrailsai.com/hub/validator/${id}\n"
     ).safe_substitute(
         module_name=package_uri,
         id=module_manifest.id,
         export=module_manifest.exports[0],
+        import_path=import_path,
     )
     success_message_logger = Template(
         "✅Successfully installed ${module_name}!\n\n"
         "Import validator:\n"
-        "from guardrails.hub import ${export}\n\n"
+        "from ${import_path} import ${export}\n\n"
         "Get more info:\n"
         "https://guardrailsai.com/hub/validator/${id}\n"
     ).safe_substitute(
         module_name=package_uri,
         id=module_manifest.id,
         export=module_manifest.exports[0],
+        import_path=import_path,
     )
     quiet_printer(success_message_cli)  # type: ignore
     cli_logger.log(level=LEVELS.get("SPAM"), msg=success_message_logger)  # type: ignore

--- a/guardrails/hub/validator_package_service.py
+++ b/guardrails/hub/validator_package_service.py
@@ -24,7 +24,6 @@ from guardrails.cli.hub.utils import (
 )
 from guardrails_hub_types import Manifest
 from guardrails.cli.server.hub_client import get_validator_manifest
-from guardrails.settings import settings
 from guardrails.types.validator_registry import ValidatorRegistry
 
 
@@ -298,10 +297,13 @@ class ValidatorPackageService:
         import_path = ValidatorPackageService.get_import_path_from_validator_id(
             validator_id
         )
+        # import_path is a dotted module path (e.g. "guardrails_ai.detect_pii");
+        # convert it to a filesystem path under site-packages.
+        module_fs_path = import_path.replace(".", os.sep)
 
         relative_path = os.path.join(
             site_packages,
-            import_path,
+            module_fs_path,
             post_install_script,
         )
 
@@ -335,19 +337,25 @@ class ValidatorPackageService:
 
     @staticmethod
     def get_normalized_package_name(validator_id: str):
+        # The public PyPI distribution name for a hub validator is
+        # ``guardrails-ai-<name>`` (e.g. ``guardrails/detect_pii`` ->
+        # ``guardrails-ai-detect-pii``). The hub namespace component of the
+        # validator id is dropped because every guardrails-owned validator now
+        # publishes under the single ``guardrails-ai-*`` dist namespace on
+        # public PyPI. The private ``<org>-grhub-<name>`` registry naming is gone.
         validator_id_parts = validator_id.split("/")
-        concatanated_package_name = (
-            f"{validator_id_parts[0]}-grhub-{validator_id_parts[1]}"
-        )
-        pep_503_package_name = canonicalize_name(concatanated_package_name)
+        validator_name = validator_id_parts[-1]
+        concatenated_package_name = f"guardrails-ai-{validator_name}"
+        pep_503_package_name = canonicalize_name(concatenated_package_name)
         return pep_503_package_name
 
     @staticmethod
     def get_import_path_from_validator_id(validator_id):
-        pep_503_package_name = ValidatorPackageService.get_normalized_package_name(
-            validator_id
-        )
-        return pep_503_package_name.replace("-", "_")
+        # Public import path uses the PEP 420 ``guardrails_ai`` namespace
+        # package: ``guardrails/detect_pii`` -> ``guardrails_ai.detect_pii``.
+        validator_id_parts = validator_id.split("/")
+        validator_name = validator_id_parts[-1].replace("-", "_")
+        return f"guardrails_ai.{validator_name}"
 
     @staticmethod
     def install_hub_module(
@@ -362,13 +370,11 @@ class ValidatorPackageService:
         )
         validator_version = validator_version if validator_version else ""
 
-        guardrails_token = settings.rc.token
         installer = ValidatorPackageService.detect_installer()
 
-        install_flags = [
-            f"--index-url=https://__token__:{guardrails_token}@pypi.guardrailsai.com/simple",
-            "--extra-index-url=https://pypi.org/simple",
-        ]
+        # Validators now publish to public PyPI as ``guardrails-ai-<name>``;
+        # no private index URL or token is required.
+        install_flags = []
 
         if upgrade:
             install_flags.append("--upgrade")
@@ -376,7 +382,7 @@ class ValidatorPackageService:
         if quiet:
             install_flags.append("-q")
 
-        # Install from guardrails hub pypi server with public pypi index as fallback
+        # Install from public PyPI (pip's default index).
 
         try:
             full_package_name = f"{pep_503_package_name}[validators]{validator_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guardrails-ai"
-version = "0.10.2"
+version = "0.11.0"
 description = "Adding guardrails to large language models."
 authors = [
     {name = "Guardrails AI", email = "contact@guardrailsai.com"}

--- a/tests/unit_tests/cli/hub/test_deprecation.py
+++ b/tests/unit_tests/cli/hub/test_deprecation.py
@@ -1,0 +1,51 @@
+import pytest
+
+from guardrails.cli.hub.deprecation import (
+    pip_name_for_uri,
+    warn_hub_cli_deprecated,
+)
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        ("hub://guardrails/detect_pii", "guardrails-ai-detect-pii"),
+        ("hub://guardrails/regex_match", "guardrails-ai-regex-match"),
+        # cross-namespace hub ids still translate to the guardrails-ai-* dist
+        ("hub://cartesia/mentions_drugs", "guardrails-ai-mentions-drugs"),
+    ],
+)
+def test_pip_name_for_uri(uri, expected):
+    assert pip_name_for_uri(uri) == expected
+
+
+def test_pip_name_for_uri_invalid_returns_none():
+    assert pip_name_for_uri("not-a-hub-uri") is None
+
+
+def test_warn_hub_cli_deprecated_emits_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        warn_hub_cli_deprecated(pip_hint="pip install guardrails-ai-detect-pii")
+
+
+def test_install_cli_emits_deprecation_and_translates_to_pip(mocker):
+    """`guardrails hub install` warns and points at the public pip command."""
+    mock_install_multiple = mocker.patch("guardrails.hub.install.install_multiple")
+    mocker.patch("guardrails.cli.hub.install.version_warnings_if_applicable")
+    mock_warn = mocker.patch("guardrails.cli.hub.deprecation.warn_hub_cli_deprecated")
+
+    from guardrails.cli.hub.install import install_cli
+
+    install_cli(
+        ["hub://guardrails/detect_pii"],
+        local_models=False,
+        quiet=True,
+        upgrade=False,
+    )
+
+    # The deprecation warning fired with the translated pip command.
+    assert mock_warn.call_count == 1
+    _, kwargs = mock_warn.call_args
+    assert kwargs["pip_hint"] == "pip install guardrails-ai-detect-pii"
+    # Install still proceeds (now from public PyPI).
+    mock_install_multiple.assert_called_once()

--- a/tests/unit_tests/cli/hub/test_uninstall.py
+++ b/tests/unit_tests/cli/hub/test_uninstall.py
@@ -29,7 +29,7 @@ def test_remove_from_hub_inits(mocker):
     expected_calls = [
         call(
             "/site-packages/guardrails/hub/__init__.py",
-            "from guardrails_grhub_test_package import Validator, Helper",
+            "from guardrails_ai.test_package import Validator, Helper",
         ),
     ]
 
@@ -95,5 +95,5 @@ def test_uninstall_hub_module(mocker):
     uninstall_hub_module(manifest_mock)
 
     mock_pip_process.assert_called_once_with(
-        "uninstall", "guardrails-grhub-test-package", flags=["-y"], quiet=True
+        "uninstall", "guardrails-ai-test-package", flags=["-y"], quiet=True
     )

--- a/tests/unit_tests/hub/test_hub_install.py
+++ b/tests/unit_tests/hub/test_hub_install.py
@@ -88,7 +88,7 @@ class TestInstall:
             ),
             call(
                 level=5,
-                msg="✅Successfully installed hub://guardrails/id!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://guardrailsai.com/hub/validator/guardrails/id\n",  # noqa
+                msg="✅Successfully installed hub://guardrails/id!\n\nImport validator:\nfrom guardrails_ai.id import TestValidator\n\nGet more info:\nhttps://guardrailsai.com/hub/validator/guardrails/id\n",  # noqa
             ),  # noqa
         ]
         assert mock_logger_log.call_count == 3
@@ -149,7 +149,7 @@ class TestInstall:
             ),
             call(
                 level=5,
-                msg="✅Successfully installed hub://guardrails/id!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://guardrailsai.com/hub/validator/guardrails/id\n",  # noqa
+                msg="✅Successfully installed hub://guardrails/id!\n\nImport validator:\nfrom guardrails_ai.id import TestValidator\n\nGet more info:\nhttps://guardrailsai.com/hub/validator/guardrails/id\n",  # noqa
             ),  # noqa
         ]
         assert mock_logger_log.call_count == 3
@@ -207,7 +207,7 @@ class TestInstall:
             ),
             call(
                 level=5,
-                msg="✅Successfully installed hub://guardrails/id!\n\nImport validator:\nfrom guardrails.hub import TestValidator\n\nGet more info:\nhttps://guardrailsai.com/hub/validator/guardrails/id\n",  # noqa
+                msg="✅Successfully installed hub://guardrails/id!\n\nImport validator:\nfrom guardrails_ai.id import TestValidator\n\nGet more info:\nhttps://guardrailsai.com/hub/validator/guardrails/id\n",  # noqa
             ),  # noqa
         ]
         assert mock_logger_log.call_count == 3

--- a/tests/unit_tests/hub/test_hub_namespace_shim.py
+++ b/tests/unit_tests/hub/test_hub_namespace_shim.py
@@ -1,0 +1,64 @@
+"""Tests for the `guardrails.hub` back-compat namespace shim (WS-G.3).
+
+After a validator is installed as a public `guardrails-ai-<name>` package
+(importable as `guardrails_ai.<name>`), `from guardrails.hub import X` must keep
+working by falling back to scanning the `guardrails_ai.*` namespace, while
+emitting a one-time DeprecationWarning.
+"""
+
+import sys
+import warnings
+
+import pytest
+
+import guardrails.hub as hub_module
+
+
+@pytest.fixture
+def fake_namespace_package(tmp_path, monkeypatch):
+    """Create an installed `guardrails_ai.faketest` namespace package on disk."""
+    ns_dir = tmp_path / "guardrails_ai" / "faketest"
+    ns_dir.mkdir(parents=True)
+    # PEP 420 namespace: no guardrails_ai/__init__.py
+    (ns_dir / "__init__.py").write_text("class FakeValidator:\n    pass\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    # Ensure a clean import + reset the shim's caches/flags.
+    for mod in list(sys.modules):
+        if mod == "guardrails_ai" or mod.startswith("guardrails_ai."):
+            del sys.modules[mod]
+    hub_module._export_map_cache = None
+    hub_module._namespace_deprecation_warned = False
+
+    yield
+
+    for mod in list(sys.modules):
+        if mod == "guardrails_ai" or mod.startswith("guardrails_ai."):
+            del sys.modules[mod]
+    hub_module._export_map_cache = None
+    hub_module._namespace_deprecation_warned = False
+
+
+def test_shim_resolves_from_guardrails_ai_namespace(fake_namespace_package):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        resolved = hub_module.__getattr__("FakeValidator")
+
+    assert resolved.__name__ == "FakeValidator"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_shim_unknown_export_raises_attribute_error(fake_namespace_package):
+    with pytest.raises(AttributeError):
+        hub_module.__getattr__("DoesNotExistValidator")
+
+
+def test_shim_returns_none_without_namespace(monkeypatch):
+    """If no guardrails_ai namespace is installed, lookups raise AttributeError."""
+    for mod in list(sys.modules):
+        if mod == "guardrails_ai" or mod.startswith("guardrails_ai."):
+            del sys.modules[mod]
+    monkeypatch.setitem(sys.modules, "guardrails_ai", None)
+    hub_module._export_map_cache = None
+    with pytest.raises(AttributeError):
+        hub_module.__getattr__("AnythingAtAll")

--- a/tests/unit_tests/hub/test_validator_package_service.py
+++ b/tests/unit_tests/hub/test_validator_package_service.py
@@ -76,7 +76,7 @@ class TestAddToHubInits:
 
         mock_hub_read = mocker.patch.object(hub_init_file, "read")
         mock_hub_read.return_value = (
-            "from guardrails_ai_grhub_id import helper, TestValidator"  # noqa
+            "from guardrails_ai.id import helper, TestValidator"  # noqa
         )
 
         hub_seek_spy = mocker.spy(hub_init_file, "seek")
@@ -149,7 +149,7 @@ class TestAddToHubInits:
         hub_write_calls = [
             call("\n"),
             call(
-                "from guardrails_ai_grhub_id import TestValidator"  # noqa
+                "from guardrails_ai.id import TestValidator"  # noqa
             ),
         ]
         hub_write_spy.assert_has_calls(hub_write_calls)
@@ -354,7 +354,7 @@ class TestRunPostInstall:
         mock_subprocess_check_output.assert_called_once_with(
             [
                 mock_sys_executable,
-                "./site_packages/guardrails_ai_grhub_id/post_install.py",  # noqa
+                "./site_packages/guardrails_ai/id/post_install.py",  # noqa
             ]
         )
 
@@ -416,7 +416,7 @@ class TestValidatorPackageService:
         manifest = cast(Manifest, self.manifest)
         ValidatorPackageService.get_validator_from_manifest(manifest)
 
-        mock_reload_module.assert_called_once_with("guardrails_grhub_id")
+        mock_reload_module.assert_called_once_with("guardrails_ai.id")
 
     def test_get_module_name_valid(self):
         module_name, module_version = ValidatorPackageService.get_validator_id(
@@ -433,10 +433,6 @@ class TestValidatorPackageService:
         mock_installer = mocker.patch(
             "guardrails.hub.validator_package_service.installer_process"
         )
-        mock_settings = mocker.patch(
-            "guardrails.hub.validator_package_service.settings"
-        )
-        mock_settings.rc.token = "mock-token"
         mocker.patch.object(
             ValidatorPackageService, "detect_installer", return_value="pip"
         )
@@ -469,17 +465,13 @@ class TestValidatorPackageService:
         mock_installer = mocker.patch(
             "guardrails.hub.validator_package_service.installer_process"
         )
-        mock_settings = mocker.patch(
-            "guardrails.hub.validator_package_service.settings"
-        )
-        mock_settings.rc.token = "mock-token"
         mocker.patch.object(
             ValidatorPackageService, "detect_installer", return_value="pip"
         )
 
         mock_installer.side_effect = [
-            PipProcessError("install", "guardrails-ai-grhub-id"),
-            "Sucessfully installed guardrails-ai-grhub-id",
+            PipProcessError("install", "guardrails-ai-id"),
+            "Sucessfully installed guardrails-ai-id",
         ]
 
         manifest = Manifest.from_dict(
@@ -504,21 +496,15 @@ class TestValidatorPackageService:
         installer_calls = [
             call(
                 "install",
-                "guardrails-ai-grhub-id[validators]",
-                [
-                    "--index-url=https://__token__:mock-token@pypi.guardrailsai.com/simple",
-                    "--extra-index-url=https://pypi.org/simple",
-                ],
+                "guardrails-ai-id[validators]",
+                [],
                 quiet=False,
                 installer="pip",
             ),
             call(
                 "install",
-                "guardrails-ai-grhub-id",
-                [
-                    "--index-url=https://__token__:mock-token@pypi.guardrailsai.com/simple",
-                    "--extra-index-url=https://pypi.org/simple",
-                ],
+                "guardrails-ai-id",
+                [],
                 quiet=False,
                 installer="pip",
             ),
@@ -529,10 +515,6 @@ class TestValidatorPackageService:
         mock_installer = mocker.patch(
             "guardrails.hub.validator_package_service.installer_process"
         )
-        mock_settings = mocker.patch(
-            "guardrails.hub.validator_package_service.settings"
-        )
-        mock_settings.rc.token = "mock-token"
         mocker.patch.object(
             ValidatorPackageService, "detect_installer", return_value="pip"
         )
@@ -561,11 +543,8 @@ class TestValidatorPackageService:
         installer_calls = [
             call(
                 "install",
-                "guardrails-ai-grhub-id[validators]",
-                [
-                    "--index-url=https://__token__:mock-token@pypi.guardrailsai.com/simple",
-                    "--extra-index-url=https://pypi.org/simple",
-                ],
+                "guardrails-ai-id[validators]",
+                [],
                 quiet=False,
                 installer="pip",
             ),
@@ -642,9 +621,9 @@ class TestRegisterValidator:
         assert registry["version"] == 1
         assert "guardrails/detect_pii" in registry["validators"]
         entry = registry["validators"]["guardrails/detect_pii"]
-        assert entry["import_path"] == "guardrails_grhub_detect_pii"
+        assert entry["import_path"] == "guardrails_ai.detect_pii"
         assert entry["exports"] == ["DetectPII"]
-        assert entry["package_name"] == "guardrails-grhub-detect-pii"
+        assert entry["package_name"] == "guardrails-ai-detect-pii"
         assert "installed_at" in entry
 
     def test_appends_to_existing_registry(self, tmp_path, mocker):
@@ -845,10 +824,6 @@ class TestInstallHubModuleWithInstaller:
             "guardrails.hub.validator_package_service.installer_process",
             return_value="Success",
         )
-        mock_settings = mocker.patch(
-            "guardrails.hub.validator_package_service.settings"
-        )
-        mock_settings.rc.token = "mock-token"
         mocker.patch.object(
             ValidatorPackageService,
             "detect_installer",
@@ -859,11 +834,8 @@ class TestInstallHubModuleWithInstaller:
 
         mock_installer.assert_called_once_with(
             "install",
-            "guardrails-grhub-detect-pii[validators]",
-            [
-                "--index-url=https://__token__:mock-token@pypi.guardrailsai.com/simple",
-                "--extra-index-url=https://pypi.org/simple",
-            ],
+            "guardrails-ai-detect-pii[validators]",
+            [],
             quiet=False,
             installer=detected_installer,
         )


### PR DESCRIPTION
## Summary
Non-breaking migration of the hub-install path off the private registry (`pypi.guardrailsai.com`) and onto **public PyPI**. The `guardrails hub` CLI and `from guardrails.hub import X` keep working, now backed by public PyPI, with deprecation warnings (per plan decision D4).

## Changes (WS-G/H/I)
- **Kill private-registry coupling:** remove the `pypi.guardrailsai.com` index URL and the `-grhub-` package-name mangling from `validator_package_service`. Installs now use public PyPI as `guardrails-ai-<name>`, imported as `guardrails_ai.<name>`.
- **Deprecate the hub CLI:** `install`/`uninstall`/`list`/`submit`/`create-validator` emit a `DeprecationWarning` and the equivalent `pip` command (shared `guardrails/cli/hub/deprecation.py`).
- **Back-compat shim:** `guardrails.hub.__getattr__` falls back to the installed `guardrails_ai.*` namespace (one-time `DeprecationWarning`), so `from guardrails.hub import DetectPII` keeps working after `pip install guardrails-ai-detect-pii`.
- **Docs:** pip-based install in README, features list, 27 example notebooks, and a new hub→public-PyPI migration guide.
- **WS-I:** the shared `validator_pypi_publish` action is deprecated (warning step + README), kept functional for legacy per-validator repos.

## Gates
- Full unit suite + `tests/unit_tests/hub/*` + `tests/unit_tests/cli/hub/*` green (incl. new `test_deprecation.py`, `test_hub_namespace_shim.py`).
- `ruff` lint/format clean; `grep -rn pypi.guardrailsai.com guardrails/` empty.

## Not in this PR
- Removing RAIL/`lxml` (WS-K) — breaking, deferred to next major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaEJd2cwNntuq4biaeNhpZ