### PR TITLE
feat(validation): include before and after values in validation summaries

### DIFF
--- a/guardrails/classes/validation/validation_summary.py
+++ b/guardrails/classes/validation/validation_summary.py
@@ -1,5 +1,7 @@
 # TODO Temp to update once generated class is in
-from typing import Iterator, List
+from typing import Any, Iterator, List, Optional
+
+from pydantic import Field
 
 from guardrails.classes.generic.arbitrary_model import ArbitraryModel
 from guardrails_ai.types import FailResult
@@ -8,6 +10,15 @@ from guardrails_ai.types import ValidationSummary as IValidationSummary
 
 
 class ValidationSummary(IValidationSummary, ArbitraryModel):
+    value_before_validation: Optional[Any] = Field(
+        default=None,
+        alias="valueBeforeValidation",
+    )
+    value_after_validation: Optional[Any] = Field(
+        default=None,
+        alias="valueAfterValidation",
+    )
+
     @staticmethod
     def _generate_summaries_from_validator_logs(
         validator_logs: List[ValidatorLogs],
@@ -30,6 +41,8 @@ class ValidationSummary(IValidationSummary, ArbitraryModel):
                 propertyPath=log.property_path,
                 failureReason=failure_reason,
                 errorSpans=error_spans,  # type: ignore
+                valueBeforeValidation=log.value_before_validation,
+                valueAfterValidation=log.value_after_validation,
             )
 
     @staticmethod

--- a/tests/unit_tests/classes/validation/test_validation_summary.py
+++ b/tests/unit_tests/classes/validation/test_validation_summary.py
@@ -1,0 +1,34 @@
+from guardrails.classes.validation.validation_summary import ValidationSummary
+from guardrails.classes.validation.validator_logs import ValidatorLogs
+from guardrails_ai.types import FailResult, Outcome
+
+
+def test_validation_summary_includes_before_and_after_values():
+    validator_log = ValidatorLogs(
+        validatorName="MockValidator",
+        registeredName="mock-validator",
+        valueBeforeValidation="original value",
+        valueAfterValidation="fixed value",
+        propertyPath="$",
+        validationResult=FailResult(
+            outcome=Outcome.FAIL,
+            errorMessage="Value failed validation.",
+            fixValue="fixed value",
+        ),
+    )
+
+    summaries = ValidationSummary.from_validator_logs_only_fails([validator_log])
+
+    assert len(summaries) == 1
+    summary = summaries[0]
+
+    assert summary.validator_name == "MockValidator"
+    assert summary.property_path == "$"
+    assert summary.failure_reason == "Value failed validation."
+    assert summary.value_before_validation == "original value"
+    assert summary.value_after_validation == "fixed value"
+
+    dumped = summary.model_dump(by_alias=True)
+
+    assert dumped["valueBeforeValidation"] == "original value"
+    assert dumped["valueAfterValidation"] == "fixed value"


### PR DESCRIPTION
## Summary

Adds `valueBeforeValidation` and `valueAfterValidation` to `ValidationSummary` entries generated from validator logs.

This makes `ValidationOutcome.validation_summaries` more useful for mutation-producing validation actions such as `on_fail="fix"`, because callers can now inspect both the value before validation and the value after validation directly from the summary.

## Motivation

In #1448, the discussion noted that most of this information is already available in validator logs / Guard history, and that adding before/after values to validation summaries would provide a lightweight audit trail without introducing a new on-fail tier or callback API.

## Changes

* Add `value_before_validation` / `value_after_validation` fields to `ValidationSummary`
* Populate them from `ValidatorLogs.value_before_validation` and `ValidatorLogs.value_after_validation`
* Add unit coverage for summary generation and alias serialization

## Test

```bash
python -m pytest tests/unit_tests/classes/validation/test_validation_summary.py -q
```

Result:

```text
1 passed
```

Related to #1448

