### PR TITLE
fix(actions): guard against empty fail_results in sub_reasks_with_fixed_values

### DIFF
--- a/guardrails/actions/reask.py
+++ b/guardrails/actions/reask.py
@@ -570,7 +570,7 @@ def sub_reasks_with_fixed_values(value: Any) -> Any:
             copy[dict_key] = sub_reasks_with_fixed_values(dict_value)
     elif isinstance(copy, FieldReAsk):
         fail_results = copy.fail_results or []
-        first_fail_result = fail_results[0]
+        first_fail_result = fail_results[0] if fail_results else None
 
         fix_value = first_fail_result.fix_value if first_fail_result else None
         # TODO handle multiple fail results

--- a/tests/unit_tests/actions/test_reask.py
+++ b/tests/unit_tests/actions/test_reask.py
@@ -117,6 +117,24 @@ def test_sub_reasks_with_fixed_values(input_dict, expected_dict):
     assert sub_reasks_with_fixed_values(input_dict) == expected_dict
 
 
+def test_sub_reasks_with_fixed_values_handles_none_fail_results():
+    """Regression test for #1491: fail_results=None must not crash.
+
+    FieldReAsk.fail_results defaults to None. Accessing fail_results[0]
+    on an empty list raised IndexError, masking the intended "return the
+    ReAsk unchanged" fallback.
+    """
+    reask = FieldReAsk(incorrect_value="bad_value")
+    result = sub_reasks_with_fixed_values(reask)
+    assert isinstance(result, FieldReAsk)
+    assert result == reask
+
+    reask_empty = FieldReAsk(incorrect_value="bad_value", fail_results=[])
+    result_empty = sub_reasks_with_fixed_values(reask_empty)
+    assert isinstance(result_empty, FieldReAsk)
+    assert result_empty == reask_empty
+
+
 def test_gather_reasks():
     """Test that reasks are gathered."""
     input_dict = {


### PR DESCRIPTION
## Description
Fixes #1491

`sub_reasks_with_fixed_values` crashed with `IndexError` when a
`FieldReAsk` had `fail_results=None` (the default). The existing
fallback `fail_results or []` produced an empty list, then
`fail_results[0]` raised before the intended
`if first_fail_result else None` guard could execute.

## Changes
- Guard the index access with a length check.
- Added a regression test covering both `None` and `[]` cases.

## Test plan
- [x] `pytest tests/unit_tests/actions/test_reask.py` — 15/15 passed
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean