### PR TITLE
fix(parsing): coerce common boolean strings instead of bool()

### DIFF
--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -289,6 +289,12 @@ def coerce_to_type(
         return payload
     elif schema_type == SimpleTypes.BOOLEAN:
         if not isinstance(payload, bool):
+            if isinstance(payload, str):
+                lower = payload.strip().lower()
+                if lower in ("false", "0", "no", "off"):
+                    return False
+                if lower in ("true", "1", "yes", "on"):
+                    return True
             return coerce(payload, bool)
         return payload
     elif schema_type == SimpleTypes.INTEGER:

--- a/tests/unit_tests/utils/test_parsing_utils.py
+++ b/tests/unit_tests/utils/test_parsing_utils.py
@@ -191,3 +191,34 @@ with open(
 def test_prune_extra_keys(schema, payload, pruned_payload):
     actual = prune_extra_keys(payload, schema)
     assert actual == pruned_payload
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("false", False),
+        ("False", False),
+        ("FALSE", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        (True, True),
+        (False, False),
+    ],
+)
+def test_coerce_to_type_boolean_strings(payload, expected):
+    """Boolean string coercion handles common truthy/falsy strings.
+
+    Regression: bool('false') is True in Python (non-empty string), so
+    coerce_to_type('false', BOOLEAN) returned True instead of False.
+    """
+    from guardrails.utils.parsing_utils import coerce_to_type
+    from guardrails.types.simple import SimpleTypes
+
+    result = coerce_to_type(payload, SimpleTypes.BOOLEAN)
+    assert result is expected


### PR DESCRIPTION
## Problem

`coerce_to_type` used `coerce(payload, bool)` for BOOLEAN schema types, which calls Python `bool()` on the payload. For strings like `"false"`, `"0"`, `"no"`, `bool()` returns `True` (any non-empty string is truthy in Python). This means when an LLM returns the string `"false"` and the schema expects a boolean, it gets incorrectly coerced to `True` — a critical correctness bug in a validation framework.

## Solution

Added explicit string-to-bool parsing in the BOOLEAN branch of `coerce_to_type` before falling back to `coerce()`:

- `"false"`, `"0"`, `"no"`, `"off"` → `False` (case-insensitive)
- `"true"`, `"1"`, `"yes"`, `"on"` → `True` (case-insensitive)
- Unrecognized strings and non-string payloads fall back to the existing `coerce(payload, bool)` behavior.

## Changes

- `guardrails/utils/parsing_utils.py`: added string-to-bool parsing in `coerce_to_type` BOOLEAN branch (~7 lines).
- `tests/unit_tests/utils/test_parsing_utils.py`: added `test_coerce_to_type_boolean_strings` with 13 parametrized cases covering falsy strings, truthy strings, and actual bool passthrough.

## Testing

- `pytest tests/unit_tests/utils/test_parsing_utils.py::test_coerce_to_type_boolean_strings` → **13 passed** (Python 3.12, Linux).
- `ruff check` clean on changed files.