### PR TITLE
fix: coerce string booleans correctly in coerce_to_type

### DIFF
--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -289,6 +289,12 @@ def coerce_to_type(
         return payload
     elif schema_type == SimpleTypes.BOOLEAN:
         if not isinstance(payload, bool):
+            if isinstance(payload, str):
+                lowered = payload.strip().lower()
+                if lowered in ("false", "0", "no"):
+                    return False
+                if lowered in ("true", "1", "yes"):
+                    return True
             return coerce(payload, bool)
         return payload
     elif schema_type == SimpleTypes.INTEGER:

--- a/tests/integration_tests/utils/test_parsing_utils_integration.py
+++ b/tests/integration_tests/utils/test_parsing_utils_integration.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from guardrails.utils.parsing_utils import coerce_types
+from guardrails.utils.parsing_utils import coerce_to_type, coerce_types
 
 
 with open(
@@ -119,3 +119,27 @@ float_schema = {"type": "number"}
 def test_coerce_types(schema, given, expected):
     coerced_payload = coerce_types(given, schema)
     assert coerced_payload == expected
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        (False, False),
+        (True, True),
+        (0, False),
+        (1, True),
+        ("maybe", True),
+    ],
+)
+def test_coerce_to_type_boolean_strings(payload, expected):
+    from guardrails.types.simple import SimpleTypes
+
+    assert coerce_to_type(payload, SimpleTypes.BOOLEAN) is expected


### PR DESCRIPTION
## Problem

`coerce_to_type()` used Python `bool()` for BOOLEAN schema types, so any non-empty string coerced to `True`. An LLM returning the string `"false"`, `"0"`, or `"no"` for a boolean field was silently validated as `True`.

Fixes #1559.

## Fix

The BOOLEAN branch now parses the common string spellings explicitly before falling back to `coerce(payload, bool)`: `false`/`0`/`no` map to `False`, `true`/`1`/`yes` map to `True` (case-insensitive, whitespace-trimmed). Non-string payloads and unrecognised strings keep the previous behaviour.

## Test

`test_coerce_to_type_boolean_strings` in `tests/integration_tests/utils/test_parsing_utils_integration.py` parametrises 13 cases: the six string spellings in both polarities, bool and int passthrough, and an unrecognised string falling back to `bool()`.

```
python3 -m pytest tests/integration_tests/utils/test_parsing_utils_integration.py -q
21 passed
```

`ruff check` and `ruff format` (v0.13.0) are clean on both changed files.
