### PR TITLE
fix(schema): respect maxItems and avoid crash on minItems>=3 in example generator

### DIFF
--- a/guardrails/schema/generator.py
+++ b/guardrails/schema/generator.py
@@ -163,10 +163,12 @@ def gen_array(
     """
     item_schema = schema.get("items", {})
     min_items = schema.get("minItems", 1)
-    max_item = schema.get("maxItem", 2)
+    max_items = schema.get("maxItems", get_max(min_items, 2))
     unique_items = schema.get("uniqueItems", False)
 
-    gen_amount = randint(min_items, max_item)
+    # Guard against minItems > maxItems, which would make randint raise.
+    max_items = get_max(min_items, max_items)
+    gen_amount = randint(min_items, max_items)
 
     array_items = []
     while len(array_items) < gen_amount:

--- a/tests/unit_tests/schema/test_generator.py
+++ b/tests/unit_tests/schema/test_generator.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 import pytest
-from guardrails.schema.generator import gen_num
+from guardrails.schema.generator import gen_array, gen_num
 
 
 @pytest.mark.parametrize(
@@ -29,3 +29,29 @@ def test_gen_num(schema, min, max, multiple, is_int: bool):
     div_result = round(Decimal(result) / Decimal(multiple), 3)
     assert div_result % 1 == 0
     assert isinstance(result, int) is is_int
+
+
+@pytest.mark.parametrize(
+    "schema,min_len,max_len",
+    [
+        # minItems above the old default of 2 used to crash randint(5, 2).
+        ({"type": "array", "items": {"type": "string"}, "minItems": 5}, 5, None),
+        # maxItems was read from the wrong key ("maxItem") and silently ignored.
+        (
+            {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 5,
+                "maxItems": 10,
+            },
+            5,
+            10,
+        ),
+        ({"type": "array", "items": {"type": "integer"}, "maxItems": 1}, 1, 1),
+    ],
+)
+def test_gen_array_respects_item_bounds(schema, min_len, max_len):
+    result = gen_array(schema)
+    assert len(result) >= min_len
+    if max_len is not None:
+        assert len(result) <= max_len


### PR DESCRIPTION
## What's broken
`gen_array` in `guardrails/schema/generator.py` reads the array upper bound from `maxItem`, but the JSON Schema keyword is `maxItems` (also what the function's docstring claims to support). Two effects:
1. A schema's `maxItems` is silently ignored — the generator always uses the default cap of `2`.
2. Any array schema with `minItems >= 3` crashes with `ValueError: empty range in randrange(...)`, because `randint(min_items, 2)` is called with `min_items > 2`.

`generate_example` is invoked during reask setup (`guardrails/actions/reask.py`), so a guard with a `minItems >= 3` array field raises on reask.

```python
generate_example({"type":"array","items":{"type":"string"},"minItems":5,"maxItems":10})
# ValueError: empty range in randrange(5, 3)
```

## Why it happens
Misspelled schema key `maxItem` (should be `maxItems`) pins the upper bound to the default `2`, so `maxItems` is never read and `randint(min_items, 2)` blows up whenever `minItems > 2`.

## Fix
Read `maxItems` (correct key), default it to `max(minItems, 2)`, and clamp `max_items = max(min_items, max_items)` so a user-supplied `minItems > maxItems` can't make `randint` raise.

## Test
Added a parametrized test covering the crash case, the previously-ignored `maxItems`, and a tight `maxItems:1` bound. Fails before the change (2 failures), passes after.
