### PR TITLE
Handle longer markdown JSON fences

### DIFF
--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -28,18 +28,31 @@ def has_code_block(
         int: The ending index of the code block.
     """  # noqa
     block_border = "```"
-    block_start_border = f"{block_border}{code_type}"
 
-    block_start_index = string_value.find(block_start_border)
-    if block_start_index != -1:
-        block_end_index = string_value.find(
-            block_border, (block_start_index + len(block_start_border))
-        )
-        return (
-            (True, block_start_index, block_end_index)
-            if block_end_index != -1
-            else (False, None, None)
-        )
+    block_start_index = string_value.find(block_border)
+    while block_start_index != -1:
+        opening_fence = regex.match(r"`{3,}", string_value[block_start_index:])
+        if opening_fence is None:
+            block_start_index = string_value.find(block_border, block_start_index + 1)
+            continue
+
+        opening_fence_len = len(opening_fence.group(0))
+        opening_line_end = string_value.find("\n", block_start_index)
+        if opening_line_end == -1:
+            return False, None, None
+
+        opening_info = string_value[
+            block_start_index + opening_fence_len : opening_line_end
+        ].strip()
+        if not code_type or opening_info.startswith(code_type):
+            block_end_index = string_value.find(block_border, opening_line_end + 1)
+            while block_end_index != -1:
+                closing_fence = regex.match(r"`{3,}", string_value[block_end_index:])
+                if closing_fence and len(closing_fence.group(0)) >= opening_fence_len:
+                    return True, block_start_index, block_end_index
+                block_end_index = string_value.find(block_border, block_end_index + 1)
+
+        block_start_index = string_value.find(block_border, block_start_index + 1)
     return (False, None, None)
 
 
@@ -60,10 +73,10 @@ def get_code_block(
     """  # noqa
     trimmed_input = string_value
 
-    block_border = "```"
-    block_start_border = f"{block_border}{code_type}"
+    opening_fence = regex.match(r"`{3,}", trimmed_input[start:])
+    opening_fence_len = len(opening_fence.group(0)) if opening_fence else 3
 
-    start_index = start + len(block_start_border)
+    start_index = start + opening_fence_len + len(code_type or "")
 
     contents = trimmed_input[start_index:end]
 

--- a/tests/unit_tests/utils/test_parsing_utils.py
+++ b/tests/unit_tests/utils/test_parsing_utils.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from guardrails.utils.parsing_utils import (
+    extract_json_from_ouput,
     get_code_block,
     has_code_block,
     prune_extra_keys,
@@ -79,6 +80,19 @@ def test_get_code_block(llm_ouput, expected_output, code_type):
     actual_output = get_code_block(llm_ouput, start, end, code_type)
 
     assert actual_output == expected_output
+
+
+def test_extract_json_from_longer_code_fence():
+    llm_output = '''````json
+{
+    "answer": "Use ``` when showing markdown fences"
+}
+````'''
+
+    parsed_output, error = extract_json_from_ouput(llm_output)
+
+    assert error is None
+    assert parsed_output == {"answer": "Use ``` when showing markdown fences"}
 
 
 with open(


### PR DESCRIPTION
## What changed

This updates code block detection to support markdown fences longer than three backticks when parsing JSON from LLM output.

## Why

Markdown allows a longer outer fence when the content itself contains triple backticks. For example:

`````markdown
````json
{"answer": "Use ``` when showing markdown fences"}
````
`````

Previously, Guardrails treated the opening ````json fence as a generic ``` block and then stopped at the inner ```, so JSON extraction returned a partial string and failed with `JSONDecodeError`.

The change tracks the full opening fence length and only accepts a closing fence with at least that many backticks. Existing three-backtick behavior is covered by the current tests.

## Validation

- `python -m pytest tests\unit_tests\utils\test_parsing_utils.py::test_extract_json_from_longer_code_fence -q` -> 1 passed
- `python -m pytest tests\unit_tests\utils\test_parsing_utils.py -q` -> 13 passed
- `python -m ruff check guardrails\utils\parsing_utils.py tests\unit_tests\utils\test_parsing_utils.py`
- `git diff --check -- guardrails/utils/parsing_utils.py tests/unit_tests/utils/test_parsing_utils.py`

Note: installing the local test dependencies with `python -m pip install -e ".[dev]"` completed, but this Windows environment also has unrelated globally installed packages with dependency-version conflicts.