### PR TITLE
fix: throttle the SQLite trace DELETE with TIME_BETWEEN_CLEANUPS

### DIFF
--- a/guardrails/call_tracing/sqlite_trace_handler.py
+++ b/guardrails/call_tracing/sqlite_trace_handler.py
@@ -125,15 +125,15 @@ class SQLiteTraceHandler(TracerMixin):
         now = time.time()
         if force or (now - self.last_cleanup > TIME_BETWEEN_CLEANUPS):
             self.last_cleanup = now
-        self.db.execute(
-            """
-            DELETE FROM guard_logs 
-            WHERE id < (
-                SELECT id FROM guard_logs ORDER BY id DESC LIMIT 1 OFFSET ?  
-            );
-            """,
-            (keep_n,),
-        )
+            self.db.execute(
+                """
+                DELETE FROM guard_logs 
+                WHERE id < (
+                    SELECT id FROM guard_logs ORDER BY id DESC LIMIT 1 OFFSET ?  
+                );
+                """,
+                (keep_n,),
+            )
 
     def log(
         self,

--- a/tests/unit_tests/test_sqlite_trace_handler.py
+++ b/tests/unit_tests/test_sqlite_trace_handler.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from guardrails.call_tracing.sqlite_trace_handler import SQLiteTraceHandler
+
+
+@pytest.fixture
+def handler(tmp_path):
+    handler = SQLiteTraceHandler(tmp_path / "test.db", read_mode=False)
+    handler.db = MagicMock()
+    return handler
+
+
+def test_truncate_is_throttled_within_cleanup_interval(handler):
+    handler._truncate()
+
+    assert handler.db.execute.call_count == 0, (
+        "a DELETE must not run before TIME_BETWEEN_CLEANUPS has elapsed"
+    )
+
+
+def test_truncate_runs_after_interval_elapses(handler):
+    handler.last_cleanup = 0
+
+    handler._truncate()
+
+    assert handler.db.execute.call_count == 1
+
+
+def test_truncate_force_runs_delete(handler):
+    handler._truncate(force=True)
+
+    assert handler.db.execute.call_count == 1


### PR DESCRIPTION
## Problem

`SQLiteTraceHandler._truncate` executed the `DELETE FROM guard_logs` statement outside the `TIME_BETWEEN_CLEANUPS` throttle block, so every `log()`, `log_entry()`, and `log_validator()` call ran a DELETE against the trace database, creating write load on every guard validation.

Fixes #1558.

## Fix

The `self.db.execute(...)` call is now inside the throttle block, so truncation runs only when the interval has elapsed or `force=True`.

## Test

New `tests/unit_tests/test_sqlite_trace_handler.py`:

- a DELETE does not run within the cleanup interval
- a DELETE runs after the interval elapses
- `force=True` runs the DELETE

```
python3 -m pytest tests/unit_tests/test_sqlite_trace_handler.py -q
3 passed
```

`ruff check` and `ruff format` (v0.13.0) clean on both changed files.
