### PR TITLE
fix: coerce_property drops legitimate falsy values in oneOf/anyOf composition

### DIFF
--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -327,14 +327,18 @@ def coerce_property(
         possible_values = []
         for sub_schema in one_of:
             possible_values.append(coerce_property(payload, sub_schema))
-            payload = safe_get(list(filter(None, possible_values)), 0, payload)
+            payload = safe_get(
+                [v for v in possible_values if v is not None], 0, payload
+            )
 
     any_of = schema.get("anyOf")
     if any_of:
         possible_values = []
         for sub_schema in any_of:
             possible_values.append(coerce_property(payload, sub_schema))
-            payload = safe_get(list(filter(None, possible_values)), 0, payload)
+            payload = safe_get(
+                [v for v in possible_values if v is not None], 0, payload
+            )
 
     all_of: List[Dict[str, Any]] = schema.get("allOf", [])
     if all_of:

--- a/tests/unit_tests/utils/test_parsing_utils.py
+++ b/tests/unit_tests/utils/test_parsing_utils.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from guardrails.utils.parsing_utils import (
+    coerce_property,
     get_code_block,
     has_code_block,
     prune_extra_keys,
@@ -191,3 +192,30 @@ with open(
 def test_prune_extra_keys(schema, payload, pruned_payload):
     actual = prune_extra_keys(payload, schema)
     assert actual == pruned_payload
+
+
+class TestCoercePropertySchemaCompositionFalsyValues:
+    """Regression tests: oneOf/anyOf schema composition in coerce_property must
+    keep a sub-schema's coerced result even when it's falsy (0, 0.0, ""),
+    rather than treating it as "no match" and falling through to a later,
+    non-matching sub-schema.
+    """
+
+    def test_one_of_picks_falsy_int_over_string(self):
+        schema = {"oneOf": [{"type": "integer"}, {"type": "string"}]}
+        result = coerce_property("0", schema)
+        assert result == 0
+        assert isinstance(result, int)
+
+    def test_any_of_picks_falsy_float_over_string(self):
+        schema = {"anyOf": [{"type": "number"}, {"type": "string"}]}
+        result = coerce_property("0.0", schema)
+        assert result == 0.0
+        assert isinstance(result, float)
+
+    def test_one_of_still_falls_through_on_none(self):
+        # A sub-schema that legitimately yields None (SimpleTypes.NULL) must
+        # still be skipped in favor of a later, non-null match.
+        schema = {"oneOf": [{"type": "null"}, {"type": "string"}]}
+        result = coerce_property("hello", schema)
+        assert result == "hello"


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in `coerce_property()`'s `oneOf`/`anyOf` schema-composition handling: it picks the winning sub-schema result via `safe_get(list(filter(None, possible_values)), 0, payload)`. `filter(None, ...)` drops *every* falsy value (`0`, `0.0`, `""`, `False`), not just `None` — so when an earlier sub-schema legitimately coerces the payload to a falsy value, that correct result is silently discarded in favor of a later, non-matching sub-schema's result (or the original, un-coerced payload).

Example: `coerce_property("0", {"oneOf": [{"type": "integer"}, {"type": "string"}]})` should coerce the string `"0"` to the int `0` via the first (matching) sub-schema, but instead returns the string `"0"` — the correct int result was computed, then thrown away.

This is the same bug class recently fixed in the sibling `properties`/`additionalProperties` loops in #1604 (`if payload_value:` → `if payload_value is not None:`), which does not touch this `oneOf`/`anyOf` code — so #1604 doesn't fix or overlap with this PR.

### Fix

Filter on `v is not None` instead of truthiness in both the `oneOf` and `anyOf` branches, matching #1604's exact pattern. This still correctly skips a sub-schema that legitimately yields `None` (e.g. a `{"type": "null"}` branch) — it just no longer skips other falsy-but-valid results (`0`, `0.0`, `""`, `False`).

### How was this tested?

- Reproduced the bug directly against unpatched `main` with two standalone scripts (`oneOf` int/string case, `anyOf` number/string case), confirmed the falsy result was dropped in both.
- Added `TestCoercePropertySchemaCompositionFalsyValues` (3 tests) to `tests/unit_tests/utils/test_parsing_utils.py`: one confirming `oneOf` keeps a falsy int, one confirming `anyOf` keeps a falsy float, and a sanity test confirming a legitimate `None` result is still correctly skipped. Confirmed the first two fail against unpatched `parsing_utils.py` (`git stash`) with the exact wrong-type/wrong-value result described above, and pass after the fix.
- `pytest tests/unit_tests/utils/test_parsing_utils.py` — 15 passed (was 12 before this PR).
- `pytest tests/unit_tests/` — 695 passed, 1 pre-existing unrelated failure (`test_guard.py::TestConfigureExtended::test_configure_with_both_parameters`, confirmed failing identically on clean `main` before this change, unrelated to `parsing_utils.py`), 31 skipped — same as baseline.
- `make lint` — clean. `make type` — 33 pre-existing `pyright` errors from optional integrations not installed under a `dev`-only extras install (`torch`, `mlflow`, `llama_index`, `sqlalchemy`, `faiss`, `numpy`), none in `parsing_utils.py`, confirmed identical on clean `main`.

### Related

Related to (does not conflict with, touches a different code path than) #1604.