### PR TITLE
fix(validation): reject non-stream None results consistently

### DIFF
--- a/guardrails/validator_service/async_validator_service.py
+++ b/guardrails/validator_service/async_validator_service.py
@@ -73,6 +73,8 @@ class AsyncValidatorService(ValidatorServiceBase):
         )
 
         if result is None:
+            if not stream:
+                raise RuntimeError(f"Unexpected result type {type(result)}")
             result = PassResult()
         return result
 

--- a/tests/integration_tests/validator_service/test_init.py
+++ b/tests/integration_tests/validator_service/test_init.py
@@ -5,6 +5,7 @@ import pytest
 
 from guardrails.validator_service import should_run_sync, get_loop
 from guardrails.classes.history import Iteration
+from guardrails.validator_base import Validator, register_validator
 
 
 try:
@@ -162,6 +163,36 @@ class TestValidate:
 
         SequentialValidatorService.__init__.assert_called_once()
         SequentialValidatorService.validate.assert_called_once()
+
+
+@register_validator(name="tests/returns-none", data_type="string")
+class ReturnsNone(Validator):
+    """A malformed validator: _validate() returns neither Pass nor Fail."""
+
+    def _validate(self, value, metadata):
+        return None
+
+
+@pytest.mark.parametrize("run_sync", ["true", "false"])
+def test_non_stream_none_result_errors_in_both_services(monkeypatch, run_sync):
+    # Both validator services must reject an undocumented non-stream result
+    # type rather than one of them promoting it to a pass.
+    monkeypatch.setenv("GUARDRAILS_RUN_SYNC", run_sync)
+
+    from guardrails.validator_service import validate
+
+    iteration = Iteration(
+        call_id="mock_call_id",
+        index=0,
+    )
+
+    with pytest.raises(RuntimeError, match="Unexpected result type"):
+        validate(
+            value="value",
+            metadata={},
+            validator_map={"$": [ReturnsNone()]},
+            iteration=iteration,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/validator_service/test_async_validator_service.py
+++ b/tests/unit_tests/validator_service/test_async_validator_service.py
@@ -775,19 +775,40 @@ class TestRunValidatorAsync:
         )
 
     @pytest.mark.asyncio
-    async def test_result_is_none(self, mocker):
+    async def test_non_stream_result_is_none_raises(self, mocker):
         mock_validator = MagicMock(spec=Validator)
 
-        validation_result = None
         mock_execute_validator = mocker.patch.object(
-            avs, "execute_validator", return_value=validation_result
+            avs, "execute_validator", return_value=None
+        )
+
+        with pytest.raises(RuntimeError, match="Unexpected result type"):
+            await avs.run_validator_async(
+                validator=mock_validator,
+                value="value",
+                metadata={},
+                stream=False,
+                validation_session_id="mock-session",
+            )
+
+        assert mock_execute_validator.call_count == 1
+        mock_execute_validator.assert_called_once_with(
+            mock_validator, "value", {}, False, validation_session_id="mock-session"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_result_is_none_still_passes(self, mocker):
+        mock_validator = MagicMock(spec=Validator)
+
+        mock_execute_validator = mocker.patch.object(
+            avs, "execute_validator", return_value=None
         )
 
         result = await avs.run_validator_async(
             validator=mock_validator,
             value="value",
             metadata={},
-            stream=False,
+            stream=True,
             validation_session_id="mock-session",
         )
 
@@ -795,5 +816,5 @@ class TestRunValidatorAsync:
 
         assert mock_execute_validator.call_count == 1
         mock_execute_validator.assert_called_once_with(
-            mock_validator, "value", {}, False, validation_session_id="mock-session"
+            mock_validator, "value", {}, True, validation_session_id="mock-session"
         )


### PR DESCRIPTION
## Summary

- Reject a non-stream validator result of `None` in the default async service instead of synthesizing `PassResult`.
- Align default and forced-sync behavior for invalid non-stream result types.
- Preserve streaming accumulation behavior.
- Add public-path service-parity coverage.

## Problem

`AsyncValidatorService.run_validator_async` currently converts every `None` result to `PassResult`. For non-stream validation this conflicts with the documented `ValidationResult` return contract and differs from the sequential service, which raises for `NoneType`.

This can make an accidentally incomplete custom validator pass under the default service while the same validator errors when `GUARDRAILS_RUN_SYNC=true`.

## Reproduce

```python
from guardrails import Guard
from guardrails.validator_base import Validator, register_validator


@register_validator(name="repro/returns-none", data_type="string")
class ReturnsNone(Validator):
    def _validate(self, value, metadata):
        return None


print(Guard().use(ReturnsNone()).validate("act"))
```

```bash
OTEL_SDK_DISABLED=true python reproduce.py
GUARDRAILS_RUN_SYNC=true OTEL_SDK_DISABLED=true python reproduce.py
```

On `main` at `96283538`, the first run reports `validation_passed=True`; the second raises `RuntimeError: Unexpected result type <class 'NoneType'>`.

## Contract and compatibility

The validator API documents non-stream `validate()` as returning `ValidationResult`; only `validate_stream()` is optional and documents `None` while accumulating chunks.

This fallback is not new. It existed in the 2023 validator-service design, was explicitly restored by `768b1eab`, and is covered by the current `test_result_is_none`. This PR intentionally narrows that compatibility behavior rather than treating it as an accidental new regression:

- `stream=True`: preserve the existing `None -> PassResult` accumulator path;
- non-stream: match the sequential service's existing invalid-result error.

This also gives the default and forced-sync services the same result for the same invalid non-stream validator. I am happy to retarget this to the 1.0 work in #1591 or revise it to a warning/deprecation path if non-stream `None` is still considered supported behavior.

This is intentionally a narrow current-line parity fix. It does not attempt to resolve the broader 1.0 validator ABI questions in #1591.

## Scope

This change is limited to non-stream `None`. It does not change streaming accumulation, no-validator behavior, normal pass/fail aggregation, or correction policy.

One validator per malformed return type, same value, both services, before and after — `None` is the only row that differs between services, and the only row this patch moves:

| `_validate()` returns | async (before) | sync (before) | async (after) | sync (after) |
|---|---|---|---|---|
| `None` | **passes** | `RuntimeError` | `RuntimeError` | `RuntimeError` |
| `True` / `dict` / `str` | `AttributeError` | `AttributeError` | `AttributeError` | `AttributeError` |
| `FailResult(...)` | `ValidationError` | `ValidationError` | `ValidationError` | `ValidationError` |
| `PassResult()` | passes | passes | passes | passes |

## Verification

- [x] validator-service unit and integration suites — 42 passed, 1 skipped
- [x] Ruff check and format-check across `guardrails/` and `tests/`
- [x] Pyright — no new findings versus baseline
- [x] Reverting the production hunk fails the two new tests, and leaves the forced-sync and streaming cases green

I could not run `tests/unit_tests/cli/` locally — those tests reach the Hub over the network — and `pyright guardrails/` already reports pre-existing errors on `main`, so I compared against baseline rather than to zero. Happy to adjust if CI surfaces anything.
