### PR TITLE
[GR-1710] Adopt guardrails-ai-types 0.5.0; construct results with field-name kwargs

### DIFF
--- a/.github/workflows/examples_check.yml
+++ b/.github/workflows/examples_check.yml
@@ -58,6 +58,11 @@ jobs:
         # Install extra stuff for notebook runs
         pip install "huggingface_hub[cli]" jupyter nbconvert
         pip install nltk
+
+        # litellm >=1.89 eagerly imports its proxy modules (which require fastapi)
+        # from the core completion() path when tool-calling is used, so notebooks
+        # that pass tools (e.g. json_function_calling_tools, summarizer) need it.
+        pip install fastapi
     - name: Huggingface Hub Login
       run: |
         source .venv/bin/activate

--- a/docs/examples/extracting_entities.ipynb
+++ b/docs/examples/extracting_entities.ipynb
@@ -240,7 +240,7 @@
     "    messages=[{\"role\": \"user\", \"content\": prompt}],\n",
     "    prompt_params={\"document\": content[:6000]},\n",
     "    model=\"gpt-5-mini\",\n",
-    "    max_tokens=2048,\n",
+    "    max_tokens=4096,\n",
     ")"
    ]
   },

--- a/guardrails/schema/validator.py
+++ b/guardrails/schema/validator.py
@@ -106,8 +106,8 @@ def schema_validation(llm_output: Any, output_schema: Dict[str, Any], **kwargs):
             incorrectValue=llm_output,
             failResults=[
                 FailResult(
-                    fixValue=None,
-                    errorMessage=schema_error,
+                    fix_value=None,
+                    error_message=schema_error,
                 )
             ],
         )

--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -202,8 +202,8 @@ def parse_json_llm_output(
             incorrectValue=output,
             failResults=[
                 FailResult(
-                    fixValue=None,
-                    errorMessage="Output is not parseable as JSON",
+                    fix_value=None,
+                    error_message="Output is not parseable as JSON",
                 )
             ],
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -2389,14 +2389,14 @@ protobuf = ["grpcio-tools (>=1.81.1)"]
 
 [[package]]
 name = "guardrails-ai-types"
-version = "0.4.0"
+version = "0.5.0"
 description = "Offical Guardrails AI Types"
 optional = false
 python-versions = "<4,>=3.10"
 groups = ["main"]
 files = [
-    {file = "guardrails_ai_types-0.4.0-py3-none-any.whl", hash = "sha256:f9d218a01e23823d986837a91c38713fbd969d56a4eb2994fc732332e5a0fe3b"},
-    {file = "guardrails_ai_types-0.4.0.tar.gz", hash = "sha256:82bb9802c29c8a5cd85130abec3104cdf3f35c9b5d5d4b98bfaa9329b8080711"},
+    {file = "guardrails_ai_types-0.5.0-py3-none-any.whl", hash = "sha256:cc7db51bbe5b5ee0bdb4c50be98522940774f16f3b979c53bf849f004e2c8574"},
+    {file = "guardrails_ai_types-0.5.0.tar.gz", hash = "sha256:de872718c09c7560ee4b79190f6b10f994983c1c90df1b774c8a4df422fe835f"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Adopts **`guardrails-ai-types` 0.5.0** (the result-model field-name type fix) in guardrails core.

1. Bump `guardrails-ai-types` `0.4.0` → `0.5.0` in `poetry.lock`.
2. types 0.5.0 switches result-model fields from `alias=` to `validation_alias`/`serialization_alias`, so type-checkers now expect the field names. Update the two `FailResult` construction sites that used camelCase aliases — `guardrails/schema/validator.py` and `guardrails/utils/parsing_utils.py` — to `error_message=` / `fix_value=`. Runtime is unaffected (`AliasChoices` still accepts both spellings).

Without (2), core's type gate breaks the moment it resolves types 0.5.0 — which is already on PyPI and satisfies the existing `guardrails-ai-types>=0.4.0` range.

All checks green ✅ (ci, cli-compatibility, install_from_hub, examples_check, server_ci, typing, pytests, license) — i.e. the full pre-merge checklist from the types PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)