### PR TITLE
Move langchain-core to an optional extra

### DIFF
--- a/guardrails/classes/__init__.py
+++ b/guardrails/classes/__init__.py
@@ -1,5 +1,4 @@
 from guardrails.classes.rc import RC
-from guardrails.classes.input_type import InputType
 from guardrails.classes.output_type import OT
 from guardrails.classes.validation.validation_result import (
     ValidationResult,
@@ -12,7 +11,6 @@ from guardrails.classes.validation_outcome import ValidationOutcome
 __all__ = [
     "RC",
     "ErrorSpan",
-    "InputType",
     "OT",
     "ValidationResult",
     "PassResult",

--- a/guardrails/classes/input_type.py
+++ b/guardrails/classes/input_type.py
@@ -1,5 +1,0 @@
-from typing import TypeVar
-
-from langchain_core.messages import BaseMessage
-
-InputType = TypeVar("InputType", str, BaseMessage)

--- a/guardrails/guard.py
+++ b/guardrails/guard.py
@@ -4,6 +4,7 @@ import os
 import uuid
 from builtins import id as object_id
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -17,7 +18,9 @@ from typing import (
     Iterable,
 )
 import warnings
-from langchain_core.runnables import Runnable
+
+if TYPE_CHECKING:
+    from langchain_core.runnables import Runnable
 
 from guardrails_ai.types import (
     Guard as IGuard,
@@ -1067,7 +1070,7 @@ class Guard(IGuard, Generic[OT]):
             )
             raise e
 
-    def to_runnable(self) -> Runnable:
+    def to_runnable(self) -> "Runnable":
         """Convert a Guard to a LangChain Runnable."""
         from guardrails.integrations.langchain.guard_runnable import GuardRunnable
 

--- a/guardrails/integrations/langchain/base_runnable.py
+++ b/guardrails/integrations/langchain/base_runnable.py
@@ -1,10 +1,11 @@
 from copy import deepcopy
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, TypeVar, Union, cast
 import json
 from langchain_core.messages import BaseMessage
 from langchain_core.runnables import Runnable, RunnableConfig
-from guardrails.classes.input_type import InputType
 from guardrails.classes.output_type import OT
+
+InputType = TypeVar("InputType", str, BaseMessage)
 
 
 class BaseRunnable(Runnable):

--- a/guardrails/validator_base.py
+++ b/guardrails/validator_base.py
@@ -13,12 +13,24 @@ from collections import defaultdict
 from dataclasses import dataclass
 import re
 from string import Template
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+)
 from warnings import warn
 
 import requests
 from guardrails.hub.registry import get_registry
-from langchain_core.runnables import Runnable
+
+if TYPE_CHECKING:
+    from langchain_core.runnables import Runnable
 
 from guardrails.settings import settings
 from guardrails_ai.types import ErrorSpan, PassResult, FailResult, ValidationResult  # noqa
@@ -499,7 +511,7 @@ class Validator:
         self._metadata = metadata
         return self
 
-    def to_runnable(self) -> Runnable:
+    def to_runnable(self) -> "Runnable":
         from guardrails.integrations.langchain.validator_runnable import (
             ValidatorRunnable,
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -3011,9 +3011,10 @@ files = [
 name = "jsonpatch"
 version = "1.33"
 description = "Apply JSON-Patches (RFC 6902)"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
 groups = ["main"]
+markers = "extra == \"langchain\""
 files = [
     {file = "jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade"},
     {file = "jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c"},
@@ -3255,9 +3256,10 @@ files = [
 name = "langchain-core"
 version = "1.4.8"
 description = "Building applications with LLMs through composability"
-optional = false
+optional = true
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
+markers = "extra == \"langchain\""
 files = [
     {file = "langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa"},
     {file = "langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a"},
@@ -3278,9 +3280,10 @@ uuid-utils = ">=0.12.0,<1.0"
 name = "langchain-protocol"
 version = "0.0.18"
 description = "Python bindings for the LangChain agent streaming protocol"
-optional = false
+optional = true
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
+markers = "extra == \"langchain\""
 files = [
     {file = "langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a"},
     {file = "langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6"},
@@ -3293,9 +3296,10 @@ typing-extensions = ">=4.13.0,<5.0.0"
 name = "langsmith"
 version = "0.8.18"
 description = "Client library to connect to the LangSmith Observability and Evaluation Platform."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"langchain\""
 files = [
     {file = "langsmith-0.8.18-py3-none-any.whl", hash = "sha256:3940183349993faef48e6c7d08e4822ee9cefd906b362d0e3c2d650314d2f282"},
     {file = "langsmith-0.8.18.tar.gz", hash = "sha256:32dde9c0e67e053e0fb738921fc8ced768af7b8fa83d7a0e3fd63597cf8776dd"},
@@ -5125,10 +5129,10 @@ typing-extensions = ">=4.5.0"
 name = "orjson"
 version = "3.11.9"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "platform_python_implementation != \"PyPy\""
+markers = "platform_python_implementation != \"PyPy\" and extra == \"langchain\""
 files = [
     {file = "orjson-3.11.9-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:135869ef917b8704ea0a94e01620e0c05021c15c52036e4663baffe75e72f8ce"},
     {file = "orjson-3.11.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:115ab5f5f4a0f203cc2a5f0fb09aee503a3f771aa08392949ab5ca230c4fbdbd"},
@@ -6707,9 +6711,10 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 name = "requests-toolbelt"
 version = "1.0.0"
 description = "A utility belt for advanced users of python-requests"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 groups = ["main"]
+markers = "extra == \"dev\" or extra == \"langchain\""
 files = [
     {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
     {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
@@ -8383,9 +8388,10 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 name = "uuid-utils"
 version = "0.16.2"
 description = "Fast, drop-in replacement for Python's uuid module, powered by Rust."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"langchain\""
 files = [
     {file = "uuid_utils-0.16.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:89a627f74cb55aa508809592ab9149806649e4ee37f4bc91b60c7ec10929f0eb"},
     {file = "uuid_utils-0.16.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e92875a315f3cc4fe7a2324c17b3c7ac5e3fd0e24b14fc4deb28370431fe6a2b"},
@@ -8678,9 +8684,10 @@ files = [
 name = "websockets"
 version = "16.0"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"langchain\""
 files = [
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a"},
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0"},
@@ -8872,9 +8879,10 @@ dev = ["pytest", "setuptools"]
 name = "xxhash"
 version = "3.7.0"
 description = "Python binding for xxHash"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"manifest\" or extra == \"langchain\""
 files = [
     {file = "xxhash-3.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd8ab85c916a58d5c8656ea15e3ce9df836fe2f120a74c296e01d69fab2614b4"},
     {file = "xxhash-3.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:85f5c0e26d945b5bb475e0a3d95193117498130baa7619357bdc7869c2391b5a"},
@@ -9225,9 +9233,10 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 name = "zstandard"
 version = "0.25.0"
 description = "Zstandard bindings for Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"langchain\""
 files = [
     {file = "zstandard-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e59fdc271772f6686e01e1b3b74537259800f57e24280be3f29c8a0deb1904dd"},
     {file = "zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d441506e9b372386a5271c64125f72d5df6d2a8e8a2a45a0ae09b03cb781ef7"},
@@ -9340,6 +9349,7 @@ databricks = ["mlflow"]
 dev = ["docformatter", "liccheck", "lxml-stubs", "pre-commit", "pypdfium2", "pyright", "pytest", "pytest-asyncio", "pytest-cov", "pytest-mock", "ruff", "twine"]
 docs-build = ["docspec_python", "pydoc-markdown"]
 huggingface = ["guardrails-jsonformer", "torch", "transformers"]
+langchain = ["langchain-core"]
 llama = ["llama-index"]
 manifest = ["manifest-ml"]
 sql = ["sqlalchemy", "sqlglot", "sqlvalidator"]
@@ -9349,4 +9359,4 @@ vectordb = ["faiss-cpu", "numpy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "b6003a268b3bac0c2ca909f86589c4c899efae6a6da4c0d71a4771e0d8b8b149"
+content-hash = "cdad8c46f0467f04c73c381d2460144f7ad0430b8cf974c32d9771bb99efef28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "tiktoken>=0.13.0,<1.0.0",
     "litellm>=1.82.5,<2.0.0",
     "pydash>=8.0.0,<9.0.0",
-    "langchain-core>=1.0.0,<2.0",
     "requests>=2.31.0,<3.0.0",
     "faker>=25.2.0,<38.0.0",
     "jsonref>=1.0.0,<2.0.0",
@@ -97,6 +96,9 @@ uv = [
 ]
 llama = [
     "llama-index>=0.14.22,<1.0.0"
+]
+langchain = [
+    "langchain-core>=1.0.0,<2.0"
 ]
 
 [project.scripts]

--- a/tests/unit_tests/test_optional_langchain_dependency.py
+++ b/tests/unit_tests/test_optional_langchain_dependency.py
@@ -1,0 +1,73 @@
+"""guardrails must import and construct a Guard without langchain-core installed.
+
+langchain-core moved from a core dependency to the `langchain` extra (see
+`Guard.to_runnable` / `Validator.to_runnable`), so `import guardrails` cannot
+require it. These checks run in a subprocess with langchain_core's import
+blocked, since the package is genuinely installed in the test environment
+(via the `langchain` extra) and any eager top-level import would otherwise
+go unnoticed here.
+"""
+
+import subprocess
+import sys
+import textwrap
+from typing import TypeVar
+
+import guardrails.classes as classes
+from guardrails.integrations.langchain.base_runnable import InputType
+
+
+def _run_with_langchain_core_blocked(script: str) -> subprocess.CompletedProcess:
+    setup = """
+        import builtins
+
+        _real_import = builtins.__import__
+
+        def _blocked_import(name, *args, **kwargs):
+            if name == "langchain_core" or name.startswith("langchain_core."):
+                raise ModuleNotFoundError(f"No module named {name!r}")
+            return _real_import(name, *args, **kwargs)
+
+        builtins.__import__ = _blocked_import
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(setup) + textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_guard_import_and_construction_without_langchain_core():
+    result = _run_with_langchain_core_blocked(
+        """
+        from guardrails import Guard
+        Guard()
+        print("OK")
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_to_runnable_still_raises_clearly_without_langchain_core():
+    result = _run_with_langchain_core_blocked(
+        """
+        from guardrails import Guard
+        try:
+            Guard().to_runnable()
+        except ModuleNotFoundError:
+            print("RAISED")
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "RAISED" in result.stdout
+
+
+def test_input_type_no_longer_exported_from_classes():
+    assert not hasattr(classes, "InputType")
+    assert "InputType" not in classes.__all__
+
+
+def test_input_type_lives_with_its_only_consumer():
+    assert isinstance(InputType, TypeVar)
+    assert InputType.__constraints__[0] is str


### PR DESCRIPTION
Closes #1596

`import guardrails` currently hard-requires `langchain-core`, even for
people who never touch the LangChain integration. `langchain-core` is a
core dependency in `pyproject.toml`, but the only things that actually
need it are `Guard.to_runnable()` / `Validator.to_runnable()`, and both
already build the real `Runnable` behind a lazy import inside the method
body. The dependency only became mandatory because three type
annotations imported `langchain_core` eagerly at module load:

- `guard.py:20` - `Runnable` used only as `to_runnable()`'s return type
- `validator_base.py:21` - same, for `Validator.to_runnable()`
- `classes/input_type.py` - `InputType = TypeVar("InputType", str, BaseMessage)`,
  whose only consumer is `integrations/langchain/base_runnable.py`

None of this is needed at import time.

## Changes

- `guard.py` / `validator_base.py`: move the `Runnable` import under
  `TYPE_CHECKING` and quote the `to_runnable()` return annotation. No
  behavior change - `to_runnable()` still does its own lazy import and
  raises the same way if `langchain-core` is missing.
- Moved `InputType` out of `guardrails/classes` and into
  `guardrails/integrations/langchain/base_runnable.py`, the only place
  that uses it, instead of a shared module that forced every `import
  guardrails` to pull in `langchain_core.messages`. It's no longer
  re-exported from `guardrails.classes.__all__` - a small public API
  removal, worth flagging in release notes since it was previously
  reachable as `from guardrails.classes import InputType`.
- `pyproject.toml`: dropped `langchain-core` from the core dependency
  list and added a `langchain` extra, matching how `llama` and
  `databricks` are already handled. Regenerated `poetry.lock`
  (`poetry lock`) so it reflects the new extra - only `langchain-core`
  and its transitive deps flip to optional.

## Testing

- Added `tests/unit_tests/test_optional_langchain_dependency.py`:
  - two subprocess-based checks that block `langchain_core` at import
    time and confirm `import guardrails` / `Guard()` still work, and
    that `Guard().to_runnable()` still raises a clear error when the
    package genuinely isn't there
  - a check that `InputType` is gone from `guardrails.classes`
  - a check that it now lives correctly in
    `integrations/langchain/base_runnable.py`
- `make lint` and `make type` both pass with no new issues.
- `make test` - full suite is green aside from one failure
  (`TestConfigureExtended::test_configure_with_both_parameters`) that
  I confirmed also fails on a clean `main` checkout, so it's unrelated
  to this change.
- Ran the existing LangChain integration tests
  (`tests/integration_tests/integrations/langchain/`) with the
  `langchain` extra installed - all pass unchanged.