### PR TITLE
fix: coerce falsy property values instead of skipping them

### DIFF
--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -361,7 +361,7 @@ def coerce_property(
     if properties and isinstance(payload, dict):
         for k, v in properties.items():
             payload_value = payload.get(k)
-            if payload_value:
+            if payload_value is not None:
                 payload[k] = coerce_property(payload_value, v)
 
     ### Object Additional Properties ###
@@ -377,7 +377,7 @@ def coerce_property(
         ]
         for prop in additional_properties:
             payload_value = payload.get(prop)
-            if payload_value:
+            if payload_value is not None:
                 payload[prop] = coerce_property(
                     payload_value, additional_properties_schema
                 )

--- a/tests/integration_tests/utils/test_parsing_utils_integration.py
+++ b/tests/integration_tests/utils/test_parsing_utils_integration.py
@@ -114,6 +114,21 @@ float_schema = {"type": "number"}
                 },
             },
         ),
+        (
+            {"type": "object", "properties": {"count": {"type": "string"}}},
+            {"count": 0},
+            {"count": "0"},
+        ),
+        (
+            {"type": "object", "properties": {"flag": {"type": "string"}}},
+            {"flag": False},
+            {"flag": "False"},
+        ),
+        (
+            {"type": "object", "additionalProperties": {"type": "string"}},
+            {"flag": False},
+            {"flag": "False"},
+        ),
     ],
 )
 def test_coerce_types(schema, given, expected):


### PR DESCRIPTION
## Problem

`coerce_property()` used truthiness checks (`if payload_value:`) to decide whether to recurse into property values, so legitimate falsy values — `0`, `0.0`, `False`, and `""` — were silently skipped during type coercion and left uncoerced, causing downstream validation failures or type mismatches for LLM-generated JSON.

Fixes #1603.

## Fix

Replaced `if payload_value:` with `if payload_value is not None:` in both the `properties` loop and the `additionalProperties` loop of `guardrails/utils/parsing_utils.py`.

## Test

Three regression cases added to `test_coerce_types` in `tests/integration_tests/utils/test_parsing_utils_integration.py`:

- `{"count": 0}` coerces to `{"count": "0"}` under a string property schema
- `{"flag": False}` coerces to `{"flag": "False"}` under a string property schema
- `{"flag": False}` coerces to `{"flag": "False"}` under an `additionalProperties` string schema

```
python3 -m pytest tests/integration_tests/utils/test_parsing_utils_integration.py -q
11 passed
```

`ruff check` and `ruff format` (v0.13.0) are clean on both changed files.
