### PR TITLE
fix(parsing): prune_extra_keys wrongly keeps extra keys on wildcard-prefix siblings

### DIFF
--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -238,7 +238,13 @@ def prune_extra_keys(
         wildcards: List[str] = [
             path.split(".*")[0] for path in all_json_paths if ".*" in path
         ]
-        ancestor_is_wildcard = any(w in json_path for w in wildcards)
+        # Match on path segments, not raw substring: `w in json_path` would treat
+        # a non-wildcard sibling whose path is a string-superset of a wildcard
+        # prefix (e.g. `$.ab` vs the wildcard `$.a`) as a wildcard descendant, so
+        # its undeclared keys would never be pruned.
+        ancestor_is_wildcard = any(
+            json_path == w or json_path.startswith(f"{w}.") for w in wildcards
+        )
         actual_keys = list(payload.keys())
         for key in actual_keys:
             child_path = f"{json_path}.{key}"

--- a/tests/unit_tests/utils/test_parsing_utils.py
+++ b/tests/unit_tests/utils/test_parsing_utils.py
@@ -191,3 +191,19 @@ with open(
 def test_prune_extra_keys(schema, payload, pruned_payload):
     actual = prune_extra_keys(payload, schema)
     assert actual == pruned_payload
+
+
+def test_prune_extra_keys_sibling_of_wildcard_is_not_treated_as_wildcard():
+    # `$.a` is a wildcard (additionalProperties) object; `$.ab` is an unrelated
+    # sibling whose path is a string-superset of `$.a`. Its undeclared keys must
+    # still be pruned -- a substring ancestor check wrongly kept them.
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "object", "additionalProperties": True},
+            "ab": {"type": "object", "properties": {"known": {"type": "string"}}},
+        },
+    }
+    payload = {"a": {"anything": 1}, "ab": {"known": "x", "extra": "y"}}
+    result = prune_extra_keys(payload, schema)
+    assert result == {"a": {"anything": 1}, "ab": {"known": "x"}}


### PR DESCRIPTION
### What's broken

`prune_extra_keys` detects whether a property sits under a wildcard (`additionalProperties`) object using a **substring** check:

```python
wildcards = [path.split(".*")[0] for path in all_json_paths if ".*" in path]  # e.g. "$.a"
ancestor_is_wildcard = any(w in json_path for w in wildcards)
```

`w in json_path` is raw string containment, not a path-ancestor relationship. So a non-wildcard property whose path is a **string-superset** of a wildcard prefix inherits the wildcard exemption:

```python
schema = {"type":"object","properties":{
    "a":  {"type":"object","additionalProperties": True},                 # -> wildcard $.a
    "ab": {"type":"object","properties":{"known":{"type":"string"}}}}}
prune_extra_keys({"a":{"anything":1}, "ab":{"known":"x","extra":"y"}}, schema)
# {'a': {'anything': 1}, 'ab': {'known': 'x', 'extra': 'y'}}   <- 'extra' should have been pruned
```

`"$.a" in "$.ab"` is `True`, so `$.ab`'s undeclared keys leak through. Property names being prefixes of each other (`a`/`ab`, `meta`/`metadata`) is common.

### Fix

Check ancestry on path segments — `json_path == w or json_path.startswith(f"{w}.")` — instead of substring containment.

### Tests

Adds `test_prune_extra_keys_sibling_of_wildcard_is_not_treated_as_wildcard`. Full `tests/unit_tests/utils/test_parsing_utils.py` passes (13), including the existing `interest_rates` wildcard case.