### PR TITLE
fix(telemetry): emit valid invocation parameters

### DIFF
--- a/guardrails/telemetry/common.py
+++ b/guardrails/telemetry/common.py
@@ -204,7 +204,7 @@ def recursive_key_operation(
     """
     if isinstance(data, str) and can_convert_to_dict(data):
         data_dict = json.loads(data)
-        data = str(recursive_key_operation(data_dict, operation, keys_to_match))
+        data = json.dumps(recursive_key_operation(data_dict, operation, keys_to_match))
     elif isinstance(data, dict):
         for key, value in data.items():
             if ismatchingkey(key, tuple(keys_to_match)) and isinstance(value, str):

--- a/guardrails/telemetry/open_inference.py
+++ b/guardrails/telemetry/open_inference.py
@@ -104,20 +104,39 @@ def trace_llm_call(
                         serialize(value),  # type: ignore
                     )
 
+    invocation_params: Optional[Dict[str, Any]] = None
     ser_invocation_parameters = serialize(invocation_parameters)
-    redacted_ser_invocation_parameters = recursive_key_operation(
-        ser_invocation_parameters, redact
-    )
-    reser_invocation_parameters = (
-        json.dumps(redacted_ser_invocation_parameters)
-        if isinstance(redacted_ser_invocation_parameters, dict)
-        or isinstance(redacted_ser_invocation_parameters, list)
-        else redacted_ser_invocation_parameters
-    )
-    if reser_invocation_parameters:
-        current_span.set_attribute(
-            "llm.invocation_parameters", reser_invocation_parameters
-        )
+    if ser_invocation_parameters is not None:
+        try:
+            parsed_invocation_parameters = json.loads(ser_invocation_parameters)
+            if isinstance(parsed_invocation_parameters, dict):
+                invocation_params = parsed_invocation_parameters
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    if invocation_params is not None:
+        payload_param_keys = ("messages", "prompt", "input", "instructions")
+        model_params = {
+            key: value
+            for key, value in invocation_params.items()
+            if key not in payload_param_keys
+        }
+        redacted_model_params = recursive_key_operation(model_params, redact)
+        if isinstance(redacted_model_params, dict) and redacted_model_params:
+            current_span.set_attribute(
+                "llm.invocation_parameters", json.dumps(redacted_model_params)
+            )
+            for param_name, param_value in redacted_model_params.items():
+                if param_value is None:
+                    continue
+                attribute_value = (
+                    json.dumps(param_value)
+                    if isinstance(param_value, (dict, list))
+                    else param_value
+                )
+                current_span.set_attribute(
+                    f"llm.invocation_parameters.{param_name}", attribute_value
+                )
 
     ser_model_name = serialize(model_name)
     if ser_model_name:

--- a/tests/unit_tests/redaction/test_recursive_redaction.py
+++ b/tests/unit_tests/redaction/test_recursive_redaction.py
@@ -1,6 +1,7 @@
+import json
 import unittest
+
 from guardrails.telemetry.common import recursive_key_operation, redact
-import ast
 
 
 # Test suite for recursive_key_operation function
@@ -9,7 +10,7 @@ class TestRecursiveKeyOperation(unittest.TestCase):
         data = '{"init_args": [], "init_kwargs": {"model": "gpt-4o-mini", \
             "api_base": "https://api.openai.com/v1", "api_key": "sk-1234"}}'
         result = recursive_key_operation(data, redact)
-        assert ast.literal_eval(result)["init_kwargs"]["api_key"] == "***1234"
+        assert json.loads(result)["init_kwargs"]["api_key"] == "***1234"
 
     def test_dict_kwargs(self):
         data = {
@@ -22,7 +23,18 @@ class TestRecursiveKeyOperation(unittest.TestCase):
             "output": None,
         }
         result = recursive_key_operation(data, redact)
-        assert ast.literal_eval(result["api"])["init_kwargs"]["api_key"] == "***1234"
+        assert json.loads(result["api"])["init_kwargs"]["api_key"] == "***1234"
+
+    def test_json_string_input_returns_json_not_repr(self):
+        data = '{"temperature": 0.3, "api_key": "sk-1234", "stream": true}'
+
+        result = recursive_key_operation(data, redact)
+
+        assert json.loads(result) == {
+            "temperature": 0.3,
+            "api_key": "***1234",
+            "stream": True,
+        }
 
     def test_nomatch(self):
         data = {"somekey": "soemvalue"}

--- a/tests/unit_tests/telemetry/test_open_inference.py
+++ b/tests/unit_tests/telemetry/test_open_inference.py
@@ -1,0 +1,99 @@
+import json
+
+import pytest
+
+from guardrails.telemetry.open_inference import trace_llm_call
+
+
+@pytest.fixture
+def captured_span_attributes(monkeypatch):
+    class CapturingSpan:
+        def __init__(self):
+            self.attributes = {}
+
+        def set_attribute(self, key, value):
+            self.attributes[key] = value
+
+    def record(**kwargs):
+        span = CapturingSpan()
+        monkeypatch.setattr(
+            "guardrails.telemetry.open_inference.get_span", lambda: span
+        )
+        trace_llm_call(**kwargs)
+        return span.attributes
+
+    return record
+
+
+def test_invocation_parameters_are_valid_json(captured_span_attributes):
+    attrs = captured_span_attributes(
+        invocation_parameters={
+            "temperature": 0.3,
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    )
+
+    assert json.loads(attrs["llm.invocation_parameters"]) == {
+        "temperature": 0.3,
+        "model": "gpt-4o-mini",
+    }
+
+
+def test_prompt_payloads_are_excluded(captured_span_attributes):
+    attrs = captured_span_attributes(
+        invocation_parameters={
+            "temperature": 0.3,
+            "messages": [{"role": "user", "content": "secret prompt"}],
+            "prompt": "secret prompt",
+            "instructions": "system text",
+            "input": "user text",
+        }
+    )
+
+    assert json.loads(attrs["llm.invocation_parameters"]) == {"temperature": 0.3}
+
+
+def test_per_key_parameters_are_emitted_and_redacted(captured_span_attributes):
+    attrs = captured_span_attributes(
+        invocation_parameters={
+            "api_key": "sk-1234",
+            "temperature": 0.3,
+            "stream": False,
+            "tools": [{"type": "function"}],
+            "nullable": None,
+        }
+    )
+
+    assert attrs["llm.invocation_parameters.api_key"] == "***1234"
+    assert attrs["llm.invocation_parameters.temperature"] == 0.3
+    assert attrs["llm.invocation_parameters.stream"] is False
+    assert json.loads(attrs["llm.invocation_parameters.tools"]) == [
+        {"type": "function"}
+    ]
+    assert "llm.invocation_parameters.nullable" not in attrs
+
+
+def test_json_string_input_is_normalized(captured_span_attributes):
+    attrs = captured_span_attributes(
+        invocation_parameters=json.dumps({"temperature": 0.3})  # type: ignore[arg-type]
+    )
+
+    assert json.loads(attrs["llm.invocation_parameters"]) == {"temperature": 0.3}
+
+
+def test_unparseable_input_sets_no_invocation_attributes(captured_span_attributes):
+    attrs = captured_span_attributes(invocation_parameters=object())  # type: ignore[arg-type]
+
+    assert not any(key.startswith("llm.invocation_parameters") for key in attrs)
+
+
+def test_other_llm_attributes_are_unchanged(captured_span_attributes):
+    attrs = captured_span_attributes(
+        input_messages=[{"role": "user", "content": "hi"}],
+        invocation_parameters={"temperature": 0.3},
+        model_name="gpt-4o-mini",
+    )
+
+    assert attrs["llm.model_name"] == "gpt-4o-mini"
+    assert attrs["llm.input_messages.0.message.role"] == "user"


### PR DESCRIPTION
## Summary

- emit `llm.invocation_parameters` as valid JSON
- exclude prompt and message payloads that are already represented by input attributes
- emit OpenInference-compatible per-parameter attributes while preserving redaction
- keep JSON-string inputs parseable after recursive redaction

Fixes #1631.

This revisits the voluntarily closed #1640 from @feiiiiii5. I revalidated the issue against current `main`, kept the change focused, and added coverage for JSON normalization, payload filtering, per-key attributes, redaction, structured values, null values, and unaffected LLM attributes.

## Verification

- `pytest tests/unit_tests/redaction/test_recursive_redaction.py tests/unit_tests/telemetry/test_open_inference.py -q` — 13 passed
- `ruff check` on the four changed Python files — passed
- `ruff format --check` on the four changed Python files — passed

AI assistance was used for implementation and test preparation; the reported commands were run locally.
