### PR TITLE
fix(trace): throttle DELETE in _truncate by moving it inside the if block

### DIFF
--- a/guardrails/call_tracing/sqlite_trace_handler.py
+++ b/guardrails/call_tracing/sqlite_trace_handler.py
@@ -125,15 +125,15 @@ class SQLiteTraceHandler(TracerMixin):
         now = time.time()
         if force or (now - self.last_cleanup > TIME_BETWEEN_CLEANUPS):
             self.last_cleanup = now
-        self.db.execute(
-            """
-            DELETE FROM guard_logs 
-            WHERE id < (
-                SELECT id FROM guard_logs ORDER BY id DESC LIMIT 1 OFFSET ?  
-            );
-            """,
-            (keep_n,),
-        )
+            self.db.execute(
+                """
+                DELETE FROM guard_logs
+                WHERE id < (
+                    SELECT id FROM guard_logs ORDER BY id DESC LIMIT 1 OFFSET ?
+                );
+                """,
+                (keep_n,),
+            )
 
     def log(
         self,

--- a/tests/unit_tests/test_sqlite_trace_handler.py
+++ b/tests/unit_tests/test_sqlite_trace_handler.py
@@ -1,0 +1,40 @@
+"""Tests for SQLiteTraceHandler._truncate throttling."""
+
+from unittest.mock import MagicMock
+
+from guardrails.call_tracing.sqlite_trace_handler import SQLiteTraceHandler
+
+
+def test_truncate_throttled_within_cleanup_interval(tmp_path):
+    """_truncate should only execute DELETE when the cleanup interval has
+    elapsed (or force=True), not on every call.
+
+    Regression test: the DELETE statement was outside the ``if`` block,
+    causing it to run on every call and defeating the TIME_BETWEEN_CLEANUPS
+    throttle.
+    """
+    handler = SQLiteTraceHandler(tmp_path / "test.db", read_mode=False)
+    # Replace db with a mock so we can count execute calls without a real
+    # sqlite3.Connection (whose .execute attribute is read-only).
+    handler.db = MagicMock()
+
+    # __init__ sets last_cleanup = time.time(), so immediately after
+    # construction the interval has NOT elapsed → DELETE should NOT run.
+    handler._truncate()
+    assert handler.db.execute.call_count == 0, (
+        "DELETE should not run within the cleanup interval"
+    )
+
+    # force=True bypasses the throttle → DELETE should run.
+    handler._truncate(force=True)
+    assert handler.db.execute.call_count == 1, "DELETE should run when force=True"
+
+    # Another force call → DELETE runs again.
+    handler._truncate(force=True)
+    assert handler.db.execute.call_count == 2
+
+    # Non-force immediately after → throttled, no new DELETE.
+    handler._truncate()
+    assert handler.db.execute.call_count == 2, (
+        "DELETE should be throttled within the interval"
+    )


### PR DESCRIPTION
## Problem

`SQLiteTraceHandler._truncate` (`guardrails/call_tracing/sqlite_trace_handler.py`) has a DELETE query **outside** the `TIME_BETWEEN_CLEANUPS` if-block. The `self.last_cleanup = now` line is inside the `if`, but `self.db.execute("DELETE ...")` is at the same indentation level as the `if` — so it runs on **every** `_truncate` call, completely bypassing the 10-second throttle.

This means every `log()`, `log_entry()`, or `log_validator()` call triggers a DELETE query against the SQLite database, creating unnecessary write load on every guard validation.

## Solution

Indent the `self.db.execute(DELETE ...)` call to be inside the `if force or (now - self.last_cleanup > TIME_BETWEEN_CLEANUPS):` block, so the DELETE only runs when the cleanup interval has elapsed or `force=True`.

## Changes

- `guardrails/call_tracing/sqlite_trace_handler.py`: moved `self.db.execute(...)` inside the if-block (indentation fix).
- `tests/unit_tests/test_sqlite_trace_handler.py`: added `test_truncate_throttled_within_cleanup_interval` verifying that DELETE is throttled within the cleanup interval and only runs on `force=True`.

## Testing

- New test passes: `pytest tests/unit_tests/test_sqlite_trace_handler.py` → **1 passed** (Python 3.12, Linux).
- `ruff check` clean on changed files.
- `ruff format --check` — already formatted.