### PR TITLE
fix(parsing): preserve falsy values (0, False, empty string) during property coercion (fixes #1603)

### DIFF
--- a/guardrails/utils/parsing_utils.py
+++ b/guardrails/utils/parsing_utils.py
@@ -327,14 +327,18 @@ def coerce_property(
         possible_values = []
         for sub_schema in one_of:
             possible_values.append(coerce_property(payload, sub_schema))
-            payload = safe_get(list(filter(None, possible_values)), 0, payload)
+            payload = safe_get(
+                [v for v in possible_values if v is not None], 0, payload
+            )
 
     any_of = schema.get("anyOf")
     if any_of:
         possible_values = []
         for sub_schema in any_of:
             possible_values.append(coerce_property(payload, sub_schema))
-            payload = safe_get(list(filter(None, possible_values)), 0, payload)
+            payload = safe_get(
+                [v for v in possible_values if v is not None], 0, payload
+            )
 
     all_of: List[Dict[str, Any]] = schema.get("allOf", [])
     if all_of:
@@ -361,7 +365,7 @@ def coerce_property(
     if properties and isinstance(payload, dict):
         for k, v in properties.items():
             payload_value = payload.get(k)
-            if payload_value:
+            if payload_value is not None:
                 payload[k] = coerce_property(payload_value, v)
 
     ### Object Additional Properties ###
@@ -377,7 +381,7 @@ def coerce_property(
         ]
         for prop in additional_properties:
             payload_value = payload.get(prop)
-            if payload_value:
+            if payload_value is not None:
                 payload[prop] = coerce_property(
                     payload_value, additional_properties_schema
                 )

--- a/tests/integration_tests/utils/test_parsing_utils_integration.py
+++ b/tests/integration_tests/utils/test_parsing_utils_integration.py
@@ -114,8 +114,53 @@ float_schema = {"type": "number"}
                 },
             },
         ),
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "count": {"type": "string"},
+                    "is_active": {"type": "string"},
+                    "rate": {"type": "number"},
+                    "enabled": {"type": "boolean"},
+                    "empty_str": {"type": "string"},
+                },
+                "additionalProperties": {"type": "string"},
+            },
+            {
+                "count": 0,
+                "is_active": False,
+                "rate": 0,
+                "enabled": 0,
+                "empty_str": "",
+                "extra_zero": 0,
+            },
+            {
+                "count": "0",
+                "is_active": "False",
+                "rate": 0.0,
+                "enabled": False,
+                "empty_str": "",
+                "extra_zero": "0",
+            },
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "union_val": {
+                        "oneOf": [
+                            {"type": "integer"},
+                            {"type": "string"},
+                        ]
+                    }
+                },
+            },
+            {"union_val": 0},
+            {"union_val": 0},
+        ),
     ],
 )
 def test_coerce_types(schema, given, expected):
     coerced_payload = coerce_types(given, schema)
     assert coerced_payload == expected
+


### PR DESCRIPTION
### Summary of Changes
Fixes #1603 by updating schema property coercion in `guardrails/utils/parsing_utils.py` to use explicit `is not None` checks instead of truthiness checks (`if payload_value:` and `filter(None, ...)`).

### Root Cause
Previously, when validating LLM outputs against a schema, valid falsy values such as `0`, `0.0`, `False`, and `""` (empty string) were skipped during property and additional property coercion because Python evaluates `bool(0)` and `bool(False)` as `False`. Furthermore, `filter(None, possible_values)` in `oneOf` and `anyOf` schema composition dropped valid falsy candidates, causing fallback schema errors.

### Key Changes
- **`guardrails/utils/parsing_utils.py`**:
  - Replaced `filter(None, possible_values)` with `[v for v in possible_values if v is not None]` in `oneOf` and `anyOf` handlers.
  - Changed `if payload_value:` to `if payload_value is not None:` in object `properties` and `additionalProperties` coercion loops.
- **`tests/integration_tests/utils/test_parsing_utils_integration.py`**:
  - Added parametrized test cases covering falsy numbers (`0` -> `"0"`, `0` -> `0.0`), falsy booleans (`False` -> `"False"`, `0` -> `False`), empty strings, wildcard `additionalProperties` with `0`, and `oneOf` unions containing `0`.

### Verification & Testing
- Ran pytest on the integration test suite:
  ```bash
  pytest tests/integration_tests/utils/test_parsing_utils_integration.py -v
