### PR TITLE
fix(validator_service): compose on_fail=fix corrections in async service

### DIFF
--- a/guardrails/validator_service/async_validator_service.py
+++ b/guardrails/validator_service/async_validator_service.py
@@ -7,12 +7,12 @@ from guardrails.classes.history import Iteration
 from guardrails_ai.types import (
     FailResult,
     PassResult,
+    ReAsk,
     ValidationResult,
 )
 from guardrails.hub_telemetry.hub_tracing import async_trace
 from guardrails.telemetry.validator_tracing import trace_async_validator
 from guardrails.types import ValidatorMap, OnFailAction
-from guardrails.classes.validation.validator_logs import ValidatorLogs
 from guardrails.actions.reask import FieldReAsk
 from guardrails.validator_base import Validator
 from guardrails.validator_service.validator_service_base import (
@@ -153,8 +153,64 @@ class AsyncValidatorService(ValidatorServiceBase):
         **kwargs,
     ):
         validators = validator_map.get(reference_property_path, [])
+
+        # Validators whose on_fail action can replace the value make every
+        # verdict depend on the value a validator observes. Run those in
+        # declaration order so each one sees the corrections of the ones
+        # before it, matching SequentialValidatorService semantics; fixes
+        # computed against the original value cannot be reconciled by the
+        # three-way merge when they overlap, and any fix that presupposes
+        # another validator's correction is lost entirely.
+        mutating_actions = (
+            OnFailAction.FIX,
+            OnFailAction.FIX_REASK,
+            OnFailAction.CUSTOM,
+        )
+        has_mutating = any(
+            validator.on_fail_descriptor in mutating_actions for validator in validators
+        )
+
+        if not has_mutating:
+            return await self._run_validators_concurrently(
+                iteration=iteration,
+                validators=validators,
+                value=value,
+                metadata=metadata,
+                absolute_property_path=absolute_property_path,
+                reference_property_path=reference_property_path,
+                stream=stream,
+                **kwargs,
+            )
+
+        for validator in validators:
+            res = await self.run_validator(
+                iteration,
+                validator,
+                value,
+                metadata,
+                absolute_property_path,
+                stream=stream,
+                reference_property_path=reference_property_path,
+                **kwargs,
+            )
+            if isinstance(res.value, (Filter, Refrain, ReAsk)):
+                return res.value, metadata
+            value = res.value
+
+        return value, metadata
+
+    async def _run_validators_concurrently(
+        self,
+        iteration: Iteration,
+        validators: List[Validator],
+        value: Any,
+        metadata: Dict,
+        absolute_property_path: str,
+        reference_property_path: str,
+        stream: Optional[bool] = False,
+        **kwargs,
+    ):
         coroutines: List[Coroutine[Any, Any, ValidatorRun]] = []
-        validators_logs: List[ValidatorLogs] = []
         for validator in validators:
             coroutines.append(
                 self.run_validator(
@@ -172,7 +228,6 @@ class AsyncValidatorService(ValidatorServiceBase):
         results = await asyncio.gather(*coroutines)
         reasks: List[FieldReAsk] = []
         for res in results:
-            validators_logs.append(res.validator_logs)
             # QUESTION: Do we still want to do this here or handle it during the merge?
             # return early if we have a filter, refrain, or reask
             if isinstance(res.value, (Filter, Refrain)):
@@ -188,22 +243,6 @@ class AsyncValidatorService(ValidatorServiceBase):
                 fail_results.extend(reask.fail_results or [])
             first_reask.fail_results = fail_results
             return first_reask, metadata
-
-        # merge the results
-        fix_values = [
-            res.value
-            for res in results
-            if (
-                isinstance(res.validator_logs.validation_result, FailResult)
-                and (
-                    res.on_fail_action == OnFailAction.FIX
-                    or res.on_fail_action == OnFailAction.FIX_REASK
-                    or res.on_fail_action == OnFailAction.CUSTOM
-                )
-            )
-        ]
-        if len(fix_values) > 0:
-            value = self.merge_results(value, fix_values)
 
         return value, metadata
 

--- a/tests/unit_tests/test_guard.py
+++ b/tests/unit_tests/test_guard.py
@@ -857,3 +857,40 @@ class TestJsonFunctionCallingTool:
         result = guard.json_function_calling_tool(tools=custom_tools)
 
         assert isinstance(result, list)
+
+
+@register_validator("fixappendera", data_type="string")
+class FixAppenderA(Validator):
+    def validate(self, value, metadata):
+        from guardrails_ai.types import FailResult
+
+        return FailResult(error_message="needs A", fix_value=f"{value}A")
+
+
+@register_validator("fixappenderb", data_type="string")
+class FixAppenderB(Validator):
+    def validate(self, value, metadata):
+        from guardrails_ai.types import FailResult
+
+        return FailResult(error_message="needs B", fix_value=f"{value}B")
+
+
+class TestFixingValidatorsCompose:
+    """Regression tests for https://github.com/guardrails-ai/guardrails/issues/1633.
+
+    The async (default) and sequential validator services must agree: fixes
+    from multiple on_fail="fix" validators compose instead of being silently
+    dropped by the three-way merge.
+    """
+
+    @pytest.mark.parametrize("run_sync", ["true", "false"])
+    def test_fixes_compose_in_both_services(self, run_sync, monkeypatch):
+        monkeypatch.setenv("GUARDRAILS_RUN_SYNC", run_sync)
+        guard = Guard().use(
+            FixAppenderA(on_fail="fix"),
+            FixAppenderB(on_fail="fix"),
+        )
+
+        result = guard.validate("x")
+
+        assert result.validated_output == "xAB"

--- a/tests/unit_tests/validator_service/test_async_validator_service.py
+++ b/tests/unit_tests/validator_service/test_async_validator_service.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, call
 
 from guardrails.actions.filter import Filter
+from guardrails.actions.reask import FieldReAsk
 from guardrails.validator_service.validator_service_base import ValidatorRun
 import pytest
 
@@ -310,6 +311,11 @@ class TestValidateChildren:
 class TestRunValidators:
     @pytest.mark.asyncio
     async def test_filter_exits_early(self, mocker):
+        noop_validator = MagicMock(spec=Validator)
+        noop_validator.on_fail_descriptor = OnFailAction.NOOP
+        filter_validator = MagicMock(spec=Validator)
+        filter_validator.on_fail_descriptor = OnFailAction.FILTER
+
         mock_run_validator = mocker.patch.object(
             avs,
             "run_validator",
@@ -349,12 +355,7 @@ class TestRunValidators:
 
         value, metadata = await avs.run_validators(
             iteration=iteration,
-            validator_map={
-                "$": [
-                    MagicMock(spec=Validator),
-                    MagicMock(spec=Validator),
-                ]
-            },
+            validator_map={"$": [noop_validator, filter_validator]},
             value=True,
             metadata={},
             absolute_property_path="$",
@@ -368,42 +369,65 @@ class TestRunValidators:
         assert metadata == {}
 
     @pytest.mark.asyncio
-    async def test_calls_merge(self, mocker):
+    async def test_fixing_validators_chain_like_sequential(self, mocker):
+        """Fixing validators must compose instead of merging against stale input.
+
+        Regression test for
+        https://github.com/guardrails-ai/guardrails/issues/1633: each validator
+        observes the corrections applied by the ones before it, matching
+        SequentialValidatorService semantics.
+        """
+        noop_validator = MagicMock(spec=Validator)
+        noop_validator.on_fail_descriptor = OnFailAction.NOOP
+        fix_validator_a = MagicMock(spec=Validator)
+        fix_validator_a.on_fail_descriptor = OnFailAction.FIX
+        fix_validator_b = MagicMock(spec=Validator)
+        fix_validator_b.on_fail_descriptor = OnFailAction.FIX
+
+        def _fail_logs(name, value_before):
+            return ValidatorLogs(
+                registered_name=name,
+                validator_name=name,
+                value_before_validation=value_before,
+                validation_result=FailResult(error_message="mock-error"),
+                property_path="$",
+            )
+
+        async def fake_run_validator(iteration, validator, value, *args, **kwargs):
+            if validator is fix_validator_a:
+                return ValidatorRun(
+                    value=f"{value}A",
+                    metadata={},
+                    on_fail_action=OnFailAction.FIX,
+                    validator_logs=_fail_logs("fix_a", value),
+                )
+            if validator is fix_validator_b:
+                # The second fixing validator must observe the first one's
+                # correction ('xA'), not the original value.
+                assert value == "xA"
+                return ValidatorRun(
+                    value=f"{value}B",
+                    metadata={},
+                    on_fail_action=OnFailAction.FIX,
+                    validator_logs=_fail_logs("fix_b", value),
+                )
+            return ValidatorRun(
+                value=value,
+                metadata={},
+                on_fail_action=OnFailAction.NOOP,
+                validator_logs=ValidatorLogs(
+                    registered_name="noop_validator",
+                    validator_name="noop_validator",
+                    value_before_validation=value,
+                    validation_result=PassResult(),
+                    property_path="$",
+                ),
+            )
+
         mock_run_validator = mocker.patch.object(
-            avs,
-            "run_validator",
-            side_effect=[
-                ValidatorRun(
-                    value="mock-value",
-                    metadata={},
-                    on_fail_action="noop",
-                    validator_logs=ValidatorLogs(
-                        registered_name="noop_validator",
-                        validator_name="noop_validator",
-                        value_before_validation="mock-value",
-                        validation_result=PassResult(),
-                        property_path="$",
-                    ),
-                ),
-                ValidatorRun(
-                    value="mock-fix-value",
-                    metadata={},
-                    on_fail_action="fix",
-                    validator_logs=ValidatorLogs(
-                        registered_name="fix_validator",
-                        validator_name="fix_validator",
-                        value_before_validation="mock-value",
-                        validation_result=FailResult(
-                            error_message="mock-error", fix_value="mock-fix-value"
-                        ),
-                        property_path="$",
-                    ),
-                ),
-            ],
+            avs, "run_validator", side_effect=fake_run_validator
         )
-        mock_merge_results = mocker.patch.object(
-            avs, "merge_results", return_value="mock-fix-value"
-        )
+        mock_merge_results = mocker.patch.object(avs, "merge_results")
 
         iteration = Iteration(
             call_id="mock-call",
@@ -412,22 +436,79 @@ class TestRunValidators:
 
         value, metadata = await avs.run_validators(
             iteration=iteration,
-            validator_map={
-                "$": [
-                    MagicMock(spec=Validator),
-                    MagicMock(spec=Validator),
-                ]
-            },
-            value=True,
+            validator_map={"$": [noop_validator, fix_validator_a, fix_validator_b]},
+            value="x",
             metadata={},
             absolute_property_path="$",
             reference_property_path="$",
         )
 
-        assert mock_run_validator.call_count == 2
-        assert mock_merge_results.call_count == 1
+        assert mock_run_validator.call_count == 3
+        assert mock_merge_results.call_count == 0
 
-        assert value == "mock-fix-value"
+        assert value == "xAB"
+        assert metadata == {}
+
+    @pytest.mark.asyncio
+    async def test_chained_path_returns_reask_early(self, mocker):
+        """In chained mode a reask stops later validators, like sequential."""
+
+        fix_validator = MagicMock(spec=Validator)
+        fix_validator.on_fail_descriptor = OnFailAction.FIX
+        reask_validator = MagicMock(spec=Validator)
+        reask_validator.on_fail_descriptor = OnFailAction.REASK
+        never_run_validator = MagicMock(spec=Validator)
+        never_run_validator.on_fail_descriptor = OnFailAction.NOOP
+
+        async def fake_run_validator(iteration, validator, value, *args, **kwargs):
+            if validator is fix_validator:
+                return ValidatorRun(
+                    value=f"{value}A",
+                    metadata={},
+                    on_fail_action=OnFailAction.FIX,
+                    validator_logs=ValidatorLogs(
+                        registered_name="fix_a",
+                        validator_name="fix_a",
+                        value_before_validation=value,
+                        validation_result=FailResult(error_message="mock-error"),
+                        property_path="$",
+                    ),
+                )
+            if validator is reask_validator:
+                # Must observe the fix that came before it.
+                assert value == "xA"
+                return ValidatorRun(
+                    value=FieldReAsk(incorrect_value=value, error_message="mock-reask"),
+                    metadata={},
+                    on_fail_action=OnFailAction.REASK,
+                    validator_logs=ValidatorLogs(
+                        registered_name="reask_validator",
+                        validator_name="reask_validator",
+                        value_before_validation=value,
+                        validation_result=FailResult(error_message="mock-error"),
+                        property_path="$",
+                    ),
+                )
+            raise AssertionError("validators after a reask must not run")
+
+        mocker.patch.object(avs, "run_validator", side_effect=fake_run_validator)
+
+        iteration = Iteration(
+            call_id="mock-call",
+            index=0,
+        )
+
+        value, metadata = await avs.run_validators(
+            iteration=iteration,
+            validator_map={"$": [fix_validator, reask_validator, never_run_validator]},
+            value="x",
+            metadata={},
+            absolute_property_path="$",
+            reference_property_path="$",
+        )
+
+        assert isinstance(value, FieldReAsk)
+        assert value.incorrect_value == "xA"
         assert metadata == {}
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The same `Guard` produces different output depending on `GUARDRAILS_RUN_SYNC` when several validators use `on_fail="fix"` (issue #1633):

```
GUARDRAILS_RUN_SYNC=true    SequentialValidatorService       'xAB'
GUARDRAILS_RUN_SYNC=false   AsyncValidatorService (default)  'xA'
```

With a third fixing validator the async path still returns `'xA'`.

## Root cause

`AsyncValidatorService.run_validators` dispatches every validator against the **original** value and reconciles fixes afterwards with a three-way merge (`merge_results`). Two failure modes follow:

1. Fixes touching the same region are a merge conflict, and `merge.py` resolves conflicts silently by *"erring on the side of deletion"* — one or more fixes vanish without any warning.
2. A validator whose fix presupposes another validator's correction ran against **stale input**. Its verdict and fix were computed on the pre-fix value, so no merger can recover that composition — even with disjoint edits, chaining semantics are lost whenever composition matters.

SequentialValidatorService threads the value through its loop, which is why only that path composes.

## Fix

Route to sequential chaining in the async service whenever any validator on the property can replace the value (`fix` / `fix_reask` / `custom`). Each validator then observes the previous corrections exactly like the sequential service:

```python
for validator in validators:
    res = await self.run_validator(iteration, validator, value, ...)
    if isinstance(res.value, (Filter, Refrain, ReAsk)):
        return res.value, metadata
    value = res.value
```

- Filters/refrains/reasks short-circuit at the point they occur (same as sequential).
- Validators that cannot mutate the value keep the existing **concurrent dispatch** (`_run_validators_concurrently`, unchanged), so pure-check workloads lose nothing.
- The silent three-way merge is gone from the fix path; `merge_results` itself is untouched for any other callers.

This is option (1) from the issue ("Async should chain like sequential"). I considered option (2) (keep merging, make conflicts loud), but merging cannot be made *correct* — it can only warn about a verdict that was already computed against stale input. If maintainers prefer a warning-only intermediate step, this diff is easy to dial back to that.

## Test script

Self-contained repro (no LLM/network). Fails on `main` (`'xA'`), passes here (`'xAB'`) in both modes:

```python
import os
os.environ.setdefault("SILENCE_WARNING_PYDANTIC_MODEL", "true")

from guardrails import Guard
from guardrails.classes.validation.validation_result import FailResult
from guardrails.validator_base import Validator, register_validator

@register_validator(name="probe/append-a", data_type="string")
class AppendA(Validator):
    def validate(self, value, metadata):
        return FailResult(error_message="needs A", fix_value=f"{value}A")

@register_validator(name="probe/append-b", data_type="string")
class AppendB(Validator):
    def validate(self, value, metadata):
        return FailResult(error_message="needs B", fix_value=f"{value}B")

guard = Guard().use(AppendA(on_fail="fix"), AppendB(on_fail="fix"))
out = guard.validate("x").validated_output
assert out == "xAB", out
print("OK:", out)
```

## Tests

- `TestFixingValidatorsCompose.test_fixes_compose_in_both_services` — Guard-level, parametrized over both services; fails pre-fix on the async side.
- `test_fixing_validators_chain_like_sequential` — service-level: second fixing validator observes the first one's correction; `merge_results` not called.
- `test_chained_path_returns_reask_early` — chained mode short-circuits at a reask and later validators don't run.
- Updated `test_filter_exits_early` mocks to carry explicit `on_fail_descriptor`s (routing now reads them); replaced `test_calls_merge`, which pinned the silent-merge behavior this PR removes.
- Full unit suite: 695 passed / 31 skipped / 1 pre-existing env failure identical on unpatched baseline.

Fixes #1633