### PR TITLE
fix: preserve falsy server validation outputs

### DIFF
--- a/guardrails/async_guard.py
+++ b/guardrails/async_guard.py
@@ -504,7 +504,7 @@ class AsyncGuard(Guard, Generic[OT]):
                 else:
                     validated_output = (
                         cast(OT, validation_output.validated_output)
-                        if validation_output.validated_output
+                        if validation_output.validated_output is not None
                         else None
                     )
                     yield ValidationOutcome[OT](

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -937,7 +937,7 @@ class Guard(IGuard, Generic[OT]):
             # return ValidationOutcome[OT].from_guard_history(call_log)
             validated_output = (
                 cast(OT, validation_output.validated_output)
-                if validation_output.validated_output
+                if validation_output.validated_output is not None
                 else None
             )
             return ValidationOutcome[OT](
@@ -975,7 +975,7 @@ class Guard(IGuard, Generic[OT]):
                 else:
                     validated_output = (
                         cast(OT, validation_output.validated_output)
-                        if validation_output.validated_output
+                        if validation_output.validated_output is not None
                         else None
                     )
                     yield ValidationOutcome[OT](

--- a/tests/unit_tests/test_server_validated_output.py
+++ b/tests/unit_tests/test_server_validated_output.py
@@ -1,0 +1,69 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from guardrails import AsyncGuard, Guard
+from guardrails_ai.types import ValidationOutcome as IValidationOutcome
+
+
+FALSY_OUTPUTS = ["", [], {}]
+
+
+def interface_outcome(validated_output):
+    return IValidationOutcome(
+        callId="call-1",
+        rawLlmOutput="raw output",
+        validatedOutput=validated_output,
+        validationPassed=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def disable_guard_history(monkeypatch):
+    monkeypatch.setitem(os.environ, "GUARD_HISTORY_ENABLED", "false")
+
+
+@pytest.mark.parametrize("validated_output", FALSY_OUTPUTS)
+def test_single_server_call_preserves_falsy_validated_output(validated_output):
+    guard = Guard()
+    guard._use_server = True
+    guard._api_client = MagicMock()
+    guard._api_client.validate.return_value = interface_outcome(validated_output)
+
+    outcome = guard._single_server_call(payload={})
+
+    assert outcome.validated_output == validated_output
+    assert type(outcome.validated_output) is type(validated_output)
+
+
+@pytest.mark.parametrize("validated_output", FALSY_OUTPUTS)
+def test_stream_server_call_preserves_falsy_validated_output(validated_output):
+    guard = Guard()
+    guard._use_server = True
+    guard._api_client = MagicMock()
+    guard._api_client.stream_validate.return_value = iter(
+        [interface_outcome(validated_output)]
+    )
+
+    [outcome] = guard._stream_server_call(payload={})
+
+    assert outcome.validated_output == validated_output
+    assert type(outcome.validated_output) is type(validated_output)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("validated_output", FALSY_OUTPUTS)
+async def test_async_stream_server_call_preserves_falsy_validated_output(
+    validated_output,
+):
+    guard = AsyncGuard()
+    guard._api_client = MagicMock()
+    guard._api_client.stream_validate.return_value = iter(
+        [interface_outcome(validated_output)]
+    )
+
+    outcomes = [outcome async for outcome in guard._stream_server_call(payload={})]
+
+    assert outcomes[0].validated_output == validated_output
+    assert type(outcomes[0].validated_output) is type(validated_output)


### PR DESCRIPTION
## Summary

- preserve valid empty strings, lists, and dictionaries returned by server-side validation
- apply the fix consistently to synchronous single-call, synchronous streaming, and asynchronous streaming paths
- add parameterized regression coverage for every affected path

## Root cause

The server adapters used a truthiness check for `validated_output`, so valid JSON-compatible results such as `""`, `[]`, and `{}` were converted to `None`. Only `None` means that no validated output was returned.

## Related work

#1606 addresses dropped wire fields through a shared adapter, but currently retains the same falsy-value collapse. If it merges first, its adapter condition should likewise distinguish `None` from valid falsy output.

## Tests

- `python -m pytest tests/unit_tests/test_server_validated_output.py -q` (9 passed)
- `ruff check guardrails tests`
- `ruff format --check guardrails tests`
- `pyright --pythonpath .venv/Scripts/python.exe guardrails/guard.py guardrails/async_guard.py`
