### PR TITLE
fix: gather_reasks no longer raises IndexError when a list has 2+ FieldReAsk items

### DIFF
--- a/guardrails/actions/reask.py
+++ b/guardrails/actions/reask.py
@@ -530,15 +530,21 @@ def gather_reasks(
     ) -> None:
         if path is None:
             path = []
+        reask_indices = []
         for idx, item in enumerate(original):
             if isinstance(item, FieldReAsk):
                 item.path = path + [idx]
                 reasks.append(item)
-                del valid_output[idx]
+                reask_indices.append(idx)
             elif isinstance(item, dict):
                 _gather_reasks_in_dict(item, valid_output[idx], path + [idx])
             elif isinstance(item, list):
                 _gather_reasks_in_list(item, valid_output[idx], path + [idx])
+        # Delete in reverse order so earlier deletions don't shift the
+        # indices of later ones (valid_output is mutated in place while
+        # `original`, which we iterate over, is left untouched).
+        for idx in reversed(reask_indices):
+            del valid_output[idx]
         return
 
     if isinstance(validated_output, Dict):

--- a/tests/unit_tests/actions/test_reask.py
+++ b/tests/unit_tests/actions/test_reask.py
@@ -243,6 +243,66 @@ def test_gather_reasks():
     assert actual_reasks == expected_reasks
 
 
+def test_gather_reasks_multiple_in_same_list():
+    """Regression test: gather_reasks must not raise IndexError, and must not
+    silently corrupt valid_output, when a single list contains more than one
+    FieldReAsk.
+
+    _gather_reasks_in_list used to delete from `valid_output` at the same
+    index it was iterating over on `original` while both lists started out
+    the same length. Each deletion shrinks `valid_output` by one, so a
+    second (or later) deletion in the same list used a now-stale index,
+    causing an IndexError (or, depending on positions, deleting/keeping the
+    wrong element instead of crashing).
+    """
+    input_dict = {
+        "items": [
+            FieldReAsk(
+                incorrect_value=-1,
+                fail_results=[FailResult(error_message="bad item 0", fix_value=1)],
+            ),
+            "ok",
+            FieldReAsk(
+                incorrect_value=-1,
+                fail_results=[FailResult(error_message="bad item 2", fix_value=3)],
+            ),
+        ]
+    }
+
+    actual_reasks, valid_output = gather_reasks(input_dict)
+
+    assert len(actual_reasks) == 2
+    assert actual_reasks[0].path == ["items", 0]
+    assert actual_reasks[1].path == ["items", 2]
+    assert valid_output == {"items": ["ok"]}
+
+
+def test_gather_reasks_all_items_in_list_are_reasks():
+    """Same as above but every item in the list fails, exercising the
+    all-deletions-from-a-top-level-list path.
+    """
+    input_list = [
+        FieldReAsk(
+            incorrect_value=-1,
+            fail_results=[FailResult(error_message="bad a")],
+        ),
+        FieldReAsk(
+            incorrect_value=-1,
+            fail_results=[FailResult(error_message="bad b")],
+        ),
+        FieldReAsk(
+            incorrect_value=-1,
+            fail_results=[FailResult(error_message="bad c")],
+        ),
+    ]
+
+    actual_reasks, valid_output = gather_reasks(input_list)
+
+    assert len(actual_reasks) == 3
+    assert [r.path for r in actual_reasks] == [[0], [1], [2]]
+    assert valid_output == []
+
+
 @pytest.mark.parametrize(
     "input_dict, expected_dict",
     [


### PR DESCRIPTION
### What

`_gather_reasks_in_list` (`guardrails/actions/reask.py`), used by `gather_reasks` on every Guard run
(sync/async/streaming) to collect failed-validation items and strip them out of `valid_output`, deletes
failing items from `valid_output` using the `enumerate()` index of the *original* list, while mutating
`valid_output` in place during the same loop. Every `del valid_output[idx]` shifts all later elements down by
one, so as soon as a single list contains two or more `FieldReAsk` items, the second deletion uses a now-stale
index — this either raises `IndexError: list assignment index out of range` (if the stale index runs past
the shrunk list) or silently deletes/keeps the wrong element (if it doesn't). Existing tests only ever
exercised a single reask per list, so this was never caught.

```
IndexError: list assignment index out of range
  at guardrails/actions/reask.py:537 (del valid_output[idx])
```

### Fix

Collect the failing indices during the enumeration instead of deleting immediately, then delete from
`valid_output` in reverse order after the loop finishes — reverse order means each deletion only shifts
indices that have already been processed, never ones still pending. `original` (the list being iterated) is
never mutated, only `valid_output`. 6 lines changed, single function, no signature change.

### Test

Added `test_gather_reasks_multiple_in_same_list` (2 of 3 items fail) and
`test_gather_reasks_all_items_in_list_are_reasks` (all 3 fail — exercises the all-deletions-from-a-list
path). Both assert the correct `FieldReAsk.path` values and the correct surviving `valid_output`.

Before fix: 2 failed (`IndexError: list assignment index out of range`). After fix: all 16 tests in
`tests/unit_tests/actions/test_reask.py` pass. `ruff check` is clean on the changed source file.

### Scope

Single-function fix in `_gather_reasks_in_list`. Does not touch `_gather_reasks_in_dict` or the top-level
`gather_reasks` dispatch, and is reachable from every Guard runner since all of them route through
`gather_reasks` to prune failed items before a reask.

This is distinct from the other currently-open reask PRs (#1492 / #1569 / #1572), which all guard
`sub_reasks_with_fixed_values` against a `None`/empty `fail_results` list — a different function and a
different bug. This PR changes only the reverse-order deletion in `_gather_reasks_in_list` and does not
overlap those diffs.
