### PR TITLE
Fix boolean coercion turning the string "false" into True

### DIFF
--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -288,9 +288,20 @@ def coerce_to_type(
             return coerce(payload, list)
         return payload
     elif schema_type == SimpleTypes.BOOLEAN:
-        if not isinstance(payload, bool):
-            return coerce(payload, bool)
-        return payload
+        if isinstance(payload, bool):
+            return payload
+        if isinstance(payload, str):
+            # bool("false") is True (every non-empty string is truthy), so a
+            # boolean the model emitted as a string was always coerced to True.
+            # Interpret the common textual forms instead, and leave anything
+            # unrecognized untouched like the integer and number branches do.
+            normalized = payload.strip().lower()
+            if normalized in ("true", "1"):
+                return True
+            if normalized in ("false", "0"):
+                return False
+            return payload
+        return coerce(payload, bool)
     elif schema_type == SimpleTypes.INTEGER:
         if not isinstance(payload, int):
             val = coerce(payload, int)

--- a/tests/integration_tests/utils/test_parsing_utils_integration.py
+++ b/tests/integration_tests/utils/test_parsing_utils_integration.py
@@ -23,6 +23,7 @@ with open(
 string_schema = {"type": "string"}
 integer_schema = {"type": "integer"}
 float_schema = {"type": "number"}
+boolean_schema = {"type": "boolean"}
 
 
 @pytest.mark.parametrize(
@@ -37,6 +38,15 @@ float_schema = {"type": "number"}
         (integer_schema, "3", 3),
         (integer_schema, 3.1, 3),
         (float_schema, "3", 3.0),
+        # A boolean the model emitted as a string must be read by its text, not
+        # by truthiness; bool("false") is True, which silently flipped the value
+        (boolean_schema, "false", False),
+        (boolean_schema, "False", False),
+        (boolean_schema, "true", True),
+        (boolean_schema, "0", False),
+        (boolean_schema, False, False),
+        (boolean_schema, True, True),
+        (boolean_schema, "maybe", "maybe"),  # unrecognized: left untouched
         (
             choice_case_json_schema,
             {


### PR DESCRIPTION
`coerce_to_type` mis-coerces a boolean field that a model returns as a string:

```python
from guardrails.utils.parsing_utils import coerce_to_type
from guardrails.types import SimpleTypes

coerce_to_type("false", SimpleTypes.BOOLEAN)  # -> True
coerce_to_type("0", SimpleTypes.BOOLEAN)      # -> True
```

The boolean branch runs string payloads through `bool()`, and `bool("false")` is `True` because every non-empty string is truthy. So a boolean the model emitted as a string (`"false"`, `"False"`, `"0"`, `"no"`, `"off"`) was always coerced to `True`, silently flipping the value in the structured output, which is the opposite of what a coercion/validation layer should do.

The fix reads the common textual forms (`true`/`false`/`1`/`0`, case-insensitive, trimmed) and leaves anything unrecognized untouched, the same way the `integer` and `number` branches already leave unparseable strings unchanged. Actual bools and numeric payloads are unaffected. Added boolean cases to `test_coerce_types`.