### PR TITLE
[GR-1767] Auto-cut a GitHub Release on PyPI publish

### DIFF
--- a/.github/workflows/release_version.yml
+++ b/.github/workflows/release_version.yml
@@ -38,3 +38,38 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+
+      - name: Read version
+        id: version
+        shell: bash
+        run: |
+          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          if [ -z "$version" ]; then
+            echo "Could not read version from pyproject.toml" >&2
+            exit 1
+          fi
+          echo "version_tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cut GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version_tag="${{ steps.version.outputs.version_tag }}"
+          # Idempotent: workflow_dispatch can be re-run, and the tag may already exist.
+          if gh release view "$version_tag" >/dev/null 2>&1; then
+            echo "Release $version_tag already exists; skipping."
+            exit 0
+          fi
+          # Mark PEP 440 pre-releases (e.g. v0.11.0a1) as GitHub pre-releases.
+          prerelease_flag=""
+          if [[ "$version_tag" =~ (a|b|rc)[0-9]*$ ]]; then
+            prerelease_flag="--prerelease"
+          fi
+          echo "Cutting GitHub Release for $version_tag $prerelease_flag"
+          # --target creates the tag at this commit (this workflow does not tag separately).
+          gh release create "$version_tag" \
+            --title "$version_tag" \
+            --target "$GITHUB_SHA" \
+            --generate-notes \
+            $prerelease_flag


### PR DESCRIPTION
## What

Extends the **Release PyPi Version** workflow so that every PyPI publish also cuts a matching GitHub Release, keeping `guardrails-ai/guardrails` GitHub Releases in sync with PyPI without a manual step.

Two steps added after the existing `pypa/gh-action-pypi-publish` step:

1. **Read version** — extracts `project.version` from `pyproject.toml` (currently `0.11.0`).
2. **Cut GitHub Release** — `gh release create v$version --generate-notes`, creating the tag at the released commit (`--target $GITHUB_SHA`).

### Behavior
- **Auto-generated notes** from merged PRs/commits.
- **Pre-release detection** — `aN` / `bN` / `rcN` versions are flagged `--prerelease`.
- **Idempotent** — skips if the release already exists, so re-running the manual dispatch is safe.
- Uses only the preinstalled `gh` CLI and `python` — **no new third-party action**, so nothing new to pin.
- `contents: write` permission already present on the job.

## Ticket
GR-1767 — Track Snowglobe client releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)