### PR TITLE
[feat] Add native Langfuse observability integration

### DIFF
--- a/docs/how_to_guides/langfuse.md
+++ b/docs/how_to_guides/langfuse.md
@@ -1,0 +1,149 @@
+# Tracing to Langfuse
+
+[Langfuse](https://langfuse.com) is an open-source LLM observability platform.
+Guardrails already emits an OpenTelemetry trace for every guard invocation; this
+integration exports those traces to Langfuse and records validation results as
+Langfuse scores.
+
+## Install
+
+```bash
+pip install "guardrails-ai[langfuse]"
+```
+
+## Configure
+
+Credentials come from the environment:
+
+```bash
+export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+export LANGFUSE_SECRET_KEY="sk-lf-..."
+export LANGFUSE_BASE_URL="https://cloud.langfuse.com"   # EU region (default)
+```
+
+Other regions are `https://us.cloud.langfuse.com`, `https://jp.cloud.langfuse.com`
+and `https://hipaa.cloud.langfuse.com`. Self-hosted Langfuse needs v3.22.0 or
+newer, which is when the OpenTelemetry endpoint was introduced.
+
+## Use
+
+```python
+from guardrails import Guard
+from guardrails.integrations.langfuse import LangfuseInstrumentor
+from guardrails_ai.regex_match import RegexMatch  # pip install guardrails-ai-regex-match
+
+langfuse = LangfuseInstrumentor().instrument()
+
+guard = Guard().use(RegexMatch, regex="^[A-Z][a-z]*$")
+guard(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "What is my name?"}],
+)
+
+langfuse.flush()  # only needed in short-lived processes
+```
+
+`instrument()` returns the `Langfuse` client, which you can use for anything else
+Langfuse offers. Call it once, at startup.
+
+## What you get
+
+A trace named after your guard, with the hierarchy Guardrails already produces:
+
+```
+guard                    (span)       validation_passed, number_of_reasks, ... as trace metadata
+└── step                 (span)
+    ├── call             (generation) model, token usage, cost
+    └── <validator>.validate (guardrail)  WARNING level when validation fails
+```
+
+Validators are typed as Langfuse `guardrail` observations, so they are filterable
+by type and render in the Langfuse **Graph** view alongside the rest of the run.
+
+Only the failing validator span is marked `WARNING`; the guard span is left at
+the default level deliberately, since under `on_fail="fix"` or `"reask"` a
+validator failing and being corrected is normal operation, and flagging every
+trace would make the level meaningless. Failed runs are still findable via the
+`validation_passed` metadata below and the score.
+
+Plus one Langfuse **score** per validator (`guardrails.<validator-name>`, with the
+error message as the comment when it fails) and one for the run overall
+(`guardrails.validation_passed`). Scores are what let you chart validator pass
+rates over time.
+
+`validation_passed`, `number_of_reasks`, `number_of_llm_calls` and `execution_id`
+are promoted to top-level trace metadata, because Langfuse only supports
+filtering on top-level metadata keys. Every trace is tagged `guardrails`, so you
+can segment guard traffic from the rest of your application in the Langfuse UI.
+
+## Attaching a user or session
+
+Use Langfuse's own helper. Guardrails spans are ordinary children of the ambient
+OpenTelemetry context, so no extra wiring is needed:
+
+```python
+from langfuse import propagate_attributes
+
+with propagate_attributes(user_id="user_123", session_id="session_abc"):
+    guard(model="gpt-4o-mini", messages=[...])
+```
+
+Guardrails also reads OpenTelemetry baggage (`user.id`, `organization`, `app`),
+which Langfuse maps natively. Baggage propagates across service boundaries, so
+never put secrets in it.
+
+## Things to know
+
+**Initialize before any other Langfuse client.** Langfuse caches one client per
+public key and returns the cached one on later calls, discarding the export
+filter and mapping hook this integration installs. `LangfuseInstrumentor` raises
+if a client already exists rather than silently dropping your spans. One Langfuse
+project per process is supported.
+
+**Do not configure another OTLP tracer alongside this.**
+`default_otlp_tracer()` and `default_otel_collector_tracer()` both call
+`trace.set_tracer_provider()`, which OpenTelemetry only honours once — whichever
+loses the race is silently ignored.
+
+**Do not combine with `MlFlowInstrumentor`.** It sets
+`settings.disable_tracing = True`, which stops Guardrails emitting the spans this
+integration exports.
+
+**Streaming traces have no token usage or cost.** Guardrails' LLM providers
+return the stream before final-usage telemetry runs, so streaming generations
+carry the model and the correct trace shape but no usage. Non-streaming calls are
+unaffected.
+
+**Redaction is partial.** Guardrails redacts keys containing `key`, `token` or
+`password` in step and call inputs and in `llm.invocation_parameters`, but *not*
+in validator inputs and outputs, nor in the guard span's input. If your prompts
+or validated values carry sensitive data, pass Langfuse's `mask` function:
+
+```python
+def mask(data):
+    ...  # return redacted data
+
+LangfuseInstrumentor(mask=mask).instrument()
+```
+
+Any keyword argument accepted by `Langfuse(...)` can be passed to
+`LangfuseInstrumentor(...)`, except an isolated `tracer_provider` — Guardrails
+takes its tracers from the global provider, so an isolated one would receive no
+Guardrails spans, and the instrumentor rejects it.
+
+**Guardrails' own hub telemetry is unrelated** and unaffected; it is a separate
+pipeline controlled by `guardrails configure`.
+
+## Turning off scores
+
+```python
+LangfuseInstrumentor(emit_validation_scores=False).instrument()
+```
+
+## Debugging
+
+If traces do not appear, set `LANGFUSE_DEBUG=True` and look for dropped-span
+messages naming the instrumentation scope. Guardrails spans use the scopes
+`guardrails-ai` and `guardrails.telemetry.guard_tracing`; both are admitted by
+this integration's export filter. In the Langfuse UI a span's scope appears under
+`metadata.scope.name`.

--- a/guardrails/integrations/langfuse/__init__.py
+++ b/guardrails/integrations/langfuse/__init__.py
@@ -1,0 +1,13 @@
+from guardrails.integrations.langfuse.langfuse_instrumentor import (
+    GUARDRAILS_INSTRUMENTATION_SCOPES,
+    LangfuseInstrumentor,
+    guardrails_mask_otel_spans,
+    guardrails_should_export_span,
+)
+
+__all__ = [
+    "GUARDRAILS_INSTRUMENTATION_SCOPES",
+    "LangfuseInstrumentor",
+    "guardrails_mask_otel_spans",
+    "guardrails_should_export_span",
+]

--- a/guardrails/integrations/langfuse/attribute_mapping.py
+++ b/guardrails/integrations/langfuse/attribute_mapping.py
@@ -1,0 +1,115 @@
+"""Translation of Guardrails span attributes into the Langfuse data model.
+
+Deliberately free of any ``langfuse`` import so the mapping can be unit tested
+without the SDK installed.
+
+Only attributes Langfuse does *not* already understand are mapped here. Langfuse
+natively reads the OpenInference attributes Guardrails emits -- ``input.value`` /
+``output.value`` become the observation input/output, ``llm.model_name`` becomes
+the model, ``llm.token_count.*`` becomes usage, and span status becomes the
+level -- so re-mapping those would be dead code.
+"""
+
+from typing import Any, Dict, Mapping
+
+GUARD = "guardrails/guard"
+STEP = "guardrails/guard/step"
+CALL = "guardrails/guard/step/call"
+VALIDATOR = "guardrails/guard/step/validator"
+
+#: Guardrails' own tracer scopes. Langfuse's default export filter drops any span
+#: that is not a Langfuse span, does not carry ``gen_ai.*`` attributes, and does
+#: not come from a known LLM instrumentation scope -- which is all of ours.
+GUARDRAILS_INSTRUMENTATION_SCOPES = (
+    "guardrails-ai",
+    "guardrails.telemetry.guard_tracing",
+)
+
+_OBSERVATION_TYPE = "langfuse.observation.type"
+_OBSERVATION_LEVEL = "langfuse.observation.level"
+_TRACE_NAME = "langfuse.trace.name"
+_TRACE_TAGS = "langfuse.trace.tags"
+_TRACE_METADATA = "langfuse.trace.metadata"
+
+#: Tag every guard run so Guardrails traffic is filterable in the Langfuse UI
+#: when Guardrails is one component among many.
+_GUARDRAILS_TAG = "guardrails"
+
+#: Guard span attributes promoted to top-level trace metadata. Langfuse only
+#: supports filtering on top-level metadata keys; anything left unmapped lands in
+#: a non-filterable ``metadata.attributes`` catch-all.
+_PROMOTED_GUARD_ATTRIBUTES = (
+    "validation_passed",
+    "number_of_reasks",
+    "number_of_llm_calls",
+    "execution_id",
+)
+
+
+def is_guardrails_scope(scope_name: Any) -> bool:
+    return scope_name in GUARDRAILS_INSTRUMENTATION_SCOPES
+
+
+def validator_failed(attributes: Mapping[str, Any]) -> bool:
+    """Whether a validator span records a failed validation.
+
+    Returns False when the outcome is missing rather than guessing.
+    """
+    return attributes.get("validator.validate.output.outcome") == "fail"
+
+
+def guard_validation_passed(attributes: Mapping[str, Any]) -> Any:
+    """The guard span's validation result, or None when not recorded."""
+    return attributes.get("validation_passed")
+
+
+def map_attributes(attributes: Mapping[str, Any]) -> Dict[str, Any]:
+    """Langfuse attributes to add to a Guardrails span.
+
+    Returns an empty dict for spans this integration does not recognise, which
+    the caller treats as "leave the span unchanged".
+    """
+    span_type = attributes.get("type")
+
+    if span_type == GUARD:
+        return _map_guard(attributes)
+    if span_type == STEP:
+        return {_OBSERVATION_TYPE: "span"}
+    if span_type == CALL:
+        # Typed by what the span *is*, not by whether a model happened to be
+        # recorded -- streaming and model-less providers are still generations.
+        return {_OBSERVATION_TYPE: "generation"}
+    if span_type == VALIDATOR:
+        return _map_validator(attributes)
+    return {}
+
+
+def _map_guard(attributes: Mapping[str, Any]) -> Dict[str, Any]:
+    mapped: Dict[str, Any] = {
+        _OBSERVATION_TYPE: "span",
+        _TRACE_TAGS: [_GUARDRAILS_TAG],
+    }
+
+    guard_name = attributes.get("guard.name")
+    if guard_name:
+        # Every Guardrails trace's root span is named "guard", so without this
+        # every trace looks identical in the Langfuse trace list.
+        mapped[_TRACE_NAME] = str(guard_name)
+
+    for key in _PROMOTED_GUARD_ATTRIBUTES:
+        value = attributes.get(key)
+        if value is not None:
+            mapped[f"{_TRACE_METADATA}.{key}"] = str(value)
+
+    # No level on the guard span even when validation fails: with on_fail="fix"
+    # or "reask" a failure is routine, and flagging every root span would make
+    # the level meaningless. The failing validator span carries the level, and
+    # failed runs stay findable via validation_passed metadata and the score.
+    return mapped
+
+
+def _map_validator(attributes: Mapping[str, Any]) -> Dict[str, Any]:
+    mapped: Dict[str, Any] = {_OBSERVATION_TYPE: "guardrail"}
+    if validator_failed(attributes):
+        mapped[_OBSERVATION_LEVEL] = "WARNING"
+    return mapped

--- a/guardrails/integrations/langfuse/langfuse_instrumentor.py
+++ b/guardrails/integrations/langfuse/langfuse_instrumentor.py
@@ -1,0 +1,180 @@
+"""Sends Guardrails' OpenTelemetry traces to Langfuse.
+
+Guardrails already emits a full trace per guard invocation. This integration
+does not create spans of its own; it makes Langfuse export the existing ones,
+translates a few attributes into the Langfuse data model, and turns validation
+results into scores.
+"""
+
+from typing import Any, Dict, Optional
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+
+try:
+    from langfuse import Langfuse
+    from langfuse._client.resource_manager import LangfuseResourceManager
+    from langfuse.span_filter import is_default_export_span
+    from langfuse.types import (
+        MaskOtelSpansParams,
+        MaskOtelSpansResult,
+        OtelSpanPatch,
+    )
+except ImportError:
+    raise ImportError(
+        "Please install langfuse to use this instrumentor: "
+        'pip install "guardrails-ai[langfuse]"'
+    )
+
+from guardrails.integrations.langfuse.attribute_mapping import (
+    GUARDRAILS_INSTRUMENTATION_SCOPES,
+    is_guardrails_scope,
+    map_attributes,
+)
+from guardrails.integrations.langfuse.score_processor import (
+    GuardrailsScoreSpanProcessor,
+)
+from guardrails.logger import logger
+from guardrails.settings import settings
+
+
+def guardrails_should_export_span(span: ReadableSpan) -> bool:
+    """Export filter that admits Guardrails spans alongside Langfuse's defaults.
+
+    Langfuse's default filter keeps only Langfuse spans, spans carrying
+    ``gen_ai.*`` attributes, and known LLM instrumentation scopes. Guardrails is
+    none of those, so without this every Guardrails span is silently dropped.
+    """
+    scope = span.instrumentation_scope
+    if scope is not None and is_guardrails_scope(scope.name):
+        return True
+    return is_default_export_span(span)
+
+
+def guardrails_mask_otel_spans(
+    *, params: MaskOtelSpansParams
+) -> Optional[MaskOtelSpansResult]:
+    """Adds ``langfuse.*`` attributes to Guardrails spans at export time."""
+    try:
+        patches: Dict[Any, OtelSpanPatch] = {}
+        for identifier, span in params.spans.items():
+            mapped = map_attributes(span.attributes or {})
+            if mapped:
+                patches[identifier] = OtelSpanPatch(set_attributes=mapped)
+        return MaskOtelSpansResult(span_patches=patches)
+    except Exception as e:
+        # Raising here would cost the user the entire export batch, so
+        # enrichment is best-effort: the spans still ship, just unmapped.
+        logger.warning(f"Failed to map Guardrails spans for Langfuse: {e}")
+        return None
+
+
+class LangfuseInstrumentor:
+    """Instruments Guardrails to send traces to Langfuse.
+
+    Credentials are read from ``LANGFUSE_PUBLIC_KEY``, ``LANGFUSE_SECRET_KEY``
+    and ``LANGFUSE_BASE_URL``.
+
+    ```python
+    from guardrails.integrations.langfuse import LangfuseInstrumentor
+
+    langfuse = LangfuseInstrumentor().instrument()
+    ```
+
+    This must run before any other Langfuse client is created for the same
+    public key: Langfuse caches one resource manager per key and returns the
+    existing one on a later call, discarding the export filter and mapping hook
+    this integration depends on.
+
+    A single Langfuse project per process is supported.
+    """
+
+    def __init__(
+        self,
+        *,
+        emit_validation_scores: bool = True,
+        **langfuse_kwargs: Any,
+    ):
+        self.emit_validation_scores = emit_validation_scores
+        self._langfuse_kwargs = langfuse_kwargs
+        self._client: Optional[Langfuse] = None
+        self._score_processor: Optional[GuardrailsScoreSpanProcessor] = None
+
+    def instrument(self) -> Langfuse:
+        """Configure Langfuse to receive Guardrails traces. Idempotent."""
+        if self._client is not None:
+            return self._client
+
+        self._reject_isolated_tracer_provider()
+        self._reject_preexisting_client()
+
+        if settings.disable_tracing:
+            logger.warning(
+                "Guardrails tracing is disabled (settings.disable_tracing), so no"
+                " spans will reach Langfuse. Note that MlFlowInstrumentor sets"
+                " this flag."
+            )
+
+        self._client = Langfuse(
+            should_export_span=guardrails_should_export_span,
+            mask_otel_spans=guardrails_mask_otel_spans,
+            **self._langfuse_kwargs,
+        )
+
+        if self.emit_validation_scores:
+            self._attach_score_processor(self._client)
+
+        return self._client
+
+    def flush(self) -> None:
+        """Flush pending spans and scores. Needed in short-lived processes."""
+        if self._client is not None:
+            self._client.flush()
+
+    def _reject_isolated_tracer_provider(self) -> None:
+        provider = self._langfuse_kwargs.get("tracer_provider")
+        if provider is not None and provider is not trace.get_tracer_provider():
+            raise ValueError(
+                "LangfuseInstrumentor does not support an isolated tracer_provider."
+                " Guardrails takes its tracers from the global TracerProvider, so"
+                " an isolated one would receive no Guardrails spans. Omit"
+                " tracer_provider, or pass the global one."
+            )
+
+    def _reject_preexisting_client(self) -> None:
+        instances = getattr(LangfuseResourceManager, "_instances", None)
+        if instances is None:
+            logger.warning(
+                "Could not verify whether a Langfuse client already exists; if one"
+                " does, Guardrails spans may not be exported."
+            )
+            return
+        if instances:
+            raise RuntimeError(
+                "A Langfuse client already exists in this process. Langfuse reuses"
+                " the cached client for a public key and ignores the export filter"
+                " and mapping hook this integration needs, so Guardrails spans"
+                " would be dropped. Call LangfuseInstrumentor().instrument() before"
+                " creating any other Langfuse client, and use the client it"
+                " returns."
+            )
+
+    def _attach_score_processor(self, client: Langfuse) -> None:
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            logger.warning(
+                "The global TracerProvider is not an OpenTelemetry SDK"
+                " TracerProvider, so Guardrails validation scores cannot be"
+                " emitted."
+            )
+            return
+        self._score_processor = GuardrailsScoreSpanProcessor(client)
+        provider.add_span_processor(self._score_processor)
+
+
+__all__ = [
+    "GUARDRAILS_INSTRUMENTATION_SCOPES",
+    "LangfuseInstrumentor",
+    "guardrails_mask_otel_spans",
+    "guardrails_should_export_span",
+]

--- a/guardrails/integrations/langfuse/score_processor.py
+++ b/guardrails/integrations/langfuse/score_processor.py
@@ -1,0 +1,84 @@
+"""Emits Langfuse scores from finished Guardrails validator and guard spans."""
+
+from typing import Any, Optional
+
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.trace import format_span_id, format_trace_id
+
+from guardrails.integrations.langfuse.attribute_mapping import (
+    GUARD,
+    VALIDATOR,
+    guard_validation_passed,
+    validator_failed,
+)
+from guardrails.logger import logger
+
+GUARD_SCORE_NAME = "guardrails.validation_passed"
+
+
+class GuardrailsScoreSpanProcessor(SpanProcessor):
+    """Turns validation results into Langfuse scores.
+
+    Scores, unlike span metadata, can be charted over time -- which is the point
+    of sending guard runs to Langfuse: pass rate per validator.
+    """
+
+    def __init__(self, client: Any):
+        self._client = client
+
+    def on_end(self, span: ReadableSpan) -> None:
+        # Runs on the exporting thread; must never raise into it.
+        try:
+            self._score(span)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"Failed to emit Langfuse score for span {span.name}: {e}")
+
+    def _score(self, span: ReadableSpan) -> None:
+        attributes = dict(span.attributes or {})
+        span_type = attributes.get("type")
+        context = span.get_span_context()
+
+        if context is None or not context.is_valid:
+            return
+
+        if span_type == VALIDATOR:
+            name = attributes.get("validator.name")
+            if not name:
+                return
+            failed = validator_failed(attributes)
+            self._create_score(
+                name=f"guardrails.{name}",
+                value=0.0 if failed else 1.0,
+                context=context,
+                comment=(
+                    str(attributes.get("validator.validate.output.error_message"))
+                    if failed
+                    else None
+                ),
+            )
+        elif span_type == GUARD:
+            passed = guard_validation_passed(attributes)
+            if passed is None:
+                return
+            self._create_score(
+                name=GUARD_SCORE_NAME,
+                value=1.0 if passed else 0.0,
+                context=context,
+            )
+
+    def _create_score(
+        self,
+        *,
+        name: str,
+        value: float,
+        context: Any,
+        comment: Optional[str] = None,
+    ) -> None:
+        self._client.create_score(
+            name=name,
+            value=value,
+            data_type="BOOLEAN",
+            trace_id=format_trace_id(context.trace_id),
+            observation_id=format_span_id(context.span_id),
+            comment=comment,
+        )

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -197,6 +197,7 @@ class LiteLLMCallable(PromptCallableBase):
                 **kwargs,
                 "model": model,
             },
+            model_name=model,
             function_call=kwargs.get(
                 "function_call", safe_get(function_calling_tools, 0)
             ),
@@ -245,6 +246,8 @@ class LiteLLMCallable(PromptCallableBase):
 
         trace_llm_call(
             output_messages=[choice.message for choice in response.choices],  # type: ignore
+            # Cost is priced against the served model, not the requested one.
+            model_name=getattr(response, "model", None) or model,
             token_count_completion=completion_tokens,  # type: ignore
             token_count_prompt=prompt_tokens,  # type: ignore
             token_count_total=total_tokens,  # type: ignore
@@ -475,6 +478,7 @@ class ArbitraryCallable(PromptCallableBase):
             invocation_parameters={
                 **kwargs,
             },
+            model_name=kwargs.get("model"),
         )
 
         # Get the response from the callable
@@ -686,6 +690,7 @@ class AsyncLiteLLMCallable(AsyncPromptCallableBase):
         trace_llm_call(
             input_messages=kwargs.get("messages"),
             invocation_parameters={**kwargs},
+            model_name=kwargs.get("model"),
             function_call=kwargs.get(
                 "function_call", safe_get(function_calling_tools, 0)
             ),
@@ -732,6 +737,8 @@ class AsyncLiteLLMCallable(AsyncPromptCallableBase):
             total_tokens = (completion_tokens or 0) + (prompt_tokens or 0)
         trace_llm_call(
             output_messages=[choice.message for choice in response.choices],  # type: ignore
+            # Cost is priced against the served model, not the requested one.
+            model_name=getattr(response, "model", None) or kwargs.get("model"),
             token_count_completion=completion_tokens,  # type: ignore
             token_count_prompt=prompt_tokens,  # type: ignore
             token_count_total=total_tokens,  # type: ignore
@@ -855,6 +862,7 @@ class AsyncArbitraryCallable(AsyncPromptCallableBase):
             invocation_parameters={
                 **kwargs,
             },
+            model_name=kwargs.get("model"),
         )
 
         output = await self.llm_api(*args, **kwargs)

--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 from pydantic import BaseModel
 from typing import Any, Callable, Dict, Optional, Union, List
 from opentelemetry.baggage import get_baggage
@@ -36,6 +37,10 @@ def serialize(val: Any) -> Optional[str]:
     try:
         if val is None:
             return None
+        if isinstance(val, Enum):
+            # Must precede __dict__: an Enum's __dict__ holds a non-serializable
+            # __objclass__, which would otherwise drop the value entirely.
+            return str(val.value)
         if hasattr(val, "to_dict"):
             return json.dumps(val.to_dict())
         elif isinstance(val, BaseModel):

--- a/guardrails/telemetry/runner_tracing.py
+++ b/guardrails/telemetry/runner_tracing.py
@@ -36,6 +36,21 @@ import sys
 if sys.version_info.minor < 10:
     from guardrails.utils.polyfills import anext
 
+
+def add_static_attributes(span: Span, span_type: str):
+    """Set attributes known before the wrapped call runs.
+
+    These are applied at span creation rather than alongside the response
+    attributes so that spans which return early — notably the streaming
+    branch of ``Runner.call`` — are still identifiable by ``type``.
+    """
+    span.set_attribute("guardrails.version", GUARDRAILS_VERSION)
+    span.set_attribute("type", span_type)
+    span.set_attribute("guard.name", get_guard_name())
+    if SpanAttributes is not None:
+        span.set_attribute(SpanAttributes.OPENINFERENCE_SPAN_KIND, "GUARDRAIL")
+
+
 #########################################
 ### START Runner.step Instrumentation ###
 #########################################
@@ -86,10 +101,7 @@ def trace_step(fn: Callable[..., Iteration]):
                 name="step",  # type: ignore
                 context=current_otel_context,  # type: ignore
             ) as step_span:
-                if SpanAttributes is not None:
-                    step_span.set_attribute(
-                        SpanAttributes.OPENINFERENCE_SPAN_KIND, "GUARDRAIL"
-                    )
+                add_static_attributes(step_span, "guardrails/guard/step")
                 try:
                     response = fn(*args, **kwargs)
                     add_step_attributes(step_span, response, *args, **kwargs)
@@ -117,8 +129,7 @@ def trace_stream_step_generator(
         name="step",  # type: ignore
         context=current_otel_context,  # type: ignore
     ) as step_span:
-        if SpanAttributes is not None:
-            step_span.set_attribute(SpanAttributes.OPENINFERENCE_SPAN_KIND, "GUARDRAIL")
+        add_static_attributes(step_span, "guardrails/guard/step")
         try:
             gen = fn(*args, **kwargs)
             next_exists = True
@@ -164,10 +175,7 @@ def trace_async_step(fn: Callable[..., Awaitable[Iteration]]):
                 name="step",  # type: ignore
                 context=current_otel_context,  # type: ignore
             ) as step_span:
-                if SpanAttributes is not None:
-                    step_span.set_attribute(
-                        SpanAttributes.OPENINFERENCE_SPAN_KIND, "GUARDRAIL"
-                    )
+                add_static_attributes(step_span, "guardrails/guard/step")
                 try:
                     response = await fn(*args, **kwargs)
                     add_user_attributes(step_span)
@@ -197,8 +205,7 @@ async def trace_async_stream_step_generator(
         name="step",  # type: ignore
         context=current_otel_context,  # type: ignore
     ) as step_span:
-        if SpanAttributes is not None:
-            step_span.set_attribute(SpanAttributes.OPENINFERENCE_SPAN_KIND, "GUARDRAIL")
+        add_static_attributes(step_span, "guardrails/guard/step")
         try:
             gen = fn(*args, **kwargs)
             next_exists = True
@@ -287,6 +294,7 @@ def trace_call(fn: Callable[..., LLMResponse]):
                 name="call",  # type: ignore
                 context=current_otel_context,  # type: ignore
             ) as call_span:
+                add_static_attributes(call_span, "guardrails/guard/step/call")
                 try:
                     response = fn(*args, **kwargs)
                     if isinstance(response, LLMResponse) and (
@@ -317,6 +325,7 @@ def trace_async_call(fn: Callable[..., Awaitable[LLMResponse]]):
                 name="call",  # type: ignore
                 context=current_otel_context,  # type: ignore
             ) as call_span:
+                add_static_attributes(call_span, "guardrails/guard/step/call")
                 try:
                     response = await fn(*args, **kwargs)
                     add_call_attributes(call_span, response, *args, **kwargs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -346,6 +346,19 @@ files = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = true
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+markers = "extra == \"langfuse\""
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 description = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
@@ -3285,6 +3298,29 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.13.0,<5.0.0"
+
+[[package]]
+name = "langfuse"
+version = "4.14.4"
+description = "Langfuse Python SDK - LLM observability/tracing, datasets, experiments, LLM-as-a-judge evaluation, and prompt management"
+optional = true
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+markers = "extra == \"langfuse\""
+files = [
+    {file = "langfuse-4.14.4-py3-none-any.whl", hash = "sha256:78692a1d4785a8c255bf6ea967e673e1ee30ce078d646e7b5f7ff44549d45cce"},
+    {file = "langfuse-4.14.4.tar.gz", hash = "sha256:48c4bdefc290f61a42881b8048a904ab6b81d37e02496473166836e71ee0ab3a"},
+]
+
+[package.dependencies]
+backoff = ">=1.10.0"
+httpx = ">=0.15.4,<1.0"
+opentelemetry-api = ">=1.33.1,<2"
+opentelemetry-exporter-otlp-proto-http = ">=1.33.1,<2"
+opentelemetry-sdk = ">=1.33.1,<2"
+packaging = ">=23.2,<27.0"
+pydantic = ">=2,<3"
+wrapt = ">=1.14,<3"
 
 [[package]]
 name = "langsmith"
@@ -8768,7 +8804,7 @@ description = "Module for decorators, wrappers and monkey patching."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"docs-build\" or extra == \"llama\""
+markers = "extra == \"docs-build\" or extra == \"llama\" or extra == \"langfuse\""
 files = [
     {file = "wrapt-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0f68f478004475d97906686e702ddbddeaf717c0b68ad2794384308f2dc713ae"},
     {file = "wrapt-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e422b2d647a65d6b080cad5accd09055d3809bdff00c76fba8dca00ca935572a"},
@@ -9337,6 +9373,7 @@ databricks = ["mlflow"]
 dev = ["docformatter", "liccheck", "lxml-stubs", "pre-commit", "pypdfium2", "pyright", "pytest", "pytest-asyncio", "pytest-cov", "pytest-mock", "ruff", "twine"]
 docs-build = ["docspec_python", "pydoc-markdown"]
 huggingface = ["guardrails-jsonformer", "torch", "transformers"]
+langfuse = ["langfuse"]
 llama = ["llama-index"]
 manifest = ["manifest-ml"]
 sql = ["sqlalchemy", "sqlglot", "sqlvalidator"]
@@ -9346,4 +9383,4 @@ vectordb = ["faiss-cpu", "numpy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "b6003a268b3bac0c2ca909f86589c4c899efae6a6da4c0d71a4771e0d8b8b149"
+content-hash = "07193e7e87f0100e99d6c37b0dd33a20aee90d3f1e098cecc4dd9d946f64d88c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ api = [
 databricks = [
     "mlflow>=3.0.0,<4.0.0"
 ]
+langfuse = [
+    "langfuse>=4.9.0,<5.0.0"
+]
 uv = [
     "uvloop>=0.22.1,<1.0.0"
 ]

--- a/tests/integration_tests/integrations/langfuse/test_langfuse_tracing.py
+++ b/tests/integration_tests/integrations/langfuse/test_langfuse_tracing.py
@@ -1,0 +1,253 @@
+"""End-to-end checks that Guardrails spans survive Langfuse's export filter and
+arrive correctly mapped.
+
+Assertions run against the spans an ``InMemorySpanExporter`` receives *behind*
+the real ``LangfuseSpanProcessor``, so the default export filter and the
+export-stage mapping hook are both exercised rather than bypassed.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+try:
+    import langfuse
+except ImportError:
+    langfuse = None
+
+pytestmark = pytest.mark.skipif(langfuse is None, reason="langfuse not installed.")
+
+
+@pytest.fixture(autouse=True)
+def langfuse_env(monkeypatch):
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "http://localhost:3000")
+
+
+@pytest.fixture(autouse=True)
+def reset_langfuse():
+    from langfuse._client.resource_manager import LangfuseResourceManager
+
+    # reset() shuts each instance down before clearing, so batch processors and
+    # their threads do not leak between tests.
+    LangfuseResourceManager.reset()
+    trace._TRACER_PROVIDER_SET_ONCE._done = False
+    yield
+    LangfuseResourceManager.reset()
+
+
+@pytest.fixture
+def instrumented():
+    """An instrumented Langfuse client with an in-memory sink and mocked scores."""
+    from guardrails.integrations.langfuse import LangfuseInstrumentor
+
+    exporter = InMemorySpanExporter()
+    instrumentor = LangfuseInstrumentor(span_exporter=exporter, flush_at=1)
+    client = instrumentor.instrument()
+    client.create_score = MagicMock()
+    return SimpleNamespace(instrumentor=instrumentor, client=client, exporter=exporter)
+
+
+def spans_by_name(exporter):
+    return {span.name: span for span in exporter.get_finished_spans()}
+
+
+def observation_types(exporter):
+    return {
+        span.name: (span.attributes or {}).get("langfuse.observation.type")
+        for span in exporter.get_finished_spans()
+    }
+
+
+def litellm_response(model="gpt-4o-mini-2024-07-18", content="hello world"):
+    """Minimal stand-in for a litellm ModelResponse."""
+    return SimpleNamespace(
+        model=model,
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content, role="assistant", to_dict=lambda: {}
+                )
+            )
+        ],
+        usage=SimpleNamespace(completion_tokens=7, prompt_tokens=11),
+    )
+
+
+class TestNonStreaming:
+    def test_spans_survive_the_filter_and_are_mapped(self, instrumented, mocker):
+        import litellm
+
+        mocker.patch.object(litellm, "completion", return_value=litellm_response())
+
+        from guardrails import Guard
+        from tests.integration_tests.test_assets.validators import LowerCase
+
+        guard = Guard(name="langfuse-guard").use(LowerCase(on_fail="noop"))
+        guard(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+        instrumented.instrumentor.flush()
+
+        types = observation_types(instrumented.exporter)
+
+        assert types == {
+            "guard": "span",
+            "step": "span",
+            "call": "generation",
+            "lower-case.validate": "guardrail",
+        }
+
+    def test_generation_carries_model_and_usage(self, instrumented, mocker):
+        import litellm
+
+        mocker.patch.object(litellm, "completion", return_value=litellm_response())
+
+        from guardrails import Guard
+
+        guard = Guard(name="langfuse-usage-guard")
+        guard(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+        instrumented.instrumentor.flush()
+
+        call = spans_by_name(instrumented.exporter)["call"]
+        attributes = call.attributes or {}
+
+        # The served model, not the requested one -- cost is priced on it.
+        assert attributes["llm.model_name"] == "gpt-4o-mini-2024-07-18"
+        assert attributes["llm.token_count.prompt"] == 11
+        assert attributes["llm.token_count.completion"] == 7
+        assert attributes["llm.token_count.total"] == 18
+
+    def test_trace_is_named_after_the_guard(self, instrumented, mocker):
+        import litellm
+
+        mocker.patch.object(litellm, "completion", return_value=litellm_response())
+
+        from guardrails import Guard
+
+        guard = Guard(name="named-guard")
+        guard(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+        instrumented.instrumentor.flush()
+
+        guard_span = spans_by_name(instrumented.exporter)["guard"]
+
+        assert (guard_span.attributes or {})["langfuse.trace.name"] == "named-guard"
+
+
+class TestStreaming:
+    """Streaming traces are structurally complete, but usage and cost are absent:
+    Guardrails' providers return the stream before final-usage telemetry runs.
+    These tests deliberately assert no usage."""
+
+    def test_sync_streaming_call_is_a_generation(self, instrumented):
+        from guardrails import Guard
+
+        guard = Guard(name="sync-stream-guard")
+        list(
+            guard(
+                lambda *args, **kwargs: iter(["hello", " world"]),
+                messages=[{"role": "user", "content": "hi"}],
+                stream=True,
+            )
+        )
+        instrumented.instrumentor.flush()
+
+        call = spans_by_name(instrumented.exporter)["call"]
+
+        assert (call.attributes or {}).get("langfuse.observation.type") == "generation"
+        assert "llm.token_count.total" not in (call.attributes or {})
+
+    @pytest.mark.asyncio
+    async def test_async_streaming_call_is_a_generation(self, instrumented):
+        from guardrails import AsyncGuard
+
+        async def astream(*args, **kwargs):
+            # AsyncArbitraryCallable awaits the callable and then reads
+            # `.completion_stream`, mirroring litellm's CustomStreamWrapper.
+            async def chunks():
+                for chunk in ["hello", " world"]:
+                    yield chunk
+
+            return SimpleNamespace(completion_stream=chunks())
+
+        guard = AsyncGuard(name="async-stream-guard")
+        async for _ in await guard(
+            astream,
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        ):
+            pass
+        instrumented.instrumentor.flush()
+
+        call = spans_by_name(instrumented.exporter)["call"]
+
+        assert (call.attributes or {}).get("langfuse.observation.type") == "generation"
+
+
+class TestScores:
+    def test_failing_validator_scores_zero_with_the_error(self, instrumented):
+        from guardrails import Guard
+        from tests.integration_tests.test_assets.validators import LowerCase
+
+        guard = Guard(name="scored-guard").use(LowerCase(on_fail="noop"))
+        guard(
+            lambda *args, **kwargs: "HELLO WORLD",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        instrumented.instrumentor.flush()
+
+        scores = {
+            call.kwargs["name"]: call.kwargs
+            for call in instrumented.client.create_score.call_args_list
+        }
+
+        assert scores["guardrails.lower-case"]["value"] == 0.0
+        assert scores["guardrails.lower-case"]["data_type"] == "BOOLEAN"
+        assert "not lower case" in scores["guardrails.lower-case"]["comment"]
+        assert scores["guardrails.validation_passed"]["value"] == 0.0
+
+    def test_passing_validator_scores_one(self, instrumented):
+        from guardrails import Guard
+        from tests.integration_tests.test_assets.validators import LowerCase
+
+        guard = Guard(name="passing-guard").use(LowerCase(on_fail="noop"))
+        guard(
+            lambda *args, **kwargs: "hello world",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        instrumented.instrumentor.flush()
+
+        scores = {
+            call.kwargs["name"]: call.kwargs
+            for call in instrumented.client.create_score.call_args_list
+        }
+
+        assert scores["guardrails.lower-case"]["value"] == 1.0
+        assert scores["guardrails.lower-case"]["comment"] is None
+        assert scores["guardrails.validation_passed"]["value"] == 1.0
+
+    def test_scores_reference_the_span_they_came_from(self, instrumented):
+        from opentelemetry.trace import format_span_id, format_trace_id
+
+        from guardrails import Guard
+        from tests.integration_tests.test_assets.validators import LowerCase
+
+        guard = Guard(name="linked-guard").use(LowerCase(on_fail="noop"))
+        guard(
+            lambda *args, **kwargs: "hello world",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        instrumented.instrumentor.flush()
+
+        validator_span = spans_by_name(instrumented.exporter)["lower-case.validate"]
+        context = validator_span.get_span_context()
+        score = next(
+            call.kwargs
+            for call in instrumented.client.create_score.call_args_list
+            if call.kwargs["name"] == "guardrails.lower-case"
+        )
+
+        assert score["trace_id"] == format_trace_id(context.trace_id)
+        assert score["observation_id"] == format_span_id(context.span_id)

--- a/tests/integration_tests/test_telemetry.py
+++ b/tests/integration_tests/test_telemetry.py
@@ -114,6 +114,68 @@ class TestTelemetry:
             "/validator_usage",
         ]
 
+    def test_call_span_is_typed_when_streaming(self, mocker):
+        """Runner.call returns early for streaming responses, so `type` has to
+        be set at span creation or the span is unidentifiable downstream."""
+        exporter = self._patch_private_exporter(mocker)
+
+        from guardrails.telemetry import default_otel_collector_tracer
+        from guardrails import Guard
+
+        default_otel_collector_tracer()
+
+        guard = Guard(name="streaming-telemetry-guard")
+        guard.configure(allow_metrics_collection=False)
+
+        list(
+            guard(
+                lambda *args, **kwargs: iter(["hello", " world"]),
+                messages=[{"role": "user", "content": "hi"}],
+                stream=True,
+            )
+        )
+
+        call_spans = [s for s in exporter.get_finished_spans() if s.name == "call"]
+
+        assert len(call_spans) == 1
+        assert call_spans[0].attributes.get("type") == "guardrails/guard/step/call"
+
+    def test_call_span_records_model_name(self, mocker):
+        """Langfuse and other consumers price cost off llm.model_name."""
+        exporter = self._patch_private_exporter(mocker)
+
+        from guardrails.telemetry import default_otel_collector_tracer
+        from guardrails import Guard
+
+        default_otel_collector_tracer()
+
+        guard = Guard(name="model-name-telemetry-guard")
+        guard.configure(allow_metrics_collection=False)
+
+        guard(
+            lambda *args, **kwargs: "hello world",
+            messages=[{"role": "user", "content": "hi"}],
+            model="gpt-4o-mini",
+        )
+
+        call_spans = [s for s in exporter.get_finished_spans() if s.name == "call"]
+
+        assert len(call_spans) == 1
+        assert call_spans[0].attributes.get("llm.model_name") == "gpt-4o-mini"
+
+    @staticmethod
+    def _patch_private_exporter(mocker) -> InMemorySpanExporter:
+        exporter = InMemorySpanExporter()
+        mocker.patch(
+            "guardrails.telemetry.default_otel_collector_tracer_mod.OTLPSpanExporter",
+            return_value=exporter,
+        )
+        mocker.patch(
+            "guardrails.telemetry.default_otel_collector_tracer_mod.BatchSpanProcessor",
+            return_value=SimpleSpanProcessor(exporter),
+        )
+        return exporter
+
     @pytest.mark.no_hub_telemetry_mock
     def test_no_cross_contamination(self, mocker):
         private_exporter = InMemorySpanExporter()

--- a/tests/unit_tests/integrations/langfuse/test_attribute_mapping.py
+++ b/tests/unit_tests/integrations/langfuse/test_attribute_mapping.py
@@ -1,0 +1,122 @@
+import pytest
+
+from guardrails.integrations.langfuse.attribute_mapping import (
+    CALL,
+    GUARD,
+    STEP,
+    VALIDATOR,
+    guard_validation_passed,
+    is_guardrails_scope,
+    map_attributes,
+    validator_failed,
+)
+
+
+class TestMapAttributes:
+    def test_unknown_span_is_left_unchanged(self):
+        assert map_attributes({"type": "something/else"}) == {}
+        assert map_attributes({}) == {}
+
+    def test_step_is_a_span(self):
+        assert map_attributes({"type": STEP}) == {"langfuse.observation.type": "span"}
+
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            {"type": CALL},
+            {"type": CALL, "llm.model_name": "gpt-4o-mini"},
+        ],
+        ids=["without_model", "with_model"],
+    )
+    def test_call_is_a_generation_regardless_of_model(self, attributes):
+        """Streaming and model-less providers are still generations, so the type
+        must come from the Guardrails span type rather than model presence."""
+        assert map_attributes(attributes) == {"langfuse.observation.type": "generation"}
+
+    def test_guard_promotes_filterable_metadata(self):
+        mapped = map_attributes(
+            {
+                "type": GUARD,
+                "guard.name": "my-guard",
+                "validation_passed": True,
+                "number_of_reasks": 2,
+                "number_of_llm_calls": 3,
+                "execution_id": "abc123",
+            }
+        )
+
+        assert mapped == {
+            "langfuse.observation.type": "span",
+            "langfuse.trace.tags": ["guardrails"],
+            "langfuse.trace.name": "my-guard",
+            "langfuse.trace.metadata.validation_passed": "True",
+            "langfuse.trace.metadata.number_of_reasks": "2",
+            "langfuse.trace.metadata.number_of_llm_calls": "3",
+            "langfuse.trace.metadata.execution_id": "abc123",
+        }
+
+    def test_guard_omits_absent_metadata(self):
+        mapped = map_attributes({"type": GUARD, "guard.name": "my-guard"})
+
+        assert mapped == {
+            "langfuse.observation.type": "span",
+            "langfuse.trace.tags": ["guardrails"],
+            "langfuse.trace.name": "my-guard",
+        }
+
+    @pytest.mark.parametrize("passed", [True, False])
+    def test_guard_never_carries_a_level(self, passed):
+        """A failure under on_fail="fix"/"reask" is routine, so flagging the root
+        span would make the level meaningless. The validator span carries it."""
+        mapped = map_attributes({"type": GUARD, "validation_passed": passed})
+
+        assert "langfuse.observation.level" not in mapped
+
+    def test_failed_guard_is_still_findable(self):
+        mapped = map_attributes({"type": GUARD, "validation_passed": False})
+
+        assert mapped["langfuse.trace.metadata.validation_passed"] == "False"
+
+    def test_failed_validator_is_flagged(self):
+        mapped = map_attributes(
+            {"type": VALIDATOR, "validator.validate.output.outcome": "fail"}
+        )
+
+        assert mapped == {
+            "langfuse.observation.type": "guardrail",
+            "langfuse.observation.level": "WARNING",
+        }
+
+    def test_passing_validator_has_no_level(self):
+        mapped = map_attributes(
+            {"type": VALIDATOR, "validator.validate.output.outcome": "pass"}
+        )
+
+        assert mapped == {"langfuse.observation.type": "guardrail"}
+
+
+class TestOutcomeHelpers:
+    def test_validator_failed(self):
+        assert validator_failed({"validator.validate.output.outcome": "fail"}) is True
+        assert validator_failed({"validator.validate.output.outcome": "pass"}) is False
+
+    def test_missing_outcome_is_not_a_failure(self):
+        """A missing outcome is unknown, not failed -- guessing would emit a
+        wrong score."""
+        assert validator_failed({}) is False
+
+    def test_guard_validation_passed(self):
+        assert guard_validation_passed({"validation_passed": False}) is False
+        assert guard_validation_passed({}) is None
+
+
+class TestScopes:
+    @pytest.mark.parametrize(
+        "scope", ["guardrails-ai", "guardrails.telemetry.guard_tracing"]
+    )
+    def test_guardrails_scopes_are_recognised(self, scope):
+        assert is_guardrails_scope(scope) is True
+
+    def test_other_scopes_are_not(self):
+        assert is_guardrails_scope("openai") is False
+        assert is_guardrails_scope(None) is False

--- a/tests/unit_tests/integrations/langfuse/test_langfuse_instrumentor.py
+++ b/tests/unit_tests/integrations/langfuse/test_langfuse_instrumentor.py
@@ -1,0 +1,187 @@
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+try:
+    import langfuse
+except ImportError:
+    langfuse = None
+
+pytestmark = pytest.mark.skipif(langfuse is None, reason="langfuse not installed.")
+
+
+@pytest.fixture(autouse=True)
+def langfuse_env(monkeypatch):
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "http://localhost:3000")
+
+
+@pytest.fixture(autouse=True)
+def reset_langfuse():
+    """Langfuse caches one resource manager per public key; without resetting,
+    a client built by one test leaks into the next."""
+    from langfuse._client.resource_manager import LangfuseResourceManager
+
+    LangfuseResourceManager.reset()
+    trace._TRACER_PROVIDER_SET_ONCE._done = False
+    yield
+    LangfuseResourceManager.reset()
+
+
+def make_instrumentor(**kwargs):
+    from guardrails.integrations.langfuse import LangfuseInstrumentor
+
+    kwargs.setdefault("span_exporter", InMemorySpanExporter())
+    return LangfuseInstrumentor(**kwargs)
+
+
+def make_span(scope_name, attributes=None):
+    span = MagicMock()
+    span.instrumentation_scope = (
+        MagicMock(name=scope_name) if scope_name is not None else None
+    )
+    # MagicMock(name=...) sets the mock's repr, not the attribute.
+    if scope_name is not None:
+        span.instrumentation_scope.name = scope_name
+    span.attributes = attributes or {}
+    return span
+
+
+class TestShouldExportSpan:
+    """The load-bearing part: Langfuse's default filter drops every Guardrails
+    span, so this predicate is what makes the integration work at all."""
+
+    @pytest.mark.parametrize(
+        "scope", ["guardrails-ai", "guardrails.telemetry.guard_tracing"]
+    )
+    def test_guardrails_spans_are_exported(self, scope):
+        from guardrails.integrations.langfuse import guardrails_should_export_span
+
+        assert guardrails_should_export_span(make_span(scope)) is True
+
+    def test_defers_to_langfuse_for_other_scopes(self, mocker):
+        from guardrails.integrations import langfuse as gr_langfuse
+        from guardrails.integrations.langfuse import guardrails_should_export_span
+
+        default = mocker.patch.object(
+            gr_langfuse.langfuse_instrumentor,
+            "is_default_export_span",
+            return_value=False,
+        )
+        span = make_span("sqlalchemy")
+
+        assert guardrails_should_export_span(span) is False
+        default.assert_called_once_with(span)
+
+    def test_missing_scope_defers_to_langfuse(self, mocker):
+        from guardrails.integrations import langfuse as gr_langfuse
+        from guardrails.integrations.langfuse import guardrails_should_export_span
+
+        mocker.patch.object(
+            gr_langfuse.langfuse_instrumentor,
+            "is_default_export_span",
+            return_value=True,
+        )
+
+        assert guardrails_should_export_span(make_span(None)) is True
+
+
+class TestMaskOtelSpans:
+    def test_maps_guardrails_spans_only(self):
+        from langfuse.types import MaskOtelSpansParams
+
+        from guardrails.integrations.langfuse import guardrails_mask_otel_spans
+
+        guard_span = make_span("guardrails-ai", {"type": "guardrails/guard"})
+        other_span = make_span("openai", {"http.method": "POST"})
+        params = MaskOtelSpansParams(spans={"a": guard_span, "b": other_span})
+
+        result = guardrails_mask_otel_spans(params=params)
+
+        assert "a" in result.span_patches
+        assert (
+            result.span_patches["a"].set_attributes["langfuse.observation.type"]
+            == "span"
+        )
+        assert "b" not in result.span_patches
+
+    def test_returns_none_instead_of_raising(self, mocker):
+        """Raising from this hook costs the user the whole export batch, so
+        enrichment must be best-effort."""
+        from langfuse.types import MaskOtelSpansParams
+
+        from guardrails.integrations import langfuse as gr_langfuse
+        from guardrails.integrations.langfuse import guardrails_mask_otel_spans
+
+        mocker.patch.object(
+            gr_langfuse.langfuse_instrumentor,
+            "map_attributes",
+            side_effect=ValueError("boom"),
+        )
+        params = MaskOtelSpansParams(
+            spans={"a": make_span("guardrails-ai", {"type": "guardrails/guard"})}
+        )
+
+        assert guardrails_mask_otel_spans(params=params) is None
+
+
+class TestInstrument:
+    def test_is_idempotent(self):
+        instrumentor = make_instrumentor()
+
+        first = instrumentor.instrument()
+        second = instrumentor.instrument()
+
+        assert first is second
+
+    def test_rejects_preexisting_client(self):
+        from langfuse import Langfuse
+
+        Langfuse()
+
+        with pytest.raises(RuntimeError, match="already exists"):
+            make_instrumentor().instrument()
+
+    def test_rejects_isolated_tracer_provider(self):
+        isolated = TracerProvider()
+
+        with pytest.raises(ValueError, match="isolated tracer_provider"):
+            make_instrumentor(tracer_provider=isolated).instrument()
+
+    def test_accepts_the_global_tracer_provider(self):
+        provider = TracerProvider()
+        trace._TRACER_PROVIDER_SET_ONCE._done = False
+        trace.set_tracer_provider(provider)
+
+        instrumentor = make_instrumentor(tracer_provider=trace.get_tracer_provider())
+
+        assert instrumentor.instrument() is not None
+
+    def test_warns_when_guardrails_tracing_is_disabled(self, mocker):
+        from guardrails.integrations import langfuse as gr_langfuse
+        from guardrails.settings import settings
+
+        warning = mocker.patch.object(
+            gr_langfuse.langfuse_instrumentor.logger, "warning"
+        )
+        mocker.patch.object(settings, "disable_tracing", True)
+
+        make_instrumentor().instrument()
+
+        assert any("disable_tracing" in str(call) for call in warning.call_args_list)
+
+    def test_score_processor_can_be_disabled(self):
+        instrumentor = make_instrumentor(emit_validation_scores=False)
+        instrumentor.instrument()
+
+        assert instrumentor._score_processor is None
+
+    def test_score_processor_is_attached_by_default(self):
+        instrumentor = make_instrumentor()
+        instrumentor.instrument()
+
+        assert instrumentor._score_processor is not None


### PR DESCRIPTION
Closes #1630

## What

Adds `guardrails.integrations.langfuse`, opt-in via `pip install "guardrails-ai[langfuse]"`.

Guardrails already emits a full OpenTelemetry trace per guard invocation, so this reuses
those spans rather than creating a parallel tracing implementation. No monkeypatching, no
duplicate spans.

```python
from guardrails.integrations.langfuse import LangfuseInstrumentor

langfuse = LangfuseInstrumentor().instrument()
```

Result in Langfuse:

```
guard                    (span)       tagged `guardrails`, validation_passed/reasks as metadata
└── step                 (span)
    ├── call             (generation) model, token usage, cost
    └── <validator>.validate (guardrail)  WARNING when validation fails
```

Plus a Langfuse **score** per validator (`guardrails.<name>`, error message as comment) and
one per run (`guardrails.validation_passed`).

## Why it isn't zero-config

Langfuse's default export filter keeps only Langfuse spans, `gen_ai.*`-bearing spans, and
known LLM instrumentation scopes. Guardrails is none of those, so **every** Guardrails span
is silently dropped. Widening `should_export_span` is the load-bearing part; enrichment then
happens via Langfuse's documented `mask_otel_spans` export hook.

## Core telemetry fixes

Three small fixes outside the integration, each a real defect affecting **all** OTel
consumers (Arize, OpenLIT, raw OTLP), not just Langfuse:

- **`llm.model_name` was never set** (`model_name` appeared nowhere in `llm_providers.py`).
  Without it there is no model on the generation and therefore no cost.
- **Streaming `call` spans carried no `type`** — `trace_call` returns early for streams,
  before `add_call_attributes` ran. Static attributes now set at span creation.
- **`serialize()` dropped every enum**, so `validator.validate.output.outcome` was an empty
  string on every validator span, making validator results unreadable.

## Testing

- 38 new tests (unit + integration). Integration tests assert against spans an
  `InMemorySpanExporter` receives *behind* the real `LangfuseSpanProcessor`, so the default
  filter and the mapping hook are exercised, not bypassed.
- 2 regression tests for the core fixes, confirmed to fail without them.
- Verified end-to-end against a **real self-hosted Langfuse v4.11.0** with a real LLM call:
  hierarchy, `GUARDRAIL` typing, model + usage, tags, scores linked to observations, and the
  passing / failing / error paths.
- `make lint` clean; `pyright` unchanged vs. baseline; full suite green except pre-existing
  failures.

## Scope

Tracing and scores only. Prompt management and datasets/experiments are intentionally left to
the Langfuse SDK — the returned client supports them.

Known gaps: streaming has no token usage or cost (providers return the stream before usage
telemetry runs); `modelParameters` is blocked by #1631; one Langfuse project per process.
