### PR TITLE
fix: coerce_property skips falsy values (0, False, empty string)

### DIFF
--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -361,7 +361,7 @@ def coerce_property(
     if properties and isinstance(payload, dict):
         for k, v in properties.items():
             payload_value = payload.get(k)
-            if payload_value:
+            if payload_value is not None:
                 payload[k] = coerce_property(payload_value, v)
 
     ### Object Additional Properties ###
@@ -377,7 +377,7 @@ def coerce_property(
         ]
         for prop in additional_properties:
             payload_value = payload.get(prop)
-            if payload_value:
+            if payload_value is not None:
                 payload[prop] = coerce_property(
                     payload_value, additional_properties_schema
                 )

--- a/tests/integration_tests/utils/test_parsing_utils_integration.py
+++ b/tests/integration_tests/utils/test_parsing_utils_integration.py
@@ -119,3 +119,81 @@ float_schema = {"type": "number"}
 def test_coerce_types(schema, given, expected):
     coerced_payload = coerce_types(given, schema)
     assert coerced_payload == expected
+
+
+class TestCoercePropertyFalsyValues:
+    """Regression tests: coerce_property must process falsy values (0, False,
+    empty string) rather than skipping them."""
+
+    def test_zero_integer_is_coerced(self):
+        """Integer 0 in payload should still be coerced to target type."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "count": {"type": "string"},
+            },
+        }
+        payload = {"count": 0}
+        result = coerce_types(payload, schema)
+        assert result == {"count": "0"}
+
+    def test_false_boolean_is_coerced(self):
+        """Boolean False in payload should still be coerced to target type."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "flag": {"type": "string"},
+            },
+        }
+        payload = {"flag": False}
+        result = coerce_types(payload, schema)
+        assert result == {"flag": "False"}
+
+    def test_empty_string_is_coerced(self):
+        """Empty string in payload should still be coerced to target type."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "integer"},
+            },
+        }
+        # int("") raises ValueError, coerce() returns original value
+        payload = {"name": ""}
+        result = coerce_types(payload, schema)
+        assert result == {"name": ""}
+
+    def test_zero_float_is_coerced(self):
+        """Float 0.0 in payload should still be coerced to target type."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "score": {"type": "string"},
+            },
+        }
+        payload = {"score": 0.0}
+        result = coerce_types(payload, schema)
+        assert result == {"score": "0.0"}
+
+    def test_additional_properties_falsy_values(self):
+        """Falsy values in additional properties should also be coerced."""
+        schema = {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": {"type": "string"},
+        }
+        payload = {"count": 0, "flag": False}
+        result = coerce_types(payload, schema)
+        assert result == {"count": "0", "flag": "False"}
+
+    def test_none_is_still_skipped(self):
+        """None values (missing keys) should still be skipped."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "integer"},
+                "age": {"type": "string"},
+            },
+        }
+        payload = {"name": "42"}
+        result = coerce_types(payload, schema)
+        assert result == {"name": 42}


### PR DESCRIPTION
## Summary

Fixes #1603.

`coerce_property()` uses `if payload_value:` to gate type coercion, which causes legitimate falsy values (`0`, `0.0`, `False`, `""`) to be silently skipped.

## Changes

- **`guardrails/utils/parsing_utils.py`**: Replace `if payload_value:` with `if payload_value is not None:` in both the `properties` loop (line 364) and the `additionalProperties` loop (line 380).
- **`tests/integration_tests/utils/test_parsing_utils_integration.py`**: Added `TestCoercePropertyFalsyValues` class with 6 regression tests covering:
  - Integer 0 coerced to string
  - Boolean False coerced to string  
  - Empty string passed to int (graceful fallback)
  - Float 0.0 coerced to string
  - Additional properties with falsy values
  - None values correctly skipped

## Reproduction

```python
from guardrails.utils.parsing_utils import coerce_types

schema = {'type': 'object', 'properties': {'count': {'type': 'string'}}}
print(coerce_types({'count': 0}, schema))
# Before fix: {'count': 0}  (skipped!)
# After fix:  {'count': '0'} (correctly coerced)
```

All existing tests continue to pass.

## AI Disclosure

AI-assisted debugging/initial draft/testing with human review of the diff and test scope (per the contribution workflow).