### PR TITLE
fix: deserialize sets from the serialized payload

### DIFF
--- a/guardrails/utils/serialization_utils.py
+++ b/guardrails/utils/serialization_utils.py
@@ -46,7 +46,7 @@ def deserialize(original: Optional[Any], serialized: Optional[str]) -> Any:
         if isinstance(original, datetime):
             return datetime.fromisoformat(loaded_val)
         elif isinstance(original, set):
-            return set(original)
+            return set(loaded_val)
         elif hasattr(original, "__class__"):
             # TODO: Handle nested classes
             # NOTE: nested pydantic classes already work

--- a/tests/unit_tests/utils/test_serialization_utils.py
+++ b/tests/unit_tests/utils/test_serialization_utils.py
@@ -40,6 +40,16 @@ class TestSerializeAndDeserialize:
         deserialized_data = deserialize(data, serialized_data)
         assert deserialized_data == data
 
+    def test_set(self):
+        data = {1, 2, 3}
+
+        serialized_data = serialize(data)
+        assert set(deserialize(data, serialized_data)) == data
+
+        # deserialize must reconstruct from the serialized payload, not return
+        # the template value passed as `original`.
+        assert deserialize(set(), serialize({4, 5, 6})) == {4, 5, 6}
+
     def test_datetime(self):
         data = datetime(2024, 9, 10, 0, 0, 0)
 


### PR DESCRIPTION
## What

`deserialize()` in `guardrails/utils/serialization_utils.py` reconstructs a value from a serialized payload, using the `original` argument as a template for the type. Every branch reads the deserialized `loaded_val` — **except the `set` branch, which returns `set(original)`**, discarding the payload:

```python
if isinstance(original, datetime):
    return datetime.fromisoformat(loaded_val)   # uses payload ✅
elif isinstance(original, set):
    return set(original)                         # ignores payload ❌
```

So the deserialized data is thrown away and the template value is returned instead:

```python
deserialize({1, 2, 3}, serialize({4, 5, 6}))   # -> {1, 2, 3}, should be {4, 5, 6}
```

This is reached via `ValidatorServiceBase.merge_results()`, which does `deserialize(original_value, current)` after merging validators' outputs — for a set-typed validated value, the merged result is dropped and the pre-validation set restored.

## Fix

Return `set(loaded_val)`, matching the sibling branches.

## Testing

Added `test_set` to `TestSerializeAndDeserialize` in `tests/unit_tests/utils/test_serialization_utils.py` — `set` was the one primitive type with no test. It asserts a round-trip **and** that `deserialize(set(), serialize({4, 5, 6})) == {4, 5, 6}` (a differing template, which is what exposes the bug — it fails on `main`, passes with the fix). Pure-Python, offline.