### PR TITLE
Add an equivalence test for the two validator services (#1633)

### DIFF
--- a/tests/integration_tests/validator_service/test_service_equivalence.py
+++ b/tests/integration_tests/validator_service/test_service_equivalence.py
@@ -1,0 +1,103 @@
+"""The two validator services must agree on validated output.
+
+`GUARDRAILS_RUN_SYNC` selects between `SequentialValidatorService` and
+`AsyncValidatorService`. It is a performance switch, so the same `Guard` with
+the same validators should produce the same `validated_output` either way.
+
+Issue #1633 reports that it does not: with several validators using
+`on_fail="fix"`, the default (async) path discards all but the first fix.
+
+The existing dispatcher tests cannot catch this. They patch both services out
+and assert which one was constructed:
+
+    mocker.patch("guardrails.validator_service.SequentialValidatorService")
+    mocker.patch("guardrails.validator_service.AsyncValidatorService")
+    vs.SequentialValidatorService.assert_called_once_with(True)
+
+That passes identically whether or not the two services agree, because nothing
+in it looks at what either service returns. The test below closes that gap: it
+runs the real services and compares their output.
+"""
+
+import os
+
+import pytest
+
+from guardrails import Guard
+from guardrails.classes.validation.validation_result import FailResult, PassResult
+from guardrails.validator_base import Validator, register_validator
+
+
+@register_validator(name="equivalence/append-a", data_type="string")
+class AppendA(Validator):
+    """Appends "A" once, then passes. Idempotent so a retry cannot skew the result."""
+
+    def validate(self, value, metadata):
+        if str(value).endswith("A"):
+            return PassResult()
+        return FailResult(error_message="needs A", fix_value=f"{value}A")
+
+
+@register_validator(name="equivalence/append-b", data_type="string")
+class AppendB(Validator):
+    def validate(self, value, metadata):
+        if str(value).endswith("B"):
+            return PassResult()
+        return FailResult(error_message="needs B", fix_value=f"{value}B")
+
+
+def _validate_under(run_sync: bool) -> str:
+    previous = os.environ.get("GUARDRAILS_RUN_SYNC")
+    os.environ["GUARDRAILS_RUN_SYNC"] = "true" if run_sync else "false"
+    try:
+        guard = Guard().use(AppendA(on_fail="fix"), AppendB(on_fail="fix"))
+        return guard.validate("x").validated_output
+    finally:
+        if previous is None:
+            del os.environ["GUARDRAILS_RUN_SYNC"]
+        else:
+            os.environ["GUARDRAILS_RUN_SYNC"] = previous
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "#1633: the async path applies only the first fix. Remove this marker "
+        "with the fix - strict=True makes the suite fail once it starts passing, "
+        "so the marker cannot outlive the bug."
+    ),
+)
+def test_both_services_produce_the_same_validated_output():
+    """Both services see two failing validators, each supplying a fix.
+
+    Whatever the canonical semantics are - apply every fix in order, or apply
+    the first and stop - the two services have to reach the same answer, because
+    the choice between them is meant to be a performance decision.
+    """
+    sequential = _validate_under(run_sync=True)
+    concurrent = _validate_under(run_sync=False)
+
+    assert sequential == concurrent, (
+        f"GUARDRAILS_RUN_SYNC=true gave {sequential!r}, "
+        f"GUARDRAILS_RUN_SYNC=false gave {concurrent!r}"
+    )
+
+
+def test_a_single_fix_is_applied_by_both_services():
+    """Control. With one validator there is nothing to drop, so this passes
+    today and shows the failure above is about combining fixes rather than
+    about fixes being ignored entirely."""
+    previous = os.environ.get("GUARDRAILS_RUN_SYNC")
+    outputs = {}
+    try:
+        for run_sync in (True, False):
+            os.environ["GUARDRAILS_RUN_SYNC"] = "true" if run_sync else "false"
+            guard = Guard().use(AppendA(on_fail="fix"))
+            outputs[run_sync] = guard.validate("x").validated_output
+    finally:
+        if previous is None:
+            os.environ.pop("GUARDRAILS_RUN_SYNC", None)
+        else:
+            os.environ["GUARDRAILS_RUN_SYNC"] = previous
+
+    assert outputs[True] == outputs[False] == "xA"


### PR DESCRIPTION
Follow-up to my comment on #1633, offering the test I mentioned there.

## What this adds

One test that runs the same `Guard` through both validator services and compares
the result:

```python
sequential = _validate_under(run_sync=True)
concurrent = _validate_under(run_sync=False)
assert sequential == concurrent
```

Using the reproduction from the issue — two validators, both `on_fail="fix"` —
on `06d0ff2` this gives:

```
GUARDRAILS_RUN_SYNC=true   -> 'xAB'
GUARDRAILS_RUN_SYNC=false  -> 'xA'
```

A single-validator control test is included and passes today, which locates the
failure in combining fixes rather than in fixes being ignored altogether.

## Why the existing tests do not cover this

`tests/unit_tests/validator_service/test_validator_service.py` patches both
services out and asserts which one was constructed:

```python
mocker.patch("guardrails.validator_service.SequentialValidatorService")
mocker.patch("guardrails.validator_service.AsyncValidatorService")
...
vs.SequentialValidatorService.assert_called_once_with(True)
```

Both real implementations are replaced, and the assertions are on construction
and call arguments, so the test passes identically whether or not the services
agree. It is also called with `value=True` and `validator_map={}`, so no
validator runs.

## Two things I would like your steer on

**The `xfail` marker.** I used `@pytest.mark.xfail(strict=True)` so the suite
stays green while the issue is open, and fails once the behaviour is fixed —
which forces the marker to be removed alongside the fix rather than lingering.
But `grep -rn xfail tests/` finds nothing, so this would introduce a convention
you do not currently use. Happy to switch it to a plain failing test to be
merged with the fix, or to a `skip`, or to drop the marker entirely — whichever
fits how you prefer to carry known bugs.

**The assertion is deliberately weak.** It asserts only that the two paths
agree, not what they agree on. I did not want to pin either `'xAB'` or `'xA'`
as canonical, since that is a semantics decision for you rather than something
I can read off the code. If you tell me which is intended I will tighten it to
assert the value directly, which would be the stronger test.

## Verification

```
$ pytest tests/integration_tests/validator_service/test_service_equivalence.py -q
1 passed, 1 xfailed
```

I ran this on Windows with Python 3.11 against `main` at `06d0ff2`. No source
files are touched — this is test-only.
