### PR TITLE
refactor(validator_service): modernize typing to built-in generics

### DIFF
--- a/guardrails/validator_service/__init__.py
+++ b/guardrails/validator_service/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
-from typing import Any, Iterator, Optional, Tuple
+from typing import Any
+from collections.abc import Iterator
 import warnings
 
 from guardrails.actions.filter import apply_filters
@@ -12,12 +13,13 @@ from guardrails.types import ValidatorMap
 from guardrails.telemetry.legacy_validator_tracing import trace_validation_result
 
 # Keep this imported for backwards compatibility
-from guardrails.validator_service.validator_service_base import ValidatorServiceBase  # noqa
+from guardrails.validator_service.validator_service_base import (
+    ValidatorServiceBase as ValidatorServiceBase,
+)
 from guardrails.validator_service.async_validator_service import AsyncValidatorService
 from guardrails.validator_service.sequential_validator_service import (
     SequentialValidatorService,
 )
-
 
 try:
     import uvloop  # type: ignore
@@ -63,8 +65,8 @@ def validate(
     metadata: dict,
     validator_map: ValidatorMap,
     iteration: Iteration,
-    disable_tracer: Optional[bool] = True,
-    path: Optional[str] = None,
+    disable_tracer: bool | None = True,
+    path: str | None = None,
     **kwargs,
 ):
     if path is None:
@@ -97,12 +99,12 @@ def validate(
 
 
 def validate_stream(
-    value_stream: Iterator[Tuple[Any, bool]],
+    value_stream: Iterator[tuple[Any, bool]],
     metadata: dict,
     validator_map: ValidatorMap,
     iteration: Iteration,
-    disable_tracer: Optional[bool] = True,
-    path: Optional[str] = None,
+    disable_tracer: bool | None = True,
+    path: str | None = None,
     **kwargs,
 ) -> Iterator[StreamValidationResult]:
     if path is None:
@@ -119,11 +121,11 @@ async def async_validate(
     metadata: dict,
     validator_map: ValidatorMap,
     iteration: Iteration,
-    disable_tracer: Optional[bool] = True,
-    path: Optional[str] = None,
-    stream: Optional[bool] = False,
+    disable_tracer: bool | None = True,
+    path: str | None = None,
+    stream: bool | None = False,
     **kwargs,
-) -> Tuple[Any, dict]:
+) -> tuple[Any, dict]:
     if path is None:
         path = "$"
     validator_service = AsyncValidatorService(disable_tracer)

--- a/guardrails/validator_service/async_validator_service.py
+++ b/guardrails/validator_service/async_validator_service.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Any, Awaitable, Coroutine, Dict, List, Optional, Tuple, Union
+from typing import Any
+from collections.abc import Awaitable, Coroutine
 
 from guardrails.actions.filter import Filter
 from guardrails.actions.refrain import Refrain
@@ -20,7 +21,7 @@ from guardrails.validator_service.validator_service_base import (
     ValidatorServiceBase,
 )
 
-ValidatorResult = Optional[Union[ValidationResult, Awaitable[ValidationResult]]]
+ValidatorResult = ValidationResult | Awaitable[ValidationResult] | None
 
 
 class AsyncValidatorService(ValidatorServiceBase):
@@ -31,12 +32,12 @@ class AsyncValidatorService(ValidatorServiceBase):
         self,
         validator: Validator,
         value: Any,
-        metadata: Optional[Dict],
-        stream: Optional[bool] = False,
+        metadata: dict | None,
+        stream: bool | None = False,
         *,
         validation_session_id: str,
         **kwargs,
-    ) -> Optional[ValidationResult]:
+    ) -> ValidationResult | None:
         validate_func = (
             validator.async_validate_stream if stream else validator.async_validate
         )
@@ -57,8 +58,8 @@ class AsyncValidatorService(ValidatorServiceBase):
         self,
         validator: Validator,
         value: Any,
-        metadata: Dict,
-        stream: Optional[bool] = False,
+        metadata: dict,
+        stream: bool | None = False,
         *,
         validation_session_id: str,
         **kwargs,
@@ -81,11 +82,11 @@ class AsyncValidatorService(ValidatorServiceBase):
         iteration: Iteration,
         validator: Validator,
         value: Any,
-        metadata: Dict,
+        metadata: dict,
         absolute_property_path: str,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         *,
-        reference_path: Optional[str] = None,
+        reference_path: str | None = None,
         **kwargs,
     ) -> ValidatorRun:
         validator_logs = self.before_run_validator(
@@ -146,15 +147,15 @@ class AsyncValidatorService(ValidatorServiceBase):
         iteration: Iteration,
         validator_map: ValidatorMap,
         value: Any,
-        metadata: Dict,
+        metadata: dict,
         absolute_property_path: str,
         reference_property_path: str,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         **kwargs,
     ):
         validators = validator_map.get(reference_property_path, [])
-        coroutines: List[Coroutine[Any, Any, ValidatorRun]] = []
-        validators_logs: List[ValidatorLogs] = []
+        coroutines: list[Coroutine[Any, Any, ValidatorRun]] = []
+        validators_logs: list[ValidatorLogs] = []
         for validator in validators:
             coroutines.append(
                 self.run_validator(
@@ -170,7 +171,7 @@ class AsyncValidatorService(ValidatorServiceBase):
             )
 
         results = await asyncio.gather(*coroutines)
-        reasks: List[FieldReAsk] = []
+        reasks: list[FieldReAsk] = []
         for res in results:
             validators_logs.append(res.validator_logs)
             # QUESTION: Do we still want to do this here or handle it during the merge?
@@ -210,16 +211,16 @@ class AsyncValidatorService(ValidatorServiceBase):
     async def validate_children(
         self,
         value: Any,
-        metadata: Dict,
+        metadata: dict,
         validator_map: ValidatorMap,
         iteration: Iteration,
         abs_parent_path: str,
         ref_parent_path: str,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         **kwargs,
     ):
         async def validate_child(
-            child_value: Any, *, key: Optional[str] = None, index: Optional[int] = None
+            child_value: Any, *, key: str | None = None, index: int | None = None
         ):
             child_key = key or index
             abs_child_path = f"{abs_parent_path}.{child_key}"
@@ -241,10 +242,10 @@ class AsyncValidatorService(ValidatorServiceBase):
             return child_key, new_child_value, new_metadata
 
         coroutines = []
-        if isinstance(value, List):
+        if isinstance(value, list):
             for index, child in enumerate(value):
                 coroutines.append(validate_child(child, index=index))
-        elif isinstance(value, Dict):
+        elif isinstance(value, dict):
             for key in value:
                 child = value.get(key)
                 coroutines.append(validate_child(child, key=key))
@@ -266,12 +267,12 @@ class AsyncValidatorService(ValidatorServiceBase):
         iteration: Iteration,
         absolute_path: str,
         reference_path: str,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         **kwargs,
     ) -> list[ValidatorRun]:
         # Then validate the parent value
         validators = validator_map.get(reference_path, [])
-        coroutines: List[Coroutine[Any, Any, ValidatorRun]] = []
+        coroutines: list[Coroutine[Any, Any, ValidatorRun]] = []
 
         for validator in validators:
             coroutines.append(
@@ -299,12 +300,12 @@ class AsyncValidatorService(ValidatorServiceBase):
         iteration: Iteration,
         absolute_path: str,
         reference_path: str,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         **kwargs,
-    ) -> Tuple[Any, dict]:
+    ) -> tuple[Any, dict]:
         child_ref_path = reference_path.replace(".*", "")
         # Validate children first
-        if isinstance(value, List) or isinstance(value, Dict):
+        if isinstance(value, list) or isinstance(value, dict):
             await self.validate_children(
                 value,
                 metadata,
@@ -339,9 +340,9 @@ class AsyncValidatorService(ValidatorServiceBase):
         absolute_path: str,
         reference_path: str,
         loop: asyncio.AbstractEventLoop,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         **kwargs,
-    ) -> Tuple[Any, dict]:
+    ) -> tuple[Any, dict]:
         value, metadata = loop.run_until_complete(
             self.async_validate(
                 value,

--- a/guardrails/validator_service/sequential_validator_service.py
+++ b/guardrails/validator_service/sequential_validator_service.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Any, Dict, Iterator, List, Optional, Tuple, cast
+from typing import Any, cast
+from collections.abc import Iterator
 
 from guardrails.actions.filter import Filter
 from guardrails.actions.refrain import Refrain
@@ -23,13 +24,13 @@ class SequentialValidatorService(ValidatorServiceBase):
         self,
         validator: Validator,
         value: Any,
-        metadata: Dict,
+        metadata: dict,
         validator_logs: ValidatorLogs,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         *,
         validation_session_id: str,
         **kwargs,
-    ) -> Optional[ValidationResult]:
+    ) -> ValidationResult | None:
         result = self.execute_validator(
             validator,
             value,
@@ -54,9 +55,9 @@ class SequentialValidatorService(ValidatorServiceBase):
         iteration: Iteration,
         validator: Validator,
         value: Any,
-        metadata: Dict,
+        metadata: dict,
         property_path: str,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         **kwargs,
     ) -> ValidatorLogs:
         validator_logs = self.before_run_validator(
@@ -79,8 +80,8 @@ class SequentialValidatorService(ValidatorServiceBase):
         self,
         iteration: Iteration,
         validator_map: ValidatorMap,
-        value_stream: Iterator[Tuple[Any, bool]],
-        metadata: Dict[str, Any],
+        value_stream: Iterator[tuple[Any, bool]],
+        metadata: dict[str, Any],
         absolute_property_path: str,
         reference_property_path: str,
         **kwargs,
@@ -111,8 +112,8 @@ class SequentialValidatorService(ValidatorServiceBase):
         self,
         iteration: Iteration,
         validator_map: ValidatorMap,
-        value_stream: Iterator[Tuple[Any, bool]],
-        metadata: Dict[str, Any],
+        value_stream: Iterator[tuple[Any, bool]],
+        metadata: dict[str, Any],
         absolute_property_path: str,
         reference_property_path: str,
         **kwargs,
@@ -260,8 +261,8 @@ class SequentialValidatorService(ValidatorServiceBase):
         self,
         iteration: Iteration,
         validator_map: ValidatorMap,
-        value_stream: Iterator[Tuple[Any, bool]],
-        metadata: Dict[str, Any],
+        value_stream: Iterator[tuple[Any, bool]],
+        metadata: dict[str, Any],
         absolute_property_path: str,
         reference_property_path: str,
         **kwargs,
@@ -317,41 +318,33 @@ class SequentialValidatorService(ValidatorServiceBase):
         iteration: Iteration,
         validator_map: ValidatorMap,
         value: Any,
-        metadata: Dict[str, Any],
+        metadata: dict[str, Any],
         absolute_property_path: str,
         reference_property_path: str,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         **kwargs,
-    ) -> Tuple[Any, Dict[str, Any]]:
+    ) -> tuple[Any, dict[str, Any]]:
         # Validate the field
         validators = validator_map.get(reference_property_path, [])
         for validator in validators:
             if stream:
                 if validator.on_fail_descriptor is OnFailAction.REASK:
-                    raise ValueError(
-                        """Reask is not supported for stream validation, 
-                        only noop and exception are supported."""
-                    )
+                    raise ValueError("""Reask is not supported for stream validation, 
+                        only noop and exception are supported.""")
                 if validator.on_fail_descriptor is OnFailAction.FIX:
-                    raise ValueError(
-                        """Fix is not supported for stream validation, 
-                        only noop and exception are supported."""
-                    )
+                    raise ValueError("""Fix is not supported for stream validation, 
+                        only noop and exception are supported.""")
                 if validator.on_fail_descriptor is OnFailAction.FIX_REASK:
                     raise ValueError(
                         """Fix reask is not supported for stream validation, 
                         only noop and exception are supported."""
                     )
                 if validator.on_fail_descriptor is OnFailAction.FILTER:
-                    raise ValueError(
-                        """Filter is not supported for stream validation, 
-                        only noop and exception are supported."""
-                    )
+                    raise ValueError("""Filter is not supported for stream validation, 
+                        only noop and exception are supported.""")
                 if validator.on_fail_descriptor is OnFailAction.REFRAIN:
-                    raise ValueError(
-                        """Refrain is not supported for stream validation, 
-                        only noop and exception are supported."""
-                    )
+                    raise ValueError("""Refrain is not supported for stream validation, 
+                        only noop and exception are supported.""")
             validator_logs = self.run_validator(
                 iteration,
                 validator,
@@ -408,9 +401,9 @@ class SequentialValidatorService(ValidatorServiceBase):
         iteration: Iteration,
         absolute_path: str,
         reference_path: str,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         **kwargs,
-    ) -> Tuple[Any, dict]:
+    ) -> tuple[Any, dict]:
         ###
         # NOTE: The way validation can be executed now is fundamentally wide open.
         #   Since validators are tracked against the JSONPaths for the
@@ -428,7 +421,7 @@ class SequentialValidatorService(ValidatorServiceBase):
 
         child_ref_path = reference_path.replace(".*", "")
         # Validate children first
-        if isinstance(value, List):
+        if isinstance(value, list):
             for index, child in enumerate(value):
                 abs_child_path = f"{absolute_path}.{index}"
                 ref_child_path = f"{child_ref_path}.*"
@@ -441,7 +434,7 @@ class SequentialValidatorService(ValidatorServiceBase):
                     ref_child_path,
                 )
                 value[index] = child_value
-        elif isinstance(value, Dict):
+        elif isinstance(value, dict):
             for key in value:
                 child = value.get(key)
                 abs_child_path = f"{absolute_path}.{key}"
@@ -471,7 +464,7 @@ class SequentialValidatorService(ValidatorServiceBase):
 
     def validate_stream(
         self,
-        value_stream: Iterator[Tuple[Any, bool]],
+        value_stream: Iterator[tuple[Any, bool]],
         metadata: dict,
         validator_map: ValidatorMap,
         iteration: Iteration,

--- a/guardrails/validator_service/validator_service_base.py
+++ b/guardrails/validator_service/validator_service_base.py
@@ -1,7 +1,8 @@
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Awaitable, Dict, Optional, Union
+from typing import Any
+from collections.abc import Awaitable
 
 from guardrails.actions.filter import Filter
 from guardrails.actions.refrain import Refrain
@@ -20,21 +21,21 @@ from guardrails.telemetry import trace_validator
 from guardrails.utils.serialization_utils import deserialize, serialize
 from guardrails.validator_base import Validator
 
-ValidatorResult = Optional[Union[ValidationResult, Awaitable[ValidationResult]]]
+ValidatorResult = ValidationResult | Awaitable[ValidationResult] | None
 
 
 @dataclass
 class ValidatorRun:
     value: Any
-    metadata: Dict
-    on_fail_action: Union[str, OnFailAction]
+    metadata: dict
+    on_fail_action: str | OnFailAction
     validator_logs: ValidatorLogs
 
 
 class ValidatorServiceBase:
     """Base class for validator services."""
 
-    def __init__(self, disable_tracer: Optional[bool] = True):
+    def __init__(self, disable_tracer: bool | None = True):
         self._disable_tracer = disable_tracer
 
     # NOTE: This is avoiding an issue with multiprocessing.
@@ -48,8 +49,8 @@ class ValidatorServiceBase:
         self,
         validator: Validator,
         value: Any,
-        metadata: Optional[Dict],
-        stream: Optional[bool] = False,
+        metadata: dict | None,
+        stream: bool | None = False,
         *,
         validation_session_id: str,
         **kwargs,
@@ -75,7 +76,7 @@ class ValidatorServiceBase:
         result: FailResult,
         value: Any,
         validator: Validator,
-        rechecked_value: Optional[ValidationResult] = None,
+        rechecked_value: ValidationResult | None = None,
     ):
         on_fail_descriptor = validator.on_fail_descriptor
         if on_fail_descriptor == OnFailAction.FIX:
@@ -147,7 +148,7 @@ class ValidatorServiceBase:
         self,
         validator: Validator,
         validator_logs: ValidatorLogs,
-        result: Optional[ValidationResult],
+        result: ValidationResult | None,
     ) -> ValidatorLogs:
         end_time = datetime.now()
         validator_logs.validation_result = result
@@ -160,15 +161,15 @@ class ValidatorServiceBase:
         iteration: Iteration,
         validator: Validator,
         value: Any,
-        metadata: Dict,
+        metadata: dict,
         absolute_property_path: str,
-        stream: Optional[bool] = False,
+        stream: bool | None = False,
         **kwargs,
     ) -> ValidatorRun:
         raise NotImplementedError
 
     # requires at least 2 validators
-    def multi_merge(self, original: str, new_values: list[str]) -> Optional[str]:
+    def multi_merge(self, original: str, new_values: list[str]) -> str | None:
         if len(new_values) == 0:
             return original
         current = new_values.pop()


### PR DESCRIPTION
## Description

Modernizes type annotations in `guardrails/validator_service/` from deprecated `typing` module aliases to Python 3.10+ built-in generics and PEP 604 union syntax. No logic changes — purely annotation modernization.

The repo's `pyproject.toml` declares `requires-python = ">=3.10,<3.14"`, so built-in generics (`list[X]`, `dict[K,V]`, `tuple[X,Y]` — Python 3.9+) and PEP 604 union syntax (`X | Y`, `X | None` — Python 3.10+) are fully supported.

## What changed

| Pattern | Before | After |
|---------|--------|-------|
| List | `typing.List[X]` | `list[X]` |
| Dict | `typing.Dict[K, V]` | `dict[K, V]` |
| Tuple | `typing.Tuple[X, Y]` | `tuple[X, Y]` |
| Optional | `typing.Optional[X]` | `X \| None` |
| Union | `typing.Union[X, Y]` | `X \| Y` |
| Iterator/Awaitable/Coroutine | `from typing import Iterator` | `from collections.abc import Iterator` |
| Re-export | `import X  # noqa` | `import X as X` (explicit re-export per ruff F401) |

## Files changed (4)

- `guardrails/validator_service/__init__.py`
- `guardrails/validator_service/validator_service_base.py`
- `guardrails/validator_service/async_validator_service.py`
- `guardrails/validator_service/sequential_validator_service.py`

## Why

The `typing.List`/`Dict`/`Tuple`/`Optional`/`Union` aliases are deprecated since Python 3.9 (PEP 585) and 3.10 (PEP 604). They're scheduled for removal in a future Python version. Modernizing now keeps the codebase forward-compatible and aligns with the repo's declared `requires-python = ">=3.10"` floor.

The `ruff` config in `pyproject.toml` doesn't currently enable `UP006`/`UP007` rules (which would auto-flag these), so this cleanup isn't being caught by CI. This PR addresses the existing technical debt in one self-contained module.

## Tests and Documentation

```bash
# 1. validator_service unit tests
$ python -m pytest tests/unit_tests/validator_service/ -v
======================== 25 passed, 5 warnings in 1.55s ========================

# 2. Full unit test suite (excluding 1 pre-existing failure unrelated to this change)
$ python -m pytest tests/unit_tests/ --deselect "tests/unit_tests/test_guard.py::TestConfigureExtended::test_configure_with_both_parameters"
================ 683 passed, 31 skipped, 1 deselected, 188 warnings in 12.71s ================

# 3. Lint + format
$ ruff check guardrails/validator_service/
All checks passed!
$ black --check guardrails/validator_service/
All done. ✨ 🍰 ✨

# 4. Verify imports work at runtime
$ python -c "from guardrails.validator_service import validate, validate_stream, async_validate, ValidatorServiceBase; print('OK')"
OK
```

### Pre-existing failure note

`tests/unit_tests/test_guard.py::TestConfigureExtended::test_configure_with_both_parameters` fails on `main` (before this PR) — verified by stashing my changes and running the test on the original code. It's unrelated to `validator_service` (tests the `Guard` class's `_allow_metrics_collection` flag). Not fixing it here to keep this PR scoped to typing modernization only.

## AI assistance disclosure

Drafted with AI assistance (Claude), reviewed and tested by me before submission. I used `ruff --select UP006,UP007,UP035,UP037,UP045 --fix` to automate the bulk of the modernization, then manually cleaned up the remaining `Optional[...]` type aliases and import lines that ruff left behind. I verified every changed file parses as valid Python, all 25 validator_service tests pass, and 683 total unit tests pass with no regressions.

Co-authored-by: Claude <noreply@anthropic.com>
